### PR TITLE
Implement weekend pages and update navigation

### DIFF
--- a/docs/COMMANDS.md
+++ b/docs/COMMANDS.md
@@ -13,7 +13,7 @@
 | `/setchannel` | - | Choose one of the admin channels to register as an announcement source. |
 | `/channels` | - | List channels where the bot is admin and mark registered ones with a cancel button. |
 | `/exhibitions` | - | List active exhibitions similar to `/events`; each entry shows the period `c <start>` / `по <end>` and includes edit/delete buttons. |
-| `/months` | - | Show links to Telegraph month pages. |
+| `/pages` | - | Show links to Telegraph month and weekend pages. |
 | `python main.py test_telegraph` | - | Verify Telegraph API access. Automatically creates a token if needed and prints the page URL. |
 
 Use `/addevent` to let model 4o extract fields. `/addevent_raw` lets you

--- a/tests/test_bot.py
+++ b/tests/test_bot.py
@@ -17,6 +17,7 @@ from main import (
     User,
     Event,
     MonthPage,
+    WeekendPage,
     create_app,
     handle_register,
     handle_start,
@@ -232,6 +233,42 @@ async def test_month_page_sync(tmp_path: Path, monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_weekend_page_sync(tmp_path: Path, monkeypatch):
+    db = Database(str(tmp_path / "db.sqlite"))
+    await db.init()
+    bot = DummyBot("123:abc")
+
+    async def fake_create(title, text, source, html_text=None, media=None):
+        return "url", "p"
+
+    called = {}
+
+    async def fake_month(db_obj, month):
+        called["month"] = month
+
+    async def fake_weekend(db_obj, start):
+        called["weekend"] = start
+
+    monkeypatch.setattr("main.create_source_page", fake_create)
+    monkeypatch.setattr("main.sync_month_page", fake_month)
+    monkeypatch.setattr("main.sync_weekend_page", fake_weekend)
+
+    msg = types.Message.model_validate(
+        {
+            "message_id": 1,
+            "date": 0,
+            "chat": {"id": 1, "type": "private"},
+            "from": {"id": 1, "is_bot": False, "first_name": "M"},
+            "text": "/addevent_raw Party|2025-07-12|18:00|Club",
+        }
+    )
+
+    await handle_add_event_raw(msg, db, bot)
+
+    assert called.get("weekend") == "2025-07-12"
+
+
+@pytest.mark.asyncio
 async def test_add_event_raw_update(tmp_path: Path, monkeypatch):
     db = Database(str(tmp_path / "db.sqlite"))
     await db.init()
@@ -311,6 +348,50 @@ async def test_edit_event(tmp_path: Path, monkeypatch):
     async with db.get_session() as session:
         updated = await session.get(Event, event.id)
     assert updated.title == "New Title"
+
+
+@pytest.mark.asyncio
+async def test_edit_event_forwarded(tmp_path: Path, monkeypatch):
+    db = Database(str(tmp_path / "db.sqlite"))
+    await db.init()
+    bot = DummyBot("123:abc")
+
+    async def fake_create(title, text, source, html_text=None, media=None):
+        return "https://t.me/test", "path"
+
+    monkeypatch.setattr("main.create_source_page", fake_create)
+
+    msg = types.Message.model_validate(
+        {
+            "message_id": 1,
+            "date": 0,
+            "chat": {"id": 1, "type": "private"},
+            "from": {"id": 1, "is_bot": False, "first_name": "M"},
+            "text": "/addevent_raw Party|2025-07-16|18:00|Club",
+        }
+    )
+    await handle_add_event_raw(msg, db, bot)
+
+    async with db.get_session() as session:
+        event = (await session.execute(select(Event))).scalars().first()
+
+    editing_sessions[1] = (event.id, "title")
+    edit_msg = types.Message.model_validate(
+        {
+            "message_id": 2,
+            "date": 0,
+            "chat": {"id": 1, "type": "private"},
+            "from": {"id": 1, "is_bot": False, "first_name": "M"},
+            "caption": "Forwarded Title",
+            "forward_from_chat": {"id": -100123, "type": "channel"},
+            "forward_from_message_id": 5,
+        }
+    )
+    await handle_edit_message(edit_msg, db, bot)
+
+    async with db.get_session() as session:
+        updated = await session.get(Event, event.id)
+    assert updated.title == "Forwarded Title"
 
 
 @pytest.mark.asyncio
@@ -837,6 +918,57 @@ async def test_mark_free(tmp_path: Path, monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_toggle_silent(tmp_path: Path, monkeypatch):
+    db = Database(str(tmp_path / "db.sqlite"))
+    await db.init()
+    bot = DummyBot("123:abc")
+
+    async def fake_create(title, text, source, html_text=None, media=None):
+        return "https://t.me/test", "path"
+
+    monkeypatch.setattr("main.create_source_page", fake_create)
+
+    msg = types.Message.model_validate(
+        {
+            "message_id": 1,
+            "date": 0,
+            "chat": {"id": 1, "type": "private"},
+            "from": {"id": 1, "is_bot": False, "first_name": "M"},
+            "text": "/addevent_raw Party|2025-07-16|18:00|Club",
+        }
+    )
+    await handle_add_event_raw(msg, db, bot)
+
+    async with db.get_session() as session:
+        event = (await session.execute(select(Event))).scalars().first()
+
+    cb = types.CallbackQuery.model_validate(
+        {
+            "id": "c2",
+            "from": {"id": 1, "is_bot": False, "first_name": "M"},
+            "chat_instance": "1",
+            "data": f"togglesilent:{event.id}",
+            "message": {
+                "message_id": 2,
+                "date": 0,
+                "chat": {"id": 1, "type": "private"},
+            },
+        }
+    ).as_(bot)
+    async def dummy_answer(*args, **kwargs):
+        return None
+    object.__setattr__(cb, "answer", dummy_answer)
+    await process_request(cb, db, bot)
+
+    async with db.get_session() as session:
+        updated = await session.get(Event, event.id)
+    assert updated.silent is True
+    assert bot.edits
+    btn = bot.edits[-1][2]["reply_markup"].inline_keyboard[0][0]
+    assert "Тихий" in btn.text
+
+
+@pytest.mark.asyncio
 async def test_exhibition_listing(tmp_path: Path, monkeypatch):
     db = Database(str(tmp_path / "db.sqlite"))
     await db.init()
@@ -1014,11 +1146,11 @@ async def test_months_command(tmp_path: Path):
             "date": 0,
             "chat": {"id": 1, "type": "private"},
             "from": {"id": 1, "is_bot": False, "first_name": "A"},
-            "text": "/months",
+            "text": "/pages",
         }
     )
 
-    await main.handle_months(msg, db, bot)
+    await main.handle_pages(msg, db, bot)
     assert "2025-07" in bot.messages[-1][1]
 
 
@@ -1045,6 +1177,30 @@ async def test_build_month_page_content(tmp_path: Path):
     assert "июле 2025" in title
     assert "Полюбить Калининград Анонсы" in title
     assert any(n.get("tag") == "br" for n in content)
+
+
+@pytest.mark.asyncio
+async def test_build_weekend_page_content(tmp_path: Path):
+    db = Database(str(tmp_path / "db.sqlite"))
+    await db.init()
+
+    saturday = date(2025, 7, 12)
+    async with db.get_session() as session:
+        session.add(
+            Event(
+                title="W",
+                description="d",
+                source_text="s",
+                date=saturday.isoformat(),
+                time="18:00",
+                location_name="Hall",
+            )
+        )
+        await session.commit()
+
+    title, content = await main.build_weekend_page_content(db, saturday.isoformat())
+    assert "выходных" in title
+    assert any(n.get("tag") == "h4" for n in content)
 
 
 @pytest.mark.asyncio
@@ -1669,6 +1825,6 @@ async def test_month_links_future(tmp_path: Path, monkeypatch):
     title, content = await main.build_month_page_content(db, "2025-07")
     found = False
     for n in content:
-        if isinstance(n, dict) and n.get("tag") == "p" and any("август" in str(c) for c in n.get("children", [])):
+        if isinstance(n, dict) and n.get("tag") == "h4" and any("август" in str(c) for c in n.get("children", [])):
             found = True
     assert found


### PR DESCRIPTION
## Summary
- support Telegraph weekend pages alongside months
- adjust month page navigation styling
- update `/pages` command output
- add silent mode toggle to events and tests
- allow editing using forwarded messages

## Testing
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686c16724aa483329edd28c689ee391a