### PR TITLE
Implement monthly Telegraph pages

### DIFF
--- a/docs/COMMANDS.md
+++ b/docs/COMMANDS.md
@@ -13,6 +13,7 @@
 | `/setchannel` | - | Choose one of the admin channels to register as an announcement source. |
 | `/channels` | - | List channels where the bot is admin and mark registered ones with a cancel button. |
 | `/exhibitions` | - | List active exhibitions similar to `/events`; each entry shows the period `c <start>` / `по <end>` and includes edit/delete buttons. |
+| `/months` | - | Show links to Telegraph month pages. |
 | `python main.py test_telegraph` | - | Verify Telegraph API access. Automatically creates a token if needed and prints the page URL. |
 
 Use `/addevent` to let model 4o extract fields. `/addevent_raw` lets you

--- a/docs/MONTH_PAGE_TEMPLATE.md
+++ b/docs/MONTH_PAGE_TEMPLATE.md
@@ -1,0 +1,55 @@
+# Month Page Template
+
+Telegraph month pages are generated from Markdown using the variables below.
+Edit this file to adjust formatting.
+
+## Event entry
+
+```
+{title}
+{description}
+{ticket_info}
+_{date} {time} {venue}, {location}, #{city}_
+{more}
+```
+
+`ticket_info` may be "Билеты в источнике" with a price range, "Бесплатно" or a
+registration link. `more` links to the individual Telegraph page.
+
+## Page layout
+
+```
+# События Калининграда в {month_year}: полный анонс
+
+Планируйте свой месяц заранее: интересные мероприятия Калининграда и 39 региона в {month_year} — от лекций и концертов до культурных шоу.
+
+{events}
+
+{next_month_link}
+
+## Выставки
+
+{exhibitions}
+```
+
+Day headers are formatted as:
+
+```
+🟥🟥🟥 {day} 🟥🟥🟥
+```
+
+For Saturday:
+
+```
+🟥🟥🟥 суббота 🟥🟥🟥
+🟥🟥🟥 {day} 🟥🟥🟥
+```
+
+For Sunday:
+
+```
+🟥🟥 воскресенье 🟥🟥
+🟥🟥🟥 {day} 🟥🟥🟥
+```
+
+If a day has no events the header is omitted.

--- a/main.py
+++ b/main.py
@@ -15,6 +15,7 @@ from functools import partial
 import asyncio
 import html
 from io import BytesIO
+import markdown
 from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
 from sqlmodel import Field, SQLModel, select
 
@@ -79,6 +80,12 @@ class Event(SQLModel, table=True):
     source_text: str
     telegraph_url: Optional[str] = None
     source_post_url: Optional[str] = None
+
+
+class MonthPage(SQLModel, table=True):
+    month: str = Field(primary_key=True)
+    url: str
+    path: str
 
 
 class Database:
@@ -681,10 +688,14 @@ async def add_events_from_text(
     first = True
     for data in parsed:
         date_str = data.get("date", "") or ""
-        end_date = data.get("end_date")
-        if ".." in date_str and not end_date:
-            start, end_date = [p.strip() for p in date_str.split("..", 1)]
+        end_date = data.get("end_date") or None
+        if end_date and ".." in end_date:
+            end_date = end_date.split("..", 1)[-1].strip()
+        if ".." in date_str:
+            start, maybe_end = [p.strip() for p in date_str.split("..", 1)]
             date_str = start
+            if not end_date:
+                end_date = maybe_end
 
         event = Event(
             title=data.get("title", ""),
@@ -738,6 +749,7 @@ async def add_events_from_text(
                     saved.telegraph_path = path
                     session.add(saved)
                     await session.commit()
+        await sync_month_page(db, saved.date[:7])
 
         lines = [
             f"title: {saved.title}",
@@ -859,6 +871,7 @@ async def handle_add_event_raw(message: types.Message, db: Database, bot: Bot):
             event.telegraph_path = path
             session.add(event)
             await session.commit()
+    await sync_month_page(db, event.date[:7])
     lines = [
         f"title: {event.title}",
         f"date: {event.date}",
@@ -906,6 +919,169 @@ MONTHS = [
 
 def format_day_pretty(day: date) -> str:
     return f"{day.day} {MONTHS[day.month - 1]}"
+
+
+def month_name(month: str) -> str:
+    y, m = month.split("-")
+    return f"{MONTHS[int(m) - 1]} {y}"
+
+
+def next_month(month: str) -> str:
+    d = datetime.fromisoformat(month + "-01")
+    n = (d.replace(day=28) + timedelta(days=4)).replace(day=1)
+    return n.strftime("%Y-%m")
+
+
+def md_to_html(text: str) -> str:
+    return markdown.markdown(text, extensions=["markdown.extensions.fenced_code"])
+
+
+def format_event_md(e: Event) -> str:
+    lines = [e.title, e.description]
+    if e.is_free:
+        lines.append("Бесплатно")
+    elif e.ticket_link and (e.ticket_price_min is not None or e.ticket_price_max is not None):
+        price = str(e.ticket_price_min or "")
+        if e.ticket_price_max is not None and e.ticket_price_max != e.ticket_price_min:
+            if price:
+                price += "-"
+            price += str(e.ticket_price_max)
+        lines.append(f"[Билеты в источнике]({e.ticket_link}) {price}".strip())
+    elif e.ticket_link:
+        lines.append(f"[по регистрации]({e.ticket_link})")
+    else:
+        price = []
+        if e.ticket_price_min is not None:
+            price.append(str(e.ticket_price_min))
+        if e.ticket_price_max is not None and e.ticket_price_max != e.ticket_price_min:
+            price.append(str(e.ticket_price_max))
+        if price:
+            lines.append("-".join(price))
+    if e.telegraph_url:
+        lines.append(f"[подробнее]({e.telegraph_url})")
+    loc = e.location_name
+    if e.location_address:
+        loc += f", {e.location_address}"
+    if e.city:
+        loc += f", #{e.city}"
+    date_part = e.date.split("..", 1)[0]
+    try:
+        day = format_day_pretty(datetime.fromisoformat(date_part).date())
+    except ValueError:
+        logging.error("Invalid event date: %s", e.date)
+        day = e.date
+    lines.append(f"_{day} {e.time} {loc}_")
+    return "\n".join(lines)
+
+
+def format_exhibition_md(e: Event) -> str:
+    lines = [e.title, e.description]
+    if e.is_free:
+        lines.append("Бесплатно")
+    elif e.ticket_link:
+        lines.append(f"[Билеты в источнике]({e.ticket_link})")
+    if e.telegraph_url:
+        lines.append(f"[подробнее]({e.telegraph_url})")
+    loc = e.location_name
+    if e.location_address:
+        loc += f", {e.location_address}"
+    if e.city:
+        loc += f", #{e.city}"
+    if e.end_date:
+        end_part = e.end_date.split("..", 1)[0]
+        try:
+            end = format_day_pretty(datetime.fromisoformat(end_part).date())
+        except ValueError:
+            logging.error("Invalid end date: %s", e.end_date)
+            end = e.end_date
+        lines.append(f"_по {end}, {loc}_")
+    return "\n".join(lines)
+
+
+async def build_month_page_markdown(db: Database, month: str) -> tuple[str, str]:
+    start = date.fromisoformat(month + "-01")
+    next_start = (start.replace(day=28) + timedelta(days=4)).replace(day=1)
+    async with db.get_session() as session:
+        result = await session.execute(
+            select(Event)
+            .where(Event.date >= start.isoformat(), Event.date < next_start.isoformat())
+            .order_by(Event.date, Event.time)
+        )
+        events = result.scalars().all()
+
+        ex_result = await session.execute(
+            select(Event)
+            .where(
+                Event.end_date.is_not(None),
+                Event.end_date >= start.isoformat(),
+                Event.date <= next_start.isoformat(),
+            )
+            .order_by(Event.date)
+        )
+        exhibitions = ex_result.scalars().all()
+
+        next_page = await session.get(MonthPage, next_month(month))
+        next_url = next_page.url if next_page else None
+
+    by_day: dict[date, list[Event]] = {}
+    for e in events:
+        date_part = e.date.split("..", 1)[0]
+        try:
+            d = datetime.fromisoformat(date_part).date()
+        except ValueError:
+            logging.error("Invalid date for event %s: %s", e.id, e.date)
+            continue
+        by_day.setdefault(d, []).append(e)
+
+    lines = [
+        f"# События Калининграда в {month_name(month)}: полный анонс",
+        "",
+        f"Планируйте свой месяц заранее: интересные мероприятия Калининграда и 39 региона в {month_name(month)} — от лекций и концертов до культурных шоу.",
+        "",
+    ]
+
+    for day in sorted(by_day):
+        if day.weekday() == 5:
+            lines.append("🟥🟥🟥 суббота 🟥🟥🟥")
+        elif day.weekday() == 6:
+            lines.append("🟥🟥 воскресенье 🟥🟥")
+        lines.append(f"🟥🟥🟥 {format_day_pretty(day)} 🟥🟥🟥")
+        lines.append("")
+        for ev in by_day[day]:
+            lines.append(format_event_md(ev))
+            lines.append("")
+
+    if next_url:
+        lines.append(f"[Страница следующего месяца]({next_url})")
+        lines.append("")
+
+    lines.append("## Выставки")
+    lines.append("")
+    for ev in exhibitions:
+        lines.append(format_exhibition_md(ev))
+        lines.append("")
+
+    title = f"События Калининграда в {month_name(month)}: полный анонс"
+    return title, "\n".join(lines)
+
+
+async def sync_month_page(db: Database, month: str):
+    title, md_text = await build_month_page_markdown(db, month)
+    html_text = md_to_html(md_text)
+    token = get_telegraph_token()
+    if not token:
+        logging.error("Telegraph token unavailable")
+        return
+    tg = Telegraph(access_token=token)
+    async with db.get_session() as session:
+        page = await session.get(MonthPage, month)
+        if page:
+            await asyncio.to_thread(tg.edit_page, page.path, title=title, html_content=html_text)
+        else:
+            data = await asyncio.to_thread(tg.create_page, title, html_content=html_text)
+            page = MonthPage(month=month, url=data.get("url"), path=data.get("path"))
+            session.add(page)
+        await session.commit()
 
 
 async def build_events_message(db: Database, target_date: date, tz: timezone):
@@ -1167,6 +1343,19 @@ async def handle_exhibitions(message: types.Message, db: Database, bot: Bot):
     await bot.send_message(message.chat.id, text, reply_markup=markup)
 
 
+async def handle_months(message: types.Message, db: Database, bot: Bot):
+    async with db.get_session() as session:
+        if not await session.get(User, message.from_user.id):
+            await bot.send_message(message.chat.id, "Not authorized")
+            return
+        result = await session.execute(select(MonthPage).order_by(MonthPage.month))
+        pages = result.scalars().all()
+    lines = ["Months:"]
+    for p in pages:
+        lines.append(f"{p.month}: {p.url}")
+    await bot.send_message(message.chat.id, "\n".join(lines))
+
+
 async def handle_edit_message(message: types.Message, db: Database, bot: Bot):
     state = editing_sessions.get(message.from_user.id)
     if not state:
@@ -1407,6 +1596,9 @@ def create_app() -> web.Application:
     async def exhibitions_wrapper(message: types.Message):
         await handle_exhibitions(message, db, bot)
 
+    async def months_wrapper(message: types.Message):
+        await handle_months(message, db, bot)
+
     async def edit_message_wrapper(message: types.Message):
         await handle_edit_message(message, db, bot)
 
@@ -1438,6 +1630,7 @@ def create_app() -> web.Application:
     dp.message.register(set_channel_wrapper, Command("setchannel"))
     dp.message.register(channels_wrapper, Command("channels"))
     dp.message.register(exhibitions_wrapper, Command("exhibitions"))
+    dp.message.register(months_wrapper, Command("months"))
     dp.message.register(edit_message_wrapper, lambda m: m.from_user.id in editing_sessions)
     dp.message.register(forward_wrapper, lambda m: bool(m.forward_date))
     dp.my_chat_member.register(partial(handle_my_chat_member, db=db))

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ sqlmodel==0.0.24
 pytest==8.1.1
 pytest-asyncio==0.23.6
 telegraph==2.2.0
+markdown>=3.5

--- a/tests/test_bot.py
+++ b/tests/test_bot.py
@@ -16,6 +16,7 @@ from main import (
     Setting,
     User,
     Event,
+    MonthPage,
     create_app,
     handle_register,
     handle_start,
@@ -196,6 +197,38 @@ async def test_add_event_raw(tmp_path: Path, monkeypatch):
     assert len(events) == 1
     assert events[0].title == "Party"
     assert events[0].telegraph_url == "https://t.me/test"
+
+
+@pytest.mark.asyncio
+async def test_month_page_sync(tmp_path: Path, monkeypatch):
+    db = Database(str(tmp_path / "db.sqlite"))
+    await db.init()
+    bot = DummyBot("123:abc")
+
+    async def fake_create(title, text, source, html_text=None, media=None):
+        return "https://t.me/test", "path"
+
+    called = {}
+
+    async def fake_sync(db_obj, month):
+        called["month"] = month
+
+    monkeypatch.setattr("main.create_source_page", fake_create)
+    monkeypatch.setattr("main.sync_month_page", fake_sync)
+
+    msg = types.Message.model_validate(
+        {
+            "message_id": 1,
+            "date": 0,
+            "chat": {"id": 1, "type": "private"},
+            "from": {"id": 1, "is_bot": False, "first_name": "M"},
+            "text": "/addevent_raw Party|2025-07-16|18:00|Club",
+        }
+    )
+
+    await handle_add_event_raw(msg, db, bot)
+
+    assert called.get("month") == "2025-07"
 
 
 @pytest.mark.asyncio
@@ -952,3 +985,86 @@ async def test_multiple_events(tmp_path: Path, monkeypatch):
     assert len(events) == 2
     assert any(e.title == "One" for e in events)
     assert any(e.title == "Two" for e in events)
+
+
+@pytest.mark.asyncio
+async def test_months_command(tmp_path: Path):
+    db = Database(str(tmp_path / "db.sqlite"))
+    await db.init()
+    bot = DummyBot("123:abc")
+
+    async with db.get_session() as session:
+        session.add(main.MonthPage(month="2025-07", url="https://t.me/p", path="p"))
+        await session.commit()
+
+    start_msg = types.Message.model_validate(
+        {
+            "message_id": 1,
+            "date": 0,
+            "chat": {"id": 1, "type": "private"},
+            "from": {"id": 1, "is_bot": False, "first_name": "A"},
+            "text": "/start",
+        }
+    )
+    await handle_start(start_msg, db, bot)
+
+    msg = types.Message.model_validate(
+        {
+            "message_id": 2,
+            "date": 0,
+            "chat": {"id": 1, "type": "private"},
+            "from": {"id": 1, "is_bot": False, "first_name": "A"},
+            "text": "/months",
+        }
+    )
+
+    await main.handle_months(msg, db, bot)
+    assert "2025-07" in bot.messages[-1][1]
+
+
+@pytest.mark.asyncio
+async def test_date_range_parsing(tmp_path: Path, monkeypatch):
+    db = Database(str(tmp_path / "db.sqlite"))
+    await db.init()
+    bot = DummyBot("123:abc")
+
+    async def fake_parse(text: str) -> list[dict]:
+        return [
+            {
+                "title": "Expo",
+                "short_description": "desc",
+                "date": "2025-07-01..2025-07-17",
+                "time": "18:00",
+                "location_name": "Hall",
+                "event_type": "выставка",
+            }
+        ]
+
+    async def fake_create(title, text, source, html_text=None, media=None):
+        return "url", "p"
+
+    monkeypatch.setattr("main.parse_event_via_4o", fake_parse)
+    monkeypatch.setattr("main.create_source_page", fake_create)
+
+    async def fake_sync(*args, **kwargs):
+        return None
+
+    monkeypatch.setattr("main.sync_month_page", fake_sync)
+
+    msg = types.Message.model_validate(
+        {
+            "message_id": 1,
+            "date": 0,
+            "chat": {"id": 1, "type": "private"},
+            "from": {"id": 1, "is_bot": False, "first_name": "A"},
+            "text": "/addevent any",
+        }
+    )
+
+    await handle_add_event(msg, db, bot)
+
+    async with db.get_session() as session:
+        ev = (await session.execute(select(Event))).scalars().first()
+
+    assert ev.date == "2025-07-01"
+    assert ev.end_date == "2025-07-17"


### PR DESCRIPTION
## Summary
- track monthly pages in database
- generate month page markdown with event data
- sync month page on new events
- add `/months` command for quick links
- document page template and new command
- handle date ranges when parsing events and building month pages

## Testing
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686aee7957a883329513ec7cf633fdf9