### PR TITLE
Implement monthly page cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,3 +79,10 @@ python main.py test_telegraph
 ```
 The command prints the created page URL and confirms that editing works.
 
+## Telegraph caching
+
+Telegram desktop may cache the first version of a Telegraph page and ignore
+edits. Opening the link in a browser or the mobile client shows the latest
+content. There is no reliable API to refresh the cached preview without creating
+a new page.
+

--- a/docs/COMMANDS.md
+++ b/docs/COMMANDS.md
@@ -13,6 +13,7 @@
 | `/setchannel` | - | Choose one of the admin channels to register as an announcement source. |
 | `/channels` | - | List channels where the bot is admin and mark registered ones with a cancel button. |
 | `/exhibitions` | - | List active exhibitions similar to `/events`; each entry shows the period `c <start>` / `по <end>` and includes edit/delete buttons. |
+| `/months` | - | Show links to Telegraph month pages. |
 | `python main.py test_telegraph` | - | Verify Telegraph API access. Automatically creates a token if needed and prints the page URL. |
 
 Use `/addevent` to let model 4o extract fields. `/addevent_raw` lets you

--- a/docs/MONTH_PAGE_TEMPLATE.md
+++ b/docs/MONTH_PAGE_TEMPLATE.md
@@ -1,0 +1,59 @@
+# Month Page Template
+
+Telegraph month pages are generated from Markdown using the variables below.
+Edit this file to adjust formatting.
+
+## Event entry
+
+```
+{title}
+{description}
+{ticket_info}
+_{date} {time} {venue}, {location}, #{city}_
+{more}
+```
+
+`ticket_info` may be "Билеты в источнике" with a price range, "Бесплатно" or a
+registration link. `more` links to the individual Telegraph page.
+
+The first line (`{title}`) becomes an `<h4>` heading on the Telegraph page.
+Recently added events (within the last 48 hours) are prefixed with the 🚩 emoji.
+
+## Page layout
+
+```
+# События Калининграда в {month_year_prep}: полный анонс
+
+Планируйте свой месяц заранее: интересные мероприятия Калининграда и 39 региона в {month_year_prep} — от лекций и концертов до культурных шоу. [Полюбить Калининград Анонсы](https://t.me/kenigevents)
+
+{events}
+
+{next_month_link}
+
+## Постоянные выставки
+
+{exhibitions}
+```
+
+Day headers are formatted as `<h3>` elements and event titles as `<h4>`.
+Day headers are formatted as:
+
+```
+🟥🟥🟥 {day} 🟥🟥🟥
+```
+
+For Saturday:
+
+```
+🟥🟥🟥 суббота 🟥🟥🟥
+🟥🟥🟥 {day} 🟥🟥🟥
+```
+
+For Sunday:
+
+```
+🟥🟥 воскресенье 🟥🟥
+🟥🟥🟥 {day} 🟥🟥🟥
+```
+
+If a day has no events the header is omitted.

--- a/docs/PROMPTS.md
+++ b/docs/PROMPTS.md
@@ -25,6 +25,7 @@ event_type       - one of: спектакль, выставка, концерт,
 emoji            - an optional emoji representing the event
 end_date         - end date for multi-day events or null
 When a range is provided, put the start date in `date` and the end date in `end_date`.
+Always put the emoji at the start of `title` so headings are easily scannable.
 ```
 
 Do **not** include words like "Открытие" or "Закрытие" in exhibition titles.

--- a/main.py
+++ b/main.py
@@ -15,6 +15,7 @@ from functools import partial
 import asyncio
 import html
 from io import BytesIO
+import markdown
 from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
 from sqlmodel import Field, SQLModel, select
 
@@ -22,6 +23,9 @@ logging.basicConfig(level=logging.INFO)
 
 DB_PATH = os.getenv("DB_PATH", "/data/db.sqlite")
 TELEGRAPH_TOKEN_FILE = os.getenv("TELEGRAPH_TOKEN_FILE", "/data/telegraph_token.txt")
+
+# separator inserted between versions on Telegraph source pages
+CONTENT_SEPARATOR = "🟧" * 10
 
 # user_id -> (event_id, field?) for editing session
 editing_sessions: dict[int, tuple[int, str | None]] = {}
@@ -79,6 +83,14 @@ class Event(SQLModel, table=True):
     source_text: str
     telegraph_url: Optional[str] = None
     source_post_url: Optional[str] = None
+    added_at: datetime = Field(default_factory=datetime.utcnow)
+
+
+class MonthPage(SQLModel, table=True):
+    __table_args__ = {"extend_existing": True}
+    month: str = Field(primary_key=True)
+    url: str
+    path: str
 
 
 class Database:
@@ -129,6 +141,10 @@ class Database:
             if "end_date" not in cols:
                 await conn.exec_driver_sql(
                     "ALTER TABLE event ADD COLUMN end_date VARCHAR"
+                )
+            if "added_at" not in cols:
+                await conn.exec_driver_sql(
+                    "ALTER TABLE event ADD COLUMN added_at VARCHAR"
                 )
 
     def get_session(self) -> AsyncSession:
@@ -395,16 +411,23 @@ async def process_request(callback: types.CallbackQuery, db: Database, bot: Bot)
             await session.commit()
             await callback.answer("Done")
     elif data.startswith("del:"):
-        _, eid, day = data.split(":")
+        _, eid, marker = data.split(":")
+        month = None
         async with db.get_session() as session:
             event = await session.get(Event, int(eid))
             if event:
+                month = event.date.split("..", 1)[0][:7]
                 await session.delete(event)
                 await session.commit()
+        if month:
+            await sync_month_page(db, month)
         offset = await get_tz_offset(db)
         tz = offset_to_timezone(offset)
-        target = datetime.strptime(day, "%Y-%m-%d").date()
-        text, markup = await build_events_message(db, target, tz)
+        if marker == "exh":
+            text, markup = await build_exhibitions_message(db, tz)
+        else:
+            target = datetime.strptime(marker, "%Y-%m-%d").date()
+            text, markup = await build_events_message(db, target, tz)
         await callback.message.edit_text(text, reply_markup=markup)
         await callback.answer("Deleted")
     elif data.startswith("edit:"):
@@ -433,6 +456,9 @@ async def process_request(callback: types.CallbackQuery, db: Database, bot: Bot)
                 event.is_free = not event.is_free
                 await session.commit()
                 logging.info("togglefree: event %s set to %s", eid, event.is_free)
+                month = event.date.split("..", 1)[0][:7]
+        if event:
+            await sync_month_page(db, month)
         async with db.get_session() as session:
             event = await session.get(Event, eid)
         if event:
@@ -446,6 +472,9 @@ async def process_request(callback: types.CallbackQuery, db: Database, bot: Bot)
                 event.is_free = True
                 await session.commit()
                 logging.info("markfree: event %s marked free", eid)
+                month = event.date.split("..", 1)[0][:7]
+        if event:
+            await sync_month_page(db, month)
         markup = types.InlineKeyboardMarkup(
             inline_keyboard=[
                 [
@@ -611,13 +640,34 @@ async def upsert_event(session: AsyncSession, new: Event) -> Tuple[Event, bool]:
     """Insert or update an event if a similar one exists.
 
     Returns (event, added_flag)."""
+
     stmt = select(Event).where(
         Event.date == new.date,
         Event.time == new.time,
-        Event.city == new.city,
     )
     candidates = (await session.execute(stmt)).scalars().all()
     for ev in candidates:
+        if (
+            ev.location_name.strip().lower() == new.location_name.strip().lower()
+            and (ev.location_address or "").strip().lower()
+            == (new.location_address or "").strip().lower()
+        ):
+            ev.title = new.title
+            ev.description = new.description
+            ev.festival = new.festival
+            ev.source_text = new.source_text
+            ev.location_name = new.location_name
+            ev.location_address = new.location_address
+            ev.ticket_price_min = new.ticket_price_min
+            ev.ticket_price_max = new.ticket_price_max
+            ev.ticket_link = new.ticket_link
+            ev.event_type = new.event_type
+            ev.emoji = new.emoji
+            ev.end_date = new.end_date
+            ev.is_free = new.is_free
+            await session.commit()
+            return ev, False
+
         title_ratio = SequenceMatcher(None, ev.title.lower(), new.title.lower()).ratio()
         loc_ratio = SequenceMatcher(None, ev.location_name.lower(), new.location_name.lower()).ratio()
         if title_ratio >= 0.6 and loc_ratio >= 0.6:
@@ -659,6 +709,7 @@ async def upsert_event(session: AsyncSession, new: Event) -> Tuple[Event, bool]:
                 ev.is_free = new.is_free
                 await session.commit()
                 return ev, False
+    new.added_at = datetime.utcnow()
     session.add(new)
     await session.commit()
     return new, True
@@ -681,10 +732,14 @@ async def add_events_from_text(
     first = True
     for data in parsed:
         date_str = data.get("date", "") or ""
-        end_date = data.get("end_date")
-        if ".." in date_str and not end_date:
-            start, end_date = [p.strip() for p in date_str.split("..", 1)]
+        end_date = data.get("end_date") or None
+        if end_date and ".." in end_date:
+            end_date = end_date.split("..", 1)[-1].strip()
+        if ".." in date_str:
+            start, maybe_end = [p.strip() for p in date_str.split("..", 1)]
             date_str = start
+            if not end_date:
+                end_date = maybe_end
 
         event = Event(
             title=data.get("title", ""),
@@ -738,6 +793,7 @@ async def add_events_from_text(
                     saved.telegraph_path = path
                     session.add(saved)
                     await session.commit()
+        await sync_month_page(db, saved.date[:7])
 
         lines = [
             f"title: {saved.title}",
@@ -859,6 +915,7 @@ async def handle_add_event_raw(message: types.Message, db: Database, bot: Bot):
             event.telegraph_path = path
             session.add(event)
             await session.commit()
+    await sync_month_page(db, event.date[:7])
     lines = [
         f"title: {event.title}",
         f"date: {event.date}",
@@ -906,6 +963,294 @@ MONTHS = [
 
 def format_day_pretty(day: date) -> str:
     return f"{day.day} {MONTHS[day.month - 1]}"
+
+
+def month_name(month: str) -> str:
+    y, m = month.split("-")
+    return f"{MONTHS[int(m) - 1]} {y}"
+
+
+MONTHS_PREP = [
+    "январе",
+    "феврале",
+    "марте",
+    "апреле",
+    "мае",
+    "июне",
+    "июле",
+    "августе",
+    "сентябре",
+    "октябре",
+    "ноябре",
+    "декабре",
+]
+
+
+def month_name_prepositional(month: str) -> str:
+    y, m = month.split("-")
+    return f"{MONTHS_PREP[int(m) - 1]} {y}"
+
+
+def next_month(month: str) -> str:
+    d = datetime.fromisoformat(month + "-01")
+    n = (d.replace(day=28) + timedelta(days=4)).replace(day=1)
+    return n.strftime("%Y-%m")
+
+
+def md_to_html(text: str) -> str:
+    html_text = markdown.markdown(
+        text,
+        extensions=["markdown.extensions.fenced_code", "markdown.extensions.nl2br"],
+    )
+    # Telegraph API does not allow h1/h2 or Telegram-specific emoji tags
+    html_text = re.sub(r"<(\/?)h[12]>", r"<\1h3>", html_text)
+    html_text = re.sub(r"</?tg-emoji[^>]*>", "", html_text)
+    return html_text
+
+
+def is_recent(e: Event) -> bool:
+    if e.added_at is None:
+        return False
+    now = datetime.utcnow()
+    start = datetime.combine(now.date() - timedelta(days=1), datetime.min.time())
+    return e.added_at >= start
+
+
+def format_event_md(e: Event) -> str:
+    prefix = ""
+    if is_recent(e):
+        prefix += "\U0001F6A9 "
+    if e.emoji:
+        prefix += f"{e.emoji} "
+    lines = [f"{prefix}{e.title}".strip(), e.description.strip()]
+    if e.is_free:
+        lines.append("🟡 Бесплатно")
+    elif e.ticket_link and (e.ticket_price_min is not None or e.ticket_price_max is not None):
+        if e.ticket_price_max is not None and e.ticket_price_max != e.ticket_price_min:
+            price = f"от {e.ticket_price_min} до {e.ticket_price_max}"
+        else:
+            price = str(e.ticket_price_min or e.ticket_price_max or "")
+        lines.append(f"[Билеты в источнике]({e.ticket_link}) {price}".strip())
+    elif e.ticket_link:
+        lines.append(f"[по регистрации]({e.ticket_link})")
+    else:
+        if e.ticket_price_min is not None and e.ticket_price_max is not None and e.ticket_price_min != e.ticket_price_max:
+            price = f"от {e.ticket_price_min} до {e.ticket_price_max}"
+        elif e.ticket_price_min is not None:
+            price = str(e.ticket_price_min)
+        elif e.ticket_price_max is not None:
+            price = str(e.ticket_price_max)
+        else:
+            price = ""
+        if price:
+            lines.append(f"Билеты {price}")
+    if e.telegraph_url:
+        lines.append(f"[подробнее]({e.telegraph_url})")
+    loc = e.location_name
+    if e.location_address:
+        loc += f", {e.location_address}"
+    if e.city:
+        loc += f", #{e.city}"
+    date_part = e.date.split("..", 1)[0]
+    try:
+        day = format_day_pretty(datetime.fromisoformat(date_part).date())
+    except ValueError:
+        logging.error("Invalid event date: %s", e.date)
+        day = e.date
+    lines.append(f"_{day} {e.time} {loc}_")
+    return "\n".join(lines)
+
+
+def format_exhibition_md(e: Event) -> str:
+    prefix = ""
+    if is_recent(e):
+        prefix += "\U0001F6A9 "
+    lines = [f"{prefix}{e.title}".strip(), e.description.strip()]
+    if e.is_free:
+        lines.append("🟡 Бесплатно")
+    elif e.ticket_link:
+        lines.append(f"[Билеты в источнике]({e.ticket_link})")
+    elif e.ticket_price_min is not None and e.ticket_price_max is not None and e.ticket_price_min != e.ticket_price_max:
+        lines.append(f"Билеты от {e.ticket_price_min} до {e.ticket_price_max}")
+    elif e.ticket_price_min is not None:
+        lines.append(f"Билеты {e.ticket_price_min}")
+    elif e.ticket_price_max is not None:
+        lines.append(f"Билеты {e.ticket_price_max}")
+    if e.telegraph_url:
+        lines.append(f"[подробнее]({e.telegraph_url})")
+    loc = e.location_name
+    if e.location_address:
+        loc += f", {e.location_address}"
+    if e.city:
+        loc += f", #{e.city}"
+    if e.end_date:
+        end_part = e.end_date.split("..", 1)[0]
+        try:
+            end = format_day_pretty(datetime.fromisoformat(end_part).date())
+        except ValueError:
+            logging.error("Invalid end date: %s", e.end_date)
+            end = e.end_date
+        lines.append(f"_по {end}, {loc}_")
+    return "\n".join(lines)
+
+
+def event_title_nodes(e: Event) -> list:
+    nodes: list = []
+    if is_recent(e):
+        nodes.append("\U0001F6A9 ")
+    if e.emoji:
+        nodes.append(f"{e.emoji} ")
+    title_text = e.title
+    if e.source_post_url:
+        nodes.append({"tag": "a", "attrs": {"href": e.source_post_url}, "children": [title_text]})
+    else:
+        nodes.append(title_text)
+    return nodes
+
+
+def event_to_nodes(e: Event) -> list[dict]:
+    md = format_event_md(e)
+    lines = md.split("\n")
+    body_md = "\n".join(lines[1:]) if len(lines) > 1 else ""
+    from telegraph.utils import html_to_nodes
+    nodes = [{"tag": "h4", "children": event_title_nodes(e)}]
+    if body_md:
+        html_text = md_to_html(body_md)
+        nodes.extend(html_to_nodes(html_text))
+    nodes.append({"tag": "br"})
+    return nodes
+
+
+def exhibition_title_nodes(e: Event) -> list:
+    nodes: list = []
+    if is_recent(e):
+        nodes.append("\U0001F6A9 ")
+    title_text = e.title
+    if e.source_post_url:
+        nodes.append({"tag": "a", "attrs": {"href": e.source_post_url}, "children": [title_text]})
+    else:
+        nodes.append(title_text)
+    return nodes
+
+
+def exhibition_to_nodes(e: Event) -> list[dict]:
+    md = format_exhibition_md(e)
+    lines = md.split("\n")
+    body_md = "\n".join(lines[1:]) if len(lines) > 1 else ""
+    from telegraph.utils import html_to_nodes
+    nodes = [{"tag": "h4", "children": exhibition_title_nodes(e)}]
+    if body_md:
+        html_text = md_to_html(body_md)
+        nodes.extend(html_to_nodes(html_text))
+    nodes.append({"tag": "br"})
+    return nodes
+
+
+async def build_month_page_content(db: Database, month: str) -> tuple[str, list]:
+    start = date.fromisoformat(month + "-01")
+    next_start = (start.replace(day=28) + timedelta(days=4)).replace(day=1)
+    async with db.get_session() as session:
+        result = await session.execute(
+            select(Event)
+            .where(Event.date >= start.isoformat(), Event.date < next_start.isoformat())
+            .order_by(Event.date, Event.time)
+        )
+        events = result.scalars().all()
+
+        ex_result = await session.execute(
+            select(Event)
+            .where(
+                Event.end_date.is_not(None),
+                Event.end_date >= start.isoformat(),
+                Event.date <= next_start.isoformat(),
+            )
+            .order_by(Event.date)
+        )
+        exhibitions = ex_result.scalars().all()
+
+        next_page = await session.get(MonthPage, next_month(month))
+        next_url = next_page.url if next_page else None
+
+    today = date.today()
+    events = [
+        e
+        for e in events
+        if (
+            (e.end_date and e.end_date >= today.isoformat())
+            or (not e.end_date and e.date >= today.isoformat())
+        )
+    ]
+    exhibitions = [
+        e for e in exhibitions if e.end_date and e.end_date >= today.isoformat()
+    ]
+
+    by_day: dict[date, list[Event]] = {}
+    for e in events:
+        date_part = e.date.split("..", 1)[0]
+        try:
+            d = datetime.fromisoformat(date_part).date()
+        except ValueError:
+            logging.error("Invalid date for event %s: %s", e.id, e.date)
+            continue
+        by_day.setdefault(d, []).append(e)
+
+    content: list[dict] = []
+    intro = (
+        f"Планируйте свой месяц заранее: интересные мероприятия Калининграда и 39 региона в {month_name_prepositional(month)} — от лекций и концертов до культурных шоу. "
+    )
+    intro_nodes = [intro, {"tag": "a", "attrs": {"href": "https://t.me/kenigevents"}, "children": ["Полюбить Калининград Анонсы"]}]
+    content.append({"tag": "p", "children": intro_nodes})
+
+    for day in sorted(by_day):
+        if day.weekday() == 5:
+            content.append({"tag": "h3", "children": ["🟥🟥🟥 суббота 🟥🟥🟥"]})
+        elif day.weekday() == 6:
+            content.append({"tag": "h3", "children": ["🟥🟥 воскресенье 🟥🟥"]})
+        content.append({"tag": "h3", "children": [f"🟥🟥🟥 {format_day_pretty(day)} 🟥🟥🟥"]})
+        for ev in by_day[day]:
+            content.extend(event_to_nodes(ev))
+
+    if next_url:
+        content.append({"tag": "a", "attrs": {"href": next_url}, "children": ["Страница следующего месяца"]})
+
+    if exhibitions:
+        content.append({"tag": "h3", "children": ["Постоянные выставки"]})
+        for ev in exhibitions:
+            content.extend(exhibition_to_nodes(ev))
+
+    title = (
+        f"События Калининграда в {month_name_prepositional(month)}: полный анонс от Полюбить Калининград Анонсы"
+    )
+    return title, content
+
+
+async def sync_month_page(db: Database, month: str):
+    title, content = await build_month_page_content(db, month)
+    token = get_telegraph_token()
+    if not token:
+        logging.error("Telegraph token unavailable")
+        return
+    tg = Telegraph(access_token=token)
+    async with db.get_session() as session:
+        page = await session.get(MonthPage, month)
+        try:
+            if page:
+                await asyncio.to_thread(
+                    tg.edit_page, page.path, title=title, content=content
+                )
+                logging.info("Edited month page %s", month)
+            else:
+                data = await asyncio.to_thread(
+                    tg.create_page, title, content=content
+                )
+                page = MonthPage(
+                    month=month, url=data.get("url"), path=data.get("path")
+                )
+                session.add(page)
+                logging.info("Created month page %s", month)
+            await session.commit()
+        except Exception as e:
+            logging.error("Failed to sync month page %s: %s", month, e)
 
 
 async def build_events_message(db: Database, target_date: date, tz: timezone):
@@ -959,14 +1304,18 @@ async def build_events_message(db: Database, target_date: date, tz: timezone):
         for e in events
     ]
 
+    today = datetime.now(tz).date()
     prev_day = target_date - timedelta(days=1)
     next_day = target_date + timedelta(days=1)
-    keyboard.append(
-        [
-            types.InlineKeyboardButton(text="\u25C0", callback_data=f"nav:{prev_day.isoformat()}"),
-            types.InlineKeyboardButton(text="\u25B6", callback_data=f"nav:{next_day.isoformat()}"),
-        ]
+    row = []
+    if target_date > today:
+        row.append(
+            types.InlineKeyboardButton(text="\u25C0", callback_data=f"nav:{prev_day.isoformat()}")
+        )
+    row.append(
+        types.InlineKeyboardButton(text="\u25B6", callback_data=f"nav:{next_day.isoformat()}")
     )
+    keyboard.append(row)
 
     text = f"Events on {format_day(target_date, tz)}\n" + "\n".join(lines)
     markup = types.InlineKeyboardMarkup(inline_keyboard=keyboard)
@@ -1167,6 +1516,19 @@ async def handle_exhibitions(message: types.Message, db: Database, bot: Bot):
     await bot.send_message(message.chat.id, text, reply_markup=markup)
 
 
+async def handle_months(message: types.Message, db: Database, bot: Bot):
+    async with db.get_session() as session:
+        if not await session.get(User, message.from_user.id):
+            await bot.send_message(message.chat.id, "Not authorized")
+            return
+        result = await session.execute(select(MonthPage).order_by(MonthPage.month))
+        pages = result.scalars().all()
+    lines = ["Months:"]
+    for p in pages:
+        lines.append(f"{p.month}: {p.url}")
+    await bot.send_message(message.chat.id, "\n".join(lines))
+
+
 async def handle_edit_message(message: types.Message, db: Database, bot: Bot):
     state = editing_sessions.get(message.from_user.id)
     if not state:
@@ -1181,6 +1543,7 @@ async def handle_edit_message(message: types.Message, db: Database, bot: Bot):
             await bot.send_message(message.chat.id, "Event not found")
             del editing_sessions[message.from_user.id]
             return
+        old_month = event.date.split("..", 1)[0][:7]
         if field in {"ticket_price_min", "ticket_price_max"}:
             try:
                 setattr(event, field, int(value))
@@ -1190,6 +1553,10 @@ async def handle_edit_message(message: types.Message, db: Database, bot: Bot):
         else:
             setattr(event, field, value)
         await session.commit()
+        new_month = event.date.split("..", 1)[0][:7]
+    await sync_month_page(db, old_month)
+    if new_month != old_month:
+        await sync_month_page(db, new_month)
     editing_sessions[message.from_user.id] = (eid, None)
     await show_edit_menu(message.from_user.id, event, bot)
 
@@ -1297,11 +1664,15 @@ async def update_source_page(path: str, title: str, new_html: str):
         return
     tg = Telegraph(access_token=token)
     try:
+        logging.info("Fetching telegraph page %s", path)
         page = await asyncio.to_thread(
-            tg.get_page, path, return_content=True, return_html=True
+            tg.get_page, path, return_html=True
         )
         html_content = page.get("content") or page.get("content_html") or ""
-        html_content += "<hr><p>" + new_html.replace("\n", "<br/>") + "</p>"
+        cleaned = re.sub(r"</?tg-emoji[^>]*>", "", new_html)
+        cleaned = cleaned.replace("\U0001F193\U0001F193\U0001F193\U0001F193", "Бесплатно")
+        html_content += f"<p>{CONTENT_SEPARATOR}</p><p>" + cleaned.replace("\n", "<br/>") + "</p>"
+        logging.info("Editing telegraph page %s", path)
         await asyncio.to_thread(
             tg.edit_page, path, title=title, html_content=html_content
         )
@@ -1407,6 +1778,9 @@ def create_app() -> web.Application:
     async def exhibitions_wrapper(message: types.Message):
         await handle_exhibitions(message, db, bot)
 
+    async def months_wrapper(message: types.Message):
+        await handle_months(message, db, bot)
+
     async def edit_message_wrapper(message: types.Message):
         await handle_edit_message(message, db, bot)
 
@@ -1438,6 +1812,7 @@ def create_app() -> web.Application:
     dp.message.register(set_channel_wrapper, Command("setchannel"))
     dp.message.register(channels_wrapper, Command("channels"))
     dp.message.register(exhibitions_wrapper, Command("exhibitions"))
+    dp.message.register(months_wrapper, Command("months"))
     dp.message.register(edit_message_wrapper, lambda m: m.from_user.id in editing_sessions)
     dp.message.register(forward_wrapper, lambda m: bool(m.forward_date))
     dp.my_chat_member.register(partial(handle_my_chat_member, db=db))
@@ -1462,9 +1837,6 @@ def create_app() -> web.Application:
     app.on_startup.append(on_startup)
     app.on_shutdown.append(on_shutdown)
     return app
-
-    async def on_shutdown(app: web.Application):
-        await bot.session.close()
 
 if __name__ == "__main__":
     import sys

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ sqlmodel==0.0.24
 pytest==8.1.1
 pytest-asyncio==0.23.6
 telegraph==2.2.0
+markdown>=3.5

--- a/tests/test_bot.py
+++ b/tests/test_bot.py
@@ -7,7 +7,7 @@ from pathlib import Path
 import pytest
 from aiogram import Bot, types
 from sqlmodel import select
-from datetime import date, timedelta
+from datetime import date, timedelta, timezone
 import main
 
 from main import (
@@ -16,6 +16,7 @@ from main import (
     Setting,
     User,
     Event,
+    MonthPage,
     create_app,
     handle_register,
     handle_start,
@@ -199,6 +200,38 @@ async def test_add_event_raw(tmp_path: Path, monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_month_page_sync(tmp_path: Path, monkeypatch):
+    db = Database(str(tmp_path / "db.sqlite"))
+    await db.init()
+    bot = DummyBot("123:abc")
+
+    async def fake_create(title, text, source, html_text=None, media=None):
+        return "https://t.me/test", "path"
+
+    called = {}
+
+    async def fake_sync(db_obj, month):
+        called["month"] = month
+
+    monkeypatch.setattr("main.create_source_page", fake_create)
+    monkeypatch.setattr("main.sync_month_page", fake_sync)
+
+    msg = types.Message.model_validate(
+        {
+            "message_id": 1,
+            "date": 0,
+            "chat": {"id": 1, "type": "private"},
+            "from": {"id": 1, "is_bot": False, "first_name": "M"},
+            "text": "/addevent_raw Party|2025-07-16|18:00|Club",
+        }
+    )
+
+    await handle_add_event_raw(msg, db, bot)
+
+    assert called.get("month") == "2025-07"
+
+
+@pytest.mark.asyncio
 async def test_add_event_raw_update(tmp_path: Path, monkeypatch):
     db = Database(str(tmp_path / "db.sqlite"))
     await db.init()
@@ -308,7 +341,7 @@ async def test_events_list(tmp_path: Path, monkeypatch):
             "date": 0,
             "chat": {"id": 1, "type": "private"},
             "from": {"id": 1, "is_bot": False, "first_name": "A"},
-            "text": "/addevent_raw Party|2025-07-16|18:00|Club",
+            "text": f"/addevent_raw Party|{FUTURE_DATE}|18:00|Club",
         }
     )
     await handle_add_event_raw(add_msg, db, bot)
@@ -952,3 +985,333 @@ async def test_multiple_events(tmp_path: Path, monkeypatch):
     assert len(events) == 2
     assert any(e.title == "One" for e in events)
     assert any(e.title == "Two" for e in events)
+
+
+@pytest.mark.asyncio
+async def test_months_command(tmp_path: Path):
+    db = Database(str(tmp_path / "db.sqlite"))
+    await db.init()
+    bot = DummyBot("123:abc")
+
+    async with db.get_session() as session:
+        session.add(main.MonthPage(month="2025-07", url="https://t.me/p", path="p"))
+        await session.commit()
+
+    start_msg = types.Message.model_validate(
+        {
+            "message_id": 1,
+            "date": 0,
+            "chat": {"id": 1, "type": "private"},
+            "from": {"id": 1, "is_bot": False, "first_name": "A"},
+            "text": "/start",
+        }
+    )
+    await handle_start(start_msg, db, bot)
+
+    msg = types.Message.model_validate(
+        {
+            "message_id": 2,
+            "date": 0,
+            "chat": {"id": 1, "type": "private"},
+            "from": {"id": 1, "is_bot": False, "first_name": "A"},
+            "text": "/months",
+        }
+    )
+
+    await main.handle_months(msg, db, bot)
+    assert "2025-07" in bot.messages[-1][1]
+
+
+@pytest.mark.asyncio
+async def test_build_month_page_content(tmp_path: Path):
+    db = Database(str(tmp_path / "db.sqlite"))
+    await db.init()
+
+    async with db.get_session() as session:
+        session.add(
+            Event(
+                title="T",
+                description="d",
+                source_text="s",
+                date="2025-07-16",
+                time="18:00",
+                location_name="Hall",
+                is_free=True,
+            )
+        )
+        await session.commit()
+
+    title, content = await main.build_month_page_content(db, "2025-07")
+    assert "июле 2025" in title
+    assert "Полюбить Калининград Анонсы" in title
+    assert any(n.get("tag") == "br" for n in content)
+
+
+@pytest.mark.asyncio
+async def test_missing_added_at(tmp_path: Path):
+    db = Database(str(tmp_path / "db.sqlite"))
+    await db.init()
+
+    async with db.get_session() as session:
+        session.add(
+            Event(
+                title="T",
+                description="d",
+                source_text="s",
+                date="2025-07-16",
+                time="18:00",
+                location_name="Hall",
+                is_free=True,
+                added_at=None,
+            )
+        )
+        await session.commit()
+
+    title, content = await main.build_month_page_content(db, "2025-07")
+    assert any(n.get("tag") == "h4" for n in content)
+
+
+@pytest.mark.asyncio
+async def test_event_title_link(tmp_path: Path):
+    db = Database(str(tmp_path / "db.sqlite"))
+    await db.init()
+
+    async with db.get_session() as session:
+        session.add(
+            Event(
+                title="Party",
+                description="d",
+                source_text="s",
+                date="2025-07-16",
+                time="18:00",
+                location_name="Hall",
+                source_post_url="https://t.me/chan/1",
+                emoji="🎉",
+            )
+        )
+        await session.commit()
+
+    _, content = await main.build_month_page_content(db, "2025-07")
+    h4 = next(n for n in content if n.get("tag") == "h4")
+    children = h4["children"]
+    assert any(isinstance(c, dict) and c.get("tag") == "a" for c in children)
+    anchor = next(c for c in children if isinstance(c, dict) and c.get("tag") == "a")
+    assert anchor["attrs"]["href"] == "https://t.me/chan/1"
+    assert anchor["children"] == ["Party"]
+
+
+@pytest.mark.asyncio
+async def test_date_range_parsing(tmp_path: Path, monkeypatch):
+    db = Database(str(tmp_path / "db.sqlite"))
+    await db.init()
+    bot = DummyBot("123:abc")
+
+    async def fake_parse(text: str) -> list[dict]:
+        return [
+            {
+                "title": "Expo",
+                "short_description": "desc",
+                "date": "2025-07-01..2025-07-17",
+                "time": "18:00",
+                "location_name": "Hall",
+                "event_type": "выставка",
+            }
+        ]
+
+    async def fake_create(title, text, source, html_text=None, media=None):
+        return "url", "p"
+
+    monkeypatch.setattr("main.parse_event_via_4o", fake_parse)
+    monkeypatch.setattr("main.create_source_page", fake_create)
+
+    async def fake_sync(*args, **kwargs):
+        return None
+
+    monkeypatch.setattr("main.sync_month_page", fake_sync)
+
+    msg = types.Message.model_validate(
+        {
+            "message_id": 1,
+            "date": 0,
+            "chat": {"id": 1, "type": "private"},
+            "from": {"id": 1, "is_bot": False, "first_name": "A"},
+            "text": "/addevent any",
+        }
+    )
+
+    await handle_add_event(msg, db, bot)
+
+    async with db.get_session() as session:
+        ev = (await session.execute(select(Event))).scalars().first()
+
+    assert ev.date == "2025-07-01"
+    assert ev.end_date == "2025-07-17"
+
+
+def test_md_to_html_sanitizes():
+    md = "# T\nline\n<tg-emoji emoji-id='1'>R</tg-emoji>"
+    html = main.md_to_html(md)
+    assert "<h1>" not in html
+    assert "tg-emoji" not in html
+    assert "<h3>" in html
+    assert "<br" in html
+
+
+@pytest.mark.asyncio
+async def test_sync_month_page_error(tmp_path: Path, monkeypatch):
+    db = Database(str(tmp_path / "db.sqlite"))
+    await db.init()
+
+    async with db.get_session() as session:
+        session.add(
+            Event(
+                title="Party",
+                description="desc",
+                source_text="t",
+                date="2025-07-16",
+                time="18:00",
+                location_name="Club",
+            )
+        )
+        session.add(main.MonthPage(month="2025-07", url="u", path="p"))
+        await session.commit()
+
+    class DummyTG:
+        def edit_page(self, *args, **kwargs):
+            raise Exception("fail")
+
+    monkeypatch.setattr("main.get_telegraph_token", lambda: "t")
+    monkeypatch.setattr("main.Telegraph", lambda access_token=None: DummyTG())
+
+    # Should not raise
+    await main.sync_month_page(db, "2025-07")
+
+
+@pytest.mark.asyncio
+async def test_update_source_page_uses_content(monkeypatch):
+    events = {}
+
+    class DummyTG:
+        def get_page(self, path, return_html=True):
+            return {"content": "<p>old</p>"}
+        def edit_page(self, path, title, html_content):
+            events["html"] = html_content
+
+    monkeypatch.setattr("main.get_telegraph_token", lambda: "t")
+    monkeypatch.setattr("main.Telegraph", lambda access_token=None: DummyTG())
+
+    await main.update_source_page("path", "Title", "new")
+    html = events.get("html", "")
+    assert "<p>old</p>" in html
+    assert "new" in html
+    assert main.CONTENT_SEPARATOR in html
+
+
+@pytest.mark.asyncio
+async def test_nav_limits_past(tmp_path: Path):
+    db = Database(str(tmp_path / "db.sqlite"))
+    await db.init()
+
+    today = date.today()
+    async with db.get_session() as session:
+        session.add(
+            Event(
+                title="T",
+                description="d",
+                source_text="t",
+                date=today.isoformat(),
+                time="10:00",
+                location_name="Hall",
+            )
+        )
+        await session.commit()
+
+    text, markup = await main.build_events_message(db, today, timezone.utc)
+    row = markup.inline_keyboard[-1]
+    assert len(row) == 1
+    assert row[0].text == "\u25B6"
+
+
+@pytest.mark.asyncio
+async def test_nav_future_has_prev(tmp_path: Path):
+    db = Database(str(tmp_path / "db.sqlite"))
+    await db.init()
+
+    today = date.today()
+    future = today + timedelta(days=1)
+    async with db.get_session() as session:
+        session.add(
+            Event(
+                title="T",
+                description="d",
+                source_text="t",
+                date=future.isoformat(),
+                time="10:00",
+                location_name="Hall",
+            )
+        )
+        await session.commit()
+
+    text, markup = await main.build_events_message(db, future, timezone.utc)
+    row = markup.inline_keyboard[-1]
+    assert len(row) == 2
+    assert row[0].text == "\u25C0"
+    assert row[1].text == "\u25B6"
+
+
+@pytest.mark.asyncio
+async def test_delete_event_updates_month(tmp_path: Path, monkeypatch):
+    db = Database(str(tmp_path / "db.sqlite"))
+    await db.init()
+    bot = DummyBot("123:abc")
+
+    async def fake_create(title, text, source, html_text=None, media=None):
+        return "url", "p"
+
+    called = {}
+
+    async def fake_sync(db_obj, month):
+        called["month"] = month
+
+    monkeypatch.setattr("main.create_source_page", fake_create)
+    monkeypatch.setattr("main.sync_month_page", fake_sync)
+
+    add_msg = types.Message.model_validate(
+        {
+            "message_id": 1,
+            "date": 0,
+            "chat": {"id": 1, "type": "private"},
+            "from": {"id": 1, "is_bot": False, "first_name": "A"},
+            "text": "/addevent_raw Party|2025-07-16|18:00|Club",
+        }
+    )
+
+    await handle_add_event_raw(add_msg, db, bot)
+
+    async with db.get_session() as session:
+        event = (await session.execute(select(Event))).scalars().first()
+
+    cb = types.CallbackQuery.model_validate(
+        {
+            "id": "c1",
+            "from": {"id": 1, "is_bot": False, "first_name": "A"},
+            "chat_instance": "1",
+            "data": f"del:{event.id}:{event.date}",
+            "message": {
+                "message_id": 2,
+                "date": 0,
+                "chat": {"id": 1, "type": "private"},
+            },
+        }
+    ).as_(bot)
+    object.__setattr__(cb.message, "_bot", bot)
+    async def dummy_edit(*args, **kwargs):
+        return None
+    object.__setattr__(cb.message, "edit_text", dummy_edit)
+    async def dummy_answer(*args, **kwargs):
+        return None
+    object.__setattr__(cb, "answer", dummy_answer)
+
+    await process_request(cb, db, bot)
+
+    assert called.get("month") == "2025-07"


### PR DESCRIPTION
## Summary
- add `added_at` to events for tracking recent additions
- filter past events from month pages and flag new ones with 🚩
- use heading tags for event titles
- avoid repeating the month page header and include channel link in intro
- document updated month page template
- fix month page model duplication issue and cleanup shutdown handler
- handle missing `added_at` for legacy events
- ensure month page titles link only the event name without emojis

## Testing
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686aee7957a883329513ec7cf633fdf9