### PR TITLE
Ensure weekend pages update links

### DIFF
--- a/docs/COMMANDS.md
+++ b/docs/COMMANDS.md
@@ -12,6 +12,8 @@
 | `/events [DATE]` | optional date `YYYY-MM-DD` or `DD.MM.YYYY` | List events for the day with delete and edit buttons. Dates are shown as `DD.MM.YYYY`. Choosing **Edit** lists all fields with inline buttons including a toggle for "Бесплатно". |
 | `/setchannel` | - | Choose one of the admin channels to register as an announcement source. |
 | `/channels` | - | List channels where the bot is admin and mark registered ones with a cancel button. |
+| `/regdailychannels` | - | Choose admin channels for daily announcements (default 08:00). |
+| `/daily` | - | Manage daily announcement channels: cancel, change time, test send. |
 | `/exhibitions` | - | List active exhibitions similar to `/events`; each entry shows the period `c <start>` / `по <end>` and includes edit/delete buttons. |
 | `/pages` | - | Show links to Telegraph month and weekend pages. |
 | `python main.py test_telegraph` | - | Verify Telegraph API access. Automatically creates a token if needed and prints the page URL. |

--- a/main.py
+++ b/main.py
@@ -13,6 +13,7 @@ import re
 from telegraph import Telegraph
 from functools import partial
 import asyncio
+import contextlib
 import html
 from io import BytesIO
 import markdown
@@ -29,6 +30,8 @@ CONTENT_SEPARATOR = "🟧" * 10
 
 # user_id -> (event_id, field?) for editing session
 editing_sessions: dict[int, tuple[int, str | None]] = {}
+# user_id -> channel_id for daily time editing
+daily_time_sessions: dict[int, int] = {}
 
 
 class User(SQLModel, table=True):
@@ -55,6 +58,8 @@ class Channel(SQLModel, table=True):
     username: Optional[str] = None
     is_admin: bool = False
     is_registered: bool = False
+    daily_time: Optional[str] = None
+    last_daily: Optional[str] = None
 
 
 class Setting(SQLModel, table=True):
@@ -147,9 +152,7 @@ class Database:
                     "ALTER TABLE event ADD COLUMN event_type VARCHAR"
                 )
             if "emoji" not in cols:
-                await conn.exec_driver_sql(
-                    "ALTER TABLE event ADD COLUMN emoji VARCHAR"
-                )
+                await conn.exec_driver_sql("ALTER TABLE event ADD COLUMN emoji VARCHAR")
             if "end_date" not in cols:
                 await conn.exec_driver_sql(
                     "ALTER TABLE event ADD COLUMN end_date VARCHAR"
@@ -157,6 +160,17 @@ class Database:
             if "added_at" not in cols:
                 await conn.exec_driver_sql(
                     "ALTER TABLE event ADD COLUMN added_at VARCHAR"
+                )
+
+            result = await conn.exec_driver_sql("PRAGMA table_info(channel)")
+            cols = [r[1] for r in result.fetchall()]
+            if "daily_time" not in cols:
+                await conn.exec_driver_sql(
+                    "ALTER TABLE channel ADD COLUMN daily_time VARCHAR"
+                )
+            if "last_daily" not in cols:
+                await conn.exec_driver_sql(
+                    "ALTER TABLE channel ADD COLUMN last_daily VARCHAR"
                 )
 
     def get_session(self) -> AsyncSession:
@@ -210,7 +224,9 @@ async def parse_event_via_4o(text: str) -> list[dict]:
     loc_path = os.path.join("docs", "LOCATIONS.md")
     if os.path.exists(loc_path):
         with open(loc_path, "r", encoding="utf-8") as f:
-            locations = [line.strip() for line in f if line.strip() and not line.startswith("#")]
+            locations = [
+                line.strip() for line in f if line.strip() and not line.startswith("#")
+            ]
         if locations:
             prompt += "\nKnown venues:\n" + "\n".join(locations)
     headers = {
@@ -233,10 +249,7 @@ async def parse_event_via_4o(text: str) -> list[dict]:
         data = await resp.json()
     logging.debug("4o response: %s", data)
     content = (
-        data.get("choices", [{}])[0]
-        .get("message", {})
-        .get("content", "{}")
-        .strip()
+        data.get("choices", [{}])[0].get("message", {}).get("content", "{}").strip()
     )
     if content.startswith("```"):
         content = content.strip("`\n")
@@ -277,12 +290,7 @@ async def ask_4o(text: str) -> str:
         resp.raise_for_status()
         data = await resp.json()
     logging.debug("4o response: %s", data)
-    return (
-        data.get("choices", [{}])[0]
-        .get("message", {})
-        .get("content", "")
-        .strip()
-    )
+    return data.get("choices", [{}])[0].get("message", {}).get("content", "").strip()
 
 
 async def check_duplicate_via_4o(ev: Event, new: Event) -> Tuple[bool, str, str]:
@@ -292,7 +300,7 @@ async def check_duplicate_via_4o(ev: Event, new: Event) -> Tuple[bool, str, str]
         f"Title: {ev.title}\nDescription: {ev.description}\nLocation: {ev.location_name} {ev.location_address}\n"
         "New event:\n"
         f"Title: {new.title}\nDescription: {new.description}\nLocation: {new.location_name} {new.location_address}\n"
-        "Are these the same event? Respond with JSON {\"duplicate\": true|false, \"title\": \"\", \"short_description\": \"\"}."
+        'Are these the same event? Respond with JSON {"duplicate": true|false, "title": "", "short_description": ""}.'
     )
     try:
         ans = await ask_4o(prompt)
@@ -323,7 +331,9 @@ def get_telegraph_token() -> str | None:
         os.makedirs(os.path.dirname(TELEGRAPH_TOKEN_FILE), exist_ok=True)
         with open(TELEGRAPH_TOKEN_FILE, "w", encoding="utf-8") as f:
             f.write(token)
-        logging.info("Created Telegraph account; token stored at %s", TELEGRAPH_TOKEN_FILE)
+        logging.info(
+            "Created Telegraph account; token stored at %s", TELEGRAPH_TOKEN_FILE
+        )
         return token
     except Exception as e:
         logging.error("Failed to create Telegraph token: %s", e)
@@ -433,7 +443,11 @@ async def process_request(callback: types.CallbackQuery, db: Database, bot: Bot)
                 await session.commit()
         if month:
             await sync_month_page(db, month)
-            w_start = weekend_start_for_date(datetime.fromisoformat(event.date).date()) if event else None
+            w_start = (
+                weekend_start_for_date(datetime.fromisoformat(event.date).date())
+                if event
+                else None
+            )
             if w_start:
                 await sync_weekend_page(db, w_start.isoformat())
         offset = await get_tz_offset(db)
@@ -501,7 +515,9 @@ async def process_request(callback: types.CallbackQuery, db: Database, bot: Bot)
                 [
                     types.InlineKeyboardButton(
                         text=(
-                            "\U0001F910 Тихий режим" if event and event.silent else "\U0001F6A9 Переключить на тихий режим"
+                            "\U0001f910 Тихий режим"
+                            if event and event.silent
+                            else "\U0001f6a9 Переключить на тихий режим"
                         ),
                         callback_data=f"togglesilent:{eid}",
                     )
@@ -539,7 +555,7 @@ async def process_request(callback: types.CallbackQuery, db: Database, bot: Bot)
                         callback_data=f"togglefree:{eid}",
                     ),
                     types.InlineKeyboardButton(
-                        text="\U0001F6A9 Переключить на тихий режим",
+                        text="\U0001f6a9 Переключить на тихий режим",
                         callback_data=f"togglesilent:{eid}",
                     ),
                 ]
@@ -582,6 +598,35 @@ async def process_request(callback: types.CallbackQuery, db: Database, bot: Bot)
                 await session.commit()
         await send_setchannel_list(callback.message, db, bot, edit=True)
         await callback.answer("Registered")
+    elif data.startswith("dailyset:"):
+        cid = int(data.split(":")[1])
+        async with db.get_session() as session:
+            ch = await session.get(Channel, cid)
+            if ch and ch.is_admin:
+                ch.daily_time = "08:00"
+                await session.commit()
+        await send_regdaily_list(callback.message, db, bot, edit=True)
+        await callback.answer("Registered")
+    elif data.startswith("dailyunset:"):
+        cid = int(data.split(":")[1])
+        async with db.get_session() as session:
+            ch = await session.get(Channel, cid)
+            if ch:
+                ch.daily_time = None
+                await session.commit()
+        await send_daily_list(callback.message, db, bot, edit=True)
+        await callback.answer("Removed")
+    elif data.startswith("dailytime:"):
+        cid = int(data.split(":")[1])
+        daily_time_sessions[callback.from_user.id] = cid
+        await callback.message.answer("Send new time HH:MM")
+        await callback.answer()
+    elif data.startswith("dailysend:"):
+        cid = int(data.split(":")[1])
+        offset = await get_tz_offset(db)
+        tz = offset_to_timezone(offset)
+        await send_daily_announcement(db, bot, cid, tz, record=False)
+        await callback.answer("Sent")
 
 
 async def handle_tz(message: types.Message, db: Database, bot: Bot):
@@ -626,7 +671,9 @@ async def handle_my_chat_member(update: types.ChatMemberUpdated, db: Database):
         await session.commit()
 
 
-async def send_channels_list(message: types.Message, db: Database, bot: Bot, edit: bool = False):
+async def send_channels_list(
+    message: types.Message, db: Database, bot: Bot, edit: bool = False
+):
     async with db.get_session() as session:
         user = await session.get(User, message.from_user.id)
         if not user or not user.is_superadmin:
@@ -644,9 +691,13 @@ async def send_channels_list(message: types.Message, db: Database, bot: Bot, edi
         name = ch.title or ch.username or str(ch.channel_id)
         if ch.is_registered:
             lines.append(f"{name} ✅")
-            keyboard.append([
-                types.InlineKeyboardButton(text="Cancel", callback_data=f"unset:{ch.channel_id}")
-            ])
+            keyboard.append(
+                [
+                    types.InlineKeyboardButton(
+                        text="Cancel", callback_data=f"unset:{ch.channel_id}"
+                    )
+                ]
+            )
         else:
             lines.append(name)
     if not lines:
@@ -658,7 +709,9 @@ async def send_channels_list(message: types.Message, db: Database, bot: Bot, edi
         await bot.send_message(message.chat.id, "\n".join(lines), reply_markup=markup)
 
 
-async def send_setchannel_list(message: types.Message, db: Database, bot: Bot, edit: bool = False):
+async def send_setchannel_list(
+    message: types.Message, db: Database, bot: Bot, edit: bool = False
+):
     async with db.get_session() as session:
         user = await session.get(User, message.from_user.id)
         if not user or not user.is_superadmin:
@@ -677,9 +730,13 @@ async def send_setchannel_list(message: types.Message, db: Database, bot: Bot, e
     for ch in channels:
         name = ch.title or ch.username or str(ch.channel_id)
         lines.append(name)
-        keyboard.append([
-            types.InlineKeyboardButton(text=name, callback_data=f"set:{ch.channel_id}")
-        ])
+        keyboard.append(
+            [
+                types.InlineKeyboardButton(
+                    text=name, callback_data=f"set:{ch.channel_id}"
+                )
+            ]
+        )
     if not lines:
         lines.append("No channels")
     markup = types.InlineKeyboardMarkup(inline_keyboard=keyboard) if keyboard else None
@@ -688,12 +745,98 @@ async def send_setchannel_list(message: types.Message, db: Database, bot: Bot, e
     else:
         await bot.send_message(message.chat.id, "\n".join(lines), reply_markup=markup)
 
+
+async def send_regdaily_list(
+    message: types.Message, db: Database, bot: Bot, edit: bool = False
+):
+    async with db.get_session() as session:
+        user = await session.get(User, message.from_user.id)
+        if not user or not user.is_superadmin:
+            if not edit:
+                await bot.send_message(message.chat.id, "Not authorized")
+            return
+        result = await session.execute(
+            select(Channel).where(
+                Channel.is_admin.is_(True), Channel.daily_time.is_(None)
+            )
+        )
+        channels = result.scalars().all()
+    lines = []
+    keyboard = []
+    for ch in channels:
+        name = ch.title or ch.username or str(ch.channel_id)
+        lines.append(name)
+        keyboard.append(
+            [
+                types.InlineKeyboardButton(
+                    text=name, callback_data=f"dailyset:{ch.channel_id}"
+                )
+            ]
+        )
+    if not lines:
+        lines.append("No channels")
+    markup = types.InlineKeyboardMarkup(inline_keyboard=keyboard) if keyboard else None
+    if edit:
+        await message.edit_text("\n".join(lines), reply_markup=markup)
+    else:
+        await bot.send_message(message.chat.id, "\n".join(lines), reply_markup=markup)
+
+
+async def send_daily_list(
+    message: types.Message, db: Database, bot: Bot, edit: bool = False
+):
+    async with db.get_session() as session:
+        user = await session.get(User, message.from_user.id)
+        if not user or not user.is_superadmin:
+            if not edit:
+                await bot.send_message(message.chat.id, "Not authorized")
+            return
+        result = await session.execute(
+            select(Channel).where(Channel.daily_time.is_not(None))
+        )
+        channels = result.scalars().all()
+    lines = []
+    keyboard = []
+    for ch in channels:
+        name = ch.title or ch.username or str(ch.channel_id)
+        t = ch.daily_time or "?"
+        lines.append(f"{name} {t}")
+        keyboard.append(
+            [
+                types.InlineKeyboardButton(
+                    text="Cancel", callback_data=f"dailyunset:{ch.channel_id}"
+                ),
+                types.InlineKeyboardButton(
+                    text="Time", callback_data=f"dailytime:{ch.channel_id}"
+                ),
+                types.InlineKeyboardButton(
+                    text="Test", callback_data=f"dailysend:{ch.channel_id}"
+                ),
+            ]
+        )
+    if not lines:
+        lines.append("No channels")
+    markup = types.InlineKeyboardMarkup(inline_keyboard=keyboard) if keyboard else None
+    if edit:
+        await message.edit_text("\n".join(lines), reply_markup=markup)
+    else:
+        await bot.send_message(message.chat.id, "\n".join(lines), reply_markup=markup)
+
+
 async def handle_set_channel(message: types.Message, db: Database, bot: Bot):
     await send_setchannel_list(message, db, bot, edit=False)
 
 
 async def handle_channels(message: types.Message, db: Database, bot: Bot):
     await send_channels_list(message, db, bot, edit=False)
+
+
+async def handle_regdailychannels(message: types.Message, db: Database, bot: Bot):
+    await send_regdaily_list(message, db, bot, edit=False)
+
+
+async def handle_daily(message: types.Message, db: Database, bot: Bot):
+    await send_daily_list(message, db, bot, edit=False)
 
 
 async def upsert_event(session: AsyncSession, new: Event) -> Tuple[Event, bool]:
@@ -846,7 +989,9 @@ async def upsert_event(session: AsyncSession, new: Event) -> Tuple[Event, bool]:
             return ev, False
 
         title_ratio = SequenceMatcher(None, ev.title.lower(), new.title.lower()).ratio()
-        loc_ratio = SequenceMatcher(None, ev.location_name.lower(), new.location_name.lower()).ratio()
+        loc_ratio = SequenceMatcher(
+            None, ev.location_name.lower(), new.location_name.lower()
+        ).ratio()
         if title_ratio >= 0.6 and loc_ratio >= 0.6:
             ev.title = new.title
             ev.description = new.description
@@ -864,7 +1009,9 @@ async def upsert_event(session: AsyncSession, new: Event) -> Tuple[Event, bool]:
             await session.commit()
             return ev, False
         should_check = False
-        if loc_ratio >= 0.4 or (ev.location_address or "") == (new.location_address or ""):
+        if loc_ratio >= 0.4 or (ev.location_address or "") == (
+            new.location_address or ""
+        ):
             should_check = True
         elif title_ratio >= 0.5:
             should_check = True
@@ -964,7 +1111,7 @@ async def add_events_from_text(
                     events_to_add.append(copy_e)
 
         for event in events_to_add:
-            if not event.ticket_link and html_text:
+            if (not is_valid_url(event.ticket_link)) and html_text:
                 extracted = extract_link_from_html(html_text)
                 if extracted:
                     event.ticket_link = extracted
@@ -985,7 +1132,9 @@ async def add_events_from_text(
 
             media_arg = media if first else None
             if saved.telegraph_url and saved.telegraph_path:
-                await update_source_page(saved.telegraph_path, saved.title or "Event", html_text or text)
+                await update_source_page(
+                    saved.telegraph_path, saved.title or "Event", html_text or text
+                )
             else:
                 res = await create_source_page(
                     saved.title or "Event",
@@ -1068,12 +1217,13 @@ async def handle_add_event(message: types.Message, db: Database, bot: Bot):
         ):
             btns.append(
                 types.InlineKeyboardButton(
-                    text="\u2753 Это бесплатное мероприятие", callback_data=f"markfree:{saved.id}"
+                    text="\u2753 Это бесплатное мероприятие",
+                    callback_data=f"markfree:{saved.id}",
                 )
             )
         btns.append(
             types.InlineKeyboardButton(
-                text="\U0001F6A9 Переключить на тихий режим",
+                text="\U0001f6a9 Переключить на тихий режим",
                 callback_data=f"togglesilent:{saved.id}",
             )
         )
@@ -1087,10 +1237,12 @@ async def handle_add_event(message: types.Message, db: Database, bot: Bot):
 
 async def handle_add_event_raw(message: types.Message, db: Database, bot: Bot):
     parts = message.text.split(maxsplit=1)
-    if len(parts) != 2 or '|' not in parts[1]:
-        await bot.send_message(message.chat.id, "Usage: /addevent_raw title|date|time|location")
+    if len(parts) != 2 or "|" not in parts[1]:
+        await bot.send_message(
+            message.chat.id, "Usage: /addevent_raw title|date|time|location"
+        )
         return
-    title, date, time, location = (p.strip() for p in parts[1].split('|', 3))
+    title, date, time, location = (p.strip() for p in parts[1].split("|", 3))
     media = None
     if message.photo:
         bio = BytesIO()
@@ -1145,13 +1297,20 @@ async def handle_add_event_raw(message: types.Message, db: Database, bot: Bot):
         lines.append(f"telegraph: {event.telegraph_url}")
     status = "added" if added else "updated"
     btns = []
-    if not event.is_free and event.ticket_price_min is None and event.ticket_price_max is None:
+    if (
+        not event.is_free
+        and event.ticket_price_min is None
+        and event.ticket_price_max is None
+    ):
         btns.append(
-            types.InlineKeyboardButton(text="\u2753 Это бесплатное мероприятие", callback_data=f"markfree:{event.id}")
+            types.InlineKeyboardButton(
+                text="\u2753 Это бесплатное мероприятие",
+                callback_data=f"markfree:{event.id}",
+            )
         )
     btns.append(
         types.InlineKeyboardButton(
-            text="\U0001F6A9 Переключить на тихий режим",
+            text="\U0001f6a9 Переключить на тихий режим",
             callback_data=f"togglesilent:{event.id}",
         )
     )
@@ -1182,6 +1341,16 @@ MONTHS = [
     "октября",
     "ноября",
     "декабря",
+]
+
+DAYS_OF_WEEK = [
+    "понедельник",
+    "вторник",
+    "среда",
+    "четверг",
+    "пятница",
+    "суббота",
+    "воскресенье",
 ]
 
 
@@ -1287,6 +1456,12 @@ def extract_link_from_html(html_text: str) -> str | None:
     return None
 
 
+def is_valid_url(text: str | None) -> bool:
+    if not text:
+        return False
+    return bool(re.match(r"https?://", text))
+
+
 def is_recent(e: Event) -> bool:
     if e.added_at is None:
         return False
@@ -1298,7 +1473,7 @@ def is_recent(e: Event) -> bool:
 def format_event_md(e: Event) -> str:
     prefix = ""
     if is_recent(e):
-        prefix += "\U0001F6A9 "
+        prefix += "\U0001f6a9 "
     emoji_part = ""
     if e.emoji and not e.title.strip().startswith(e.emoji):
         emoji_part = f"{e.emoji} "
@@ -1308,7 +1483,9 @@ def format_event_md(e: Event) -> str:
         if e.ticket_link:
             txt += f" [по регистрации]({e.ticket_link})"
         lines.append(txt)
-    elif e.ticket_link and (e.ticket_price_min is not None or e.ticket_price_max is not None):
+    elif e.ticket_link and (
+        e.ticket_price_min is not None or e.ticket_price_max is not None
+    ):
         if e.ticket_price_max is not None and e.ticket_price_max != e.ticket_price_min:
             price = f"от {e.ticket_price_min} до {e.ticket_price_max}"
         else:
@@ -1317,7 +1494,11 @@ def format_event_md(e: Event) -> str:
     elif e.ticket_link:
         lines.append(f"[по регистрации]({e.ticket_link})")
     else:
-        if e.ticket_price_min is not None and e.ticket_price_max is not None and e.ticket_price_min != e.ticket_price_max:
+        if (
+            e.ticket_price_min is not None
+            and e.ticket_price_max is not None
+            and e.ticket_price_min != e.ticket_price_max
+        ):
             price = f"от {e.ticket_price_min} до {e.ticket_price_max}"
         elif e.ticket_price_min is not None:
             price = str(e.ticket_price_min)
@@ -1344,10 +1525,75 @@ def format_event_md(e: Event) -> str:
     return "\n".join(lines)
 
 
+def format_event_daily(e: Event, highlight: bool = False) -> str:
+    """Return HTML-formatted text for a daily announcement item."""
+    prefix = ""
+    if highlight:
+        prefix += "\U0001f449 "
+    if is_recent(e):
+        prefix += "\U0001f6a9 "
+    emoji_part = ""
+    if e.emoji and not e.title.strip().startswith(e.emoji):
+        emoji_part = f"{e.emoji} "
+
+    title = html.escape(e.title)
+    if e.source_post_url:
+        title = f'<a href="{html.escape(e.source_post_url)}">{title}</a>'
+    title = f"<b>{prefix}{emoji_part}{title}</b>".strip()
+    lines = [title, html.escape(e.description.strip())]
+
+    if e.is_free:
+        txt = "🟡 Бесплатно"
+        if e.ticket_link:
+            txt += f' <a href="{html.escape(e.ticket_link)}">по регистрации</a>'
+        lines.append(txt)
+    elif e.ticket_link and (
+        e.ticket_price_min is not None or e.ticket_price_max is not None
+    ):
+        if e.ticket_price_max is not None and e.ticket_price_max != e.ticket_price_min:
+            price = f"от {e.ticket_price_min} до {e.ticket_price_max}"
+        else:
+            price = str(e.ticket_price_min or e.ticket_price_max or "")
+        lines.append(
+            f'<a href="{html.escape(e.ticket_link)}">Билеты в источнике</a> {price}'.strip()
+        )
+    elif e.ticket_link:
+        lines.append(f'<a href="{html.escape(e.ticket_link)}">по регистрации</a>')
+    else:
+        price = ""
+        if (
+            e.ticket_price_min is not None
+            and e.ticket_price_max is not None
+            and e.ticket_price_min != e.ticket_price_max
+        ):
+            price = f"от {e.ticket_price_min} до {e.ticket_price_max}"
+        elif e.ticket_price_min is not None:
+            price = str(e.ticket_price_min)
+        elif e.ticket_price_max is not None:
+            price = str(e.ticket_price_max)
+        if price:
+            lines.append(f"Билеты {price}")
+
+    loc = html.escape(e.location_name)
+    if e.location_address:
+        loc += f", {html.escape(e.location_address)}"
+    if e.city:
+        loc += f", #{html.escape(e.city)}"
+    date_part = e.date.split("..", 1)[0]
+    try:
+        day = format_day_pretty(datetime.fromisoformat(date_part).date())
+    except ValueError:
+        logging.error("Invalid event date: %s", e.date)
+        day = e.date
+    lines.append(f"<i>{day} {e.time} {loc}</i>")
+
+    return "\n".join(lines)
+
+
 def format_exhibition_md(e: Event) -> str:
     prefix = ""
     if is_recent(e):
-        prefix += "\U0001F6A9 "
+        prefix += "\U0001f6a9 "
     emoji_part = ""
     if e.emoji and not e.title.strip().startswith(e.emoji):
         emoji_part = f"{e.emoji} "
@@ -1359,7 +1605,11 @@ def format_exhibition_md(e: Event) -> str:
         lines.append(txt)
     elif e.ticket_link:
         lines.append(f"[Билеты в источнике]({e.ticket_link})")
-    elif e.ticket_price_min is not None and e.ticket_price_max is not None and e.ticket_price_min != e.ticket_price_max:
+    elif (
+        e.ticket_price_min is not None
+        and e.ticket_price_max is not None
+        and e.ticket_price_min != e.ticket_price_max
+    ):
         lines.append(f"Билеты от {e.ticket_price_min} до {e.ticket_price_max}")
     elif e.ticket_price_min is not None:
         lines.append(f"Билеты {e.ticket_price_min}")
@@ -1386,12 +1636,14 @@ def format_exhibition_md(e: Event) -> str:
 def event_title_nodes(e: Event) -> list:
     nodes: list = []
     if is_recent(e):
-        nodes.append("\U0001F6A9 ")
+        nodes.append("\U0001f6a9 ")
     if e.emoji and not e.title.strip().startswith(e.emoji):
         nodes.append(f"{e.emoji} ")
     title_text = e.title
     if e.source_post_url:
-        nodes.append({"tag": "a", "attrs": {"href": e.source_post_url}, "children": [title_text]})
+        nodes.append(
+            {"tag": "a", "attrs": {"href": e.source_post_url}, "children": [title_text]}
+        )
     else:
         nodes.append(title_text)
     return nodes
@@ -1402,23 +1654,26 @@ def event_to_nodes(e: Event) -> list[dict]:
     lines = md.split("\n")
     body_md = "\n".join(lines[1:]) if len(lines) > 1 else ""
     from telegraph.utils import html_to_nodes
+
     nodes = [{"tag": "h4", "children": event_title_nodes(e)}]
     if body_md:
         html_text = md_to_html(body_md)
         nodes.extend(html_to_nodes(html_text))
-    nodes.append({"tag": "p", "children": ["\u00A0"]})
+    nodes.append({"tag": "p", "children": ["\u00a0"]})
     return nodes
 
 
 def exhibition_title_nodes(e: Event) -> list:
     nodes: list = []
     if is_recent(e):
-        nodes.append("\U0001F6A9 ")
+        nodes.append("\U0001f6a9 ")
     if e.emoji and not e.title.strip().startswith(e.emoji):
         nodes.append(f"{e.emoji} ")
     title_text = e.title
     if e.source_post_url:
-        nodes.append({"tag": "a", "attrs": {"href": e.source_post_url}, "children": [title_text]})
+        nodes.append(
+            {"tag": "a", "attrs": {"href": e.source_post_url}, "children": [title_text]}
+        )
     else:
         nodes.append(title_text)
     return nodes
@@ -1429,11 +1684,12 @@ def exhibition_to_nodes(e: Event) -> list[dict]:
     lines = md.split("\n")
     body_md = "\n".join(lines[1:]) if len(lines) > 1 else ""
     from telegraph.utils import html_to_nodes
+
     nodes = [{"tag": "h4", "children": exhibition_title_nodes(e)}]
     if body_md:
         html_text = md_to_html(body_md)
         nodes.extend(html_to_nodes(html_text))
-    nodes.append({"tag": "p", "children": ["\u00A0"]})
+    nodes.append({"tag": "p", "children": ["\u00a0"]})
     return nodes
 
 
@@ -1471,6 +1727,7 @@ async def build_month_page_content(db: Database, month: str) -> tuple[str, list]
             (e.end_date and e.end_date >= today.isoformat())
             or (not e.end_date and e.date >= today.isoformat())
         )
+        and not (e.event_type == "выставка" and e.date < today.isoformat())
     ]
     exhibitions = [
         e
@@ -1491,10 +1748,15 @@ async def build_month_page_content(db: Database, month: str) -> tuple[str, list]
         by_day.setdefault(d, []).append(e)
 
     content: list[dict] = []
-    intro = (
-        f"Планируйте свой месяц заранее: интересные мероприятия Калининграда и 39 региона в {month_name_prepositional(month)} — от лекций и концертов до культурных шоу. "
-    )
-    intro_nodes = [intro, {"tag": "a", "attrs": {"href": "https://t.me/kenigevents"}, "children": ["Полюбить Калининград Анонсы"]}]
+    intro = f"Планируйте свой месяц заранее: интересные мероприятия Калининграда и 39 региона в {month_name_prepositional(month)} — от лекций и концертов до культурных шоу. "
+    intro_nodes = [
+        intro,
+        {
+            "tag": "a",
+            "attrs": {"href": "https://t.me/kenigevents"},
+            "children": ["Полюбить Калининград Анонсы"],
+        },
+    ]
     content.append({"tag": "p", "children": intro_nodes})
 
     for day in sorted(by_day):
@@ -1502,9 +1764,11 @@ async def build_month_page_content(db: Database, month: str) -> tuple[str, list]
             content.append({"tag": "h3", "children": ["🟥🟥🟥 суббота 🟥🟥🟥"]})
         elif day.weekday() == 6:
             content.append({"tag": "h3", "children": ["🟥🟥 воскресенье 🟥🟥"]})
-        content.append({"tag": "h3", "children": [f"🟥🟥🟥 {format_day_pretty(day)} 🟥🟥🟥"]})
+        content.append(
+            {"tag": "h3", "children": [f"🟥🟥🟥 {format_day_pretty(day)} 🟥🟥🟥"]}
+        )
         content.append({"tag": "br"})
-        content.append({"tag": "p", "children": ["\u00A0"]})
+        content.append({"tag": "p", "children": ["\u00a0"]})
         for ev in by_day[day]:
             content.extend(event_to_nodes(ev))
 
@@ -1517,7 +1781,9 @@ async def build_month_page_content(db: Database, month: str) -> tuple[str, list]
             if p.month == month:
                 nav_children.append(name)
             else:
-                nav_children.append({"tag": "a", "attrs": {"href": p.url}, "children": [name]})
+                nav_children.append(
+                    {"tag": "a", "attrs": {"href": p.url}, "children": [name]}
+                )
             if idx < len(future_pages) - 1:
                 nav_children.append(" ")
         content.append({"tag": "br"})
@@ -1526,18 +1792,15 @@ async def build_month_page_content(db: Database, month: str) -> tuple[str, list]
     if exhibitions:
         content.append({"tag": "h3", "children": ["Постоянные выставки"]})
         content.append({"tag": "br"})
-        content.append({"tag": "p", "children": ["\u00A0"]})
+        content.append({"tag": "p", "children": ["\u00a0"]})
         for ev in exhibitions:
             content.extend(exhibition_to_nodes(ev))
 
-    title = (
-        f"События Калининграда в {month_name_prepositional(month)}: полный анонс от Полюбить Калининград Анонсы"
-    )
+    title = f"События Калининграда в {month_name_prepositional(month)}: полный анонс от Полюбить Калининград Анонсы"
     return title, content
 
 
 async def sync_month_page(db: Database, month: str, update_links: bool = True):
-    title, content = await build_month_page_content(db, month)
     token = get_telegraph_token()
     if not token:
         logging.error("Telegraph token unavailable")
@@ -1546,20 +1809,22 @@ async def sync_month_page(db: Database, month: str, update_links: bool = True):
     async with db.get_session() as session:
         page = await session.get(MonthPage, month)
         try:
-            if page:
-                await asyncio.to_thread(
-                    tg.edit_page, page.path, title=title, content=content
-                )
-                logging.info("Edited month page %s", month)
-            else:
-                data = await asyncio.to_thread(
-                    tg.create_page, title, content=content
-                )
+            created = False
+            if not page:
+                title, content = await build_month_page_content(db, month)
+                data = await asyncio.to_thread(tg.create_page, title, content=content)
                 page = MonthPage(
                     month=month, url=data.get("url"), path=data.get("path")
                 )
                 session.add(page)
-                logging.info("Created month page %s", month)
+                await session.commit()
+                created = True
+
+            title, content = await build_month_page_content(db, month)
+            await asyncio.to_thread(
+                tg.edit_page, page.path, title=title, content=content
+            )
+            logging.info("%s month page %s", "Created" if created else "Edited", month)
             await session.commit()
         except Exception as e:
             logging.error("Failed to sync month page %s: %s", month, e)
@@ -1581,6 +1846,16 @@ def weekend_start_for_date(d: date) -> date | None:
     return None
 
 
+def next_weekend_start(d: date) -> date:
+    w = weekend_start_for_date(d)
+    if w and d <= w:
+        return w
+    days_ahead = (5 - d.weekday()) % 7
+    if days_ahead == 0:
+        days_ahead = 7
+    return d + timedelta(days=days_ahead)
+
+
 async def build_weekend_page_content(db: Database, start: str) -> tuple[str, list]:
     saturday = date.fromisoformat(start)
     sunday = saturday + timedelta(days=1)
@@ -1592,6 +1867,23 @@ async def build_weekend_page_content(db: Database, start: str) -> tuple[str, lis
             .order_by(Event.date, Event.time)
         )
         events = result.scalars().all()
+
+        ex_res = await session.execute(
+            select(Event)
+            .where(
+                Event.event_type == "выставка",
+                Event.end_date.is_not(None),
+                Event.date <= sunday.isoformat(),
+                Event.end_date >= saturday.isoformat(),
+            )
+            .order_by(Event.date)
+        )
+        exhibitions = ex_res.scalars().all()
+
+        res_w = await session.execute(select(WeekendPage).order_by(WeekendPage.start))
+        weekend_pages = res_w.scalars().all()
+        res_m = await session.execute(select(MonthPage).order_by(MonthPage.month))
+        month_pages = res_m.scalars().all()
 
     today = date.today()
     events = [
@@ -1625,20 +1917,61 @@ async def build_weekend_page_content(db: Database, start: str) -> tuple[str, lis
             content.append({"tag": "h3", "children": ["🟥🟥🟥 суббота 🟥🟥🟥"]})
         elif d.weekday() == 6:
             content.append({"tag": "h3", "children": ["🟥🟥 воскресенье 🟥🟥"]})
-        content.append({"tag": "h3", "children": [f"🟥🟥🟥 {format_day_pretty(d)} 🟥🟥🟥"]})
+        content.append(
+            {"tag": "h3", "children": [f"🟥🟥🟥 {format_day_pretty(d)} 🟥🟥🟥"]}
+        )
         content.append({"tag": "br"})
-        content.append({"tag": "p", "children": ["\u00A0"]})
+        content.append({"tag": "p", "children": ["\u00a0"]})
         for ev in by_day[d]:
             content.extend(event_to_nodes(ev))
 
-    title = (
-        f"Чем заняться на выходных в Калининградской области {format_day_pretty(saturday)}–{format_day_pretty(sunday)}"
-    )
+    future_weekends = [w for w in weekend_pages if w.start >= start]
+    if future_weekends:
+        nav_children = []
+        for idx, w in enumerate(future_weekends):
+            s = date.fromisoformat(w.start)
+            label = f"{s.day}\u2013{(s + timedelta(days=1)).day} {MONTHS[s.month - 1]}"
+            if w.start == start:
+                nav_children.append(label)
+            else:
+                nav_children.append(
+                    {"tag": "a", "attrs": {"href": w.url}, "children": [label]}
+                )
+            if idx < len(future_weekends) - 1:
+                nav_children.append(" ")
+        content.append({"tag": "br"})
+        content.append({"tag": "h4", "children": nav_children})
+
+    cur_month = start[:7]
+    today_month = date.today().strftime("%Y-%m")
+    future_months = [m for m in month_pages if m.month >= today_month]
+    if future_months:
+        nav_children = []
+        for idx, p in enumerate(future_months):
+            name = month_name_nominative(p.month)
+            if p.month == cur_month:
+                nav_children.append(name)
+            else:
+                nav_children.append(
+                    {"tag": "a", "attrs": {"href": p.url}, "children": [name]}
+                )
+            if idx < len(future_months) - 1:
+                nav_children.append(" ")
+        content.append({"tag": "br"})
+        content.append({"tag": "h4", "children": nav_children})
+
+    if exhibitions:
+        content.append({"tag": "h3", "children": ["Постоянные выставки"]})
+        content.append({"tag": "br"})
+        content.append({"tag": "p", "children": ["\u00a0"]})
+        for ev in exhibitions:
+            content.extend(exhibition_to_nodes(ev))
+
+    title = f"Чем заняться на выходных в Калининградской области {format_day_pretty(saturday)}–{format_day_pretty(sunday)}"
     return title, content
 
 
-async def sync_weekend_page(db: Database, start: str):
-    title, content = await build_weekend_page_content(db, start)
+async def sync_weekend_page(db: Database, start: str, update_links: bool = True):
     token = get_telegraph_token()
     if not token:
         logging.error("Telegraph token unavailable")
@@ -1647,26 +1980,177 @@ async def sync_weekend_page(db: Database, start: str):
     async with db.get_session() as session:
         page = await session.get(WeekendPage, start)
         try:
-            if page:
-                await asyncio.to_thread(tg.edit_page, page.path, title=title, content=content)
-                logging.info("Edited weekend page %s", start)
-            else:
+            created = False
+            if not page:
+                # Create a placeholder page to obtain path and URL
+                title, content = await build_weekend_page_content(db, start)
                 data = await asyncio.to_thread(tg.create_page, title, content=content)
-                page = WeekendPage(start=start, url=data.get("url"), path=data.get("path"))
+                page = WeekendPage(
+                    start=start, url=data.get("url"), path=data.get("path")
+                )
                 session.add(page)
-                logging.info("Created weekend page %s", start)
+                await session.commit()
+                created = True
+
+            # Rebuild content including this page in navigation
+            title, content = await build_weekend_page_content(db, start)
+            await asyncio.to_thread(
+                tg.edit_page, page.path, title=title, content=content
+            )
+            logging.info(
+                "%s weekend page %s", "Created" if created else "Edited", start
+            )
             await session.commit()
         except Exception as e:
             logging.error("Failed to sync weekend page %s: %s", start, e)
+
+    if update_links:
+        async with db.get_session() as session:
+            result = await session.execute(
+                select(WeekendPage).order_by(WeekendPage.start)
+            )
+            weekends = result.scalars().all()
+        for w in weekends:
+            if w.start != start:
+                await sync_weekend_page(db, w.start, update_links=False)
+
+
+async def build_daily_posts(
+    db: Database, tz: timezone
+) -> list[tuple[str, types.InlineKeyboardMarkup | None]]:
+    today = datetime.now(tz).date()
+    yesterday_utc = datetime.utcnow() - timedelta(days=1)
+    async with db.get_session() as session:
+        res_today = await session.execute(
+            select(Event).where(Event.date == today.isoformat()).order_by(Event.time)
+        )
+        events_today = res_today.scalars().all()
+        res_new = await session.execute(
+            select(Event)
+            .where(
+                Event.date > today.isoformat(),
+                Event.added_at.is_not(None),
+                Event.added_at >= yesterday_utc,
+                Event.silent.is_(False),
+            )
+            .order_by(Event.date, Event.time)
+        )
+        events_new = res_new.scalars().all()
+
+        w_start = next_weekend_start(today)
+        wpage = await session.get(WeekendPage, w_start.isoformat())
+        cur_month = today.strftime("%Y-%m")
+        mp_cur = await session.get(MonthPage, cur_month)
+        mp_next = await session.get(MonthPage, next_month(cur_month))
+
+    lines1 = [
+        f"<b>АНОНС на {format_day_pretty(today)} {today.year} #ежедневныйанонс</b>",
+        DAYS_OF_WEEK[today.weekday()],
+        "",
+        "<b><i>НЕ ПРОПУСТИТЕ СЕГОДНЯ</i></b>",
+    ]
+    for e in events_today:
+        lines1.append("")
+        lines1.append(format_event_daily(e, highlight=True))
+    section1 = "\n".join(lines1)
+
+    lines2 = ["<b><i>ДОБАВИЛИ В АНОНС</i></b>"]
+    for e in events_new:
+        lines2.append("")
+        lines2.append(format_event_daily(e))
+    section2 = "\n".join(lines2)
+
+    buttons = []
+    if wpage:
+        sunday = w_start + timedelta(days=1)
+        text = f"Мероприятия на выходные {w_start.day} {sunday.day} {MONTHS[w_start.month - 1]}"
+        buttons.append(types.InlineKeyboardButton(text=text, url=wpage.url))
+    if mp_cur:
+        buttons.append(
+            types.InlineKeyboardButton(
+                text=f"Мероприятия на {month_name_nominative(cur_month)}",
+                url=mp_cur.url,
+            )
+        )
+    if mp_next:
+        buttons.append(
+            types.InlineKeyboardButton(
+                text=f"Мероприятия на {month_name_nominative(next_month(cur_month))}",
+                url=mp_next.url,
+            )
+        )
+    markup = None
+    if buttons:
+        markup = types.InlineKeyboardMarkup(inline_keyboard=[[b] for b in buttons])
+
+    combined = section1 + "\n\n\n" + section2
+    if len(combined) <= 4096:
+        return [(combined, markup)]
+    return [(section1, None), (section2, markup)]
+
+
+async def send_daily_announcement(
+    db: Database,
+    bot: Bot,
+    channel_id: int,
+    tz: timezone,
+    *,
+    record: bool = True,
+):
+    posts = await build_daily_posts(db, tz)
+    for text, markup in posts:
+        await bot.send_message(
+            channel_id,
+            text,
+            reply_markup=markup,
+            parse_mode="HTML",
+            disable_web_page_preview=True,
+        )
+    if record:
+        async with db.get_session() as session:
+            ch = await session.get(Channel, channel_id)
+            if ch:
+                ch.last_daily = datetime.now(tz).date().isoformat()
+                await session.commit()
+
+
+async def daily_scheduler(db: Database, bot: Bot):
+    while True:
+        offset = await get_tz_offset(db)
+        tz = offset_to_timezone(offset)
+        now = datetime.now(tz)
+        now_time = now.time().replace(second=0, microsecond=0)
+        async with db.get_session() as session:
+            result = await session.execute(
+                select(Channel).where(Channel.daily_time.is_not(None))
+            )
+            channels = result.scalars().all()
+        for ch in channels:
+            if not ch.daily_time:
+                continue
+            try:
+                target_time = datetime.strptime(ch.daily_time, "%H:%M").time()
+            except ValueError:
+                continue
+            if (
+                ch.last_daily or ""
+            ) != now.date().isoformat() and now_time >= target_time:
+                try:
+                    await send_daily_announcement(db, bot, ch.channel_id, tz)
+                except Exception as e:
+                    logging.error("daily send failed for %s: %s", ch.channel_id, e)
+        await asyncio.sleep(60)
 
 
 async def build_events_message(db: Database, target_date: date, tz: timezone):
     async with db.get_session() as session:
         result = await session.execute(
-            select(Event).where(
+            select(Event)
+            .where(
                 (Event.date == target_date.isoformat())
                 | (Event.end_date == target_date.isoformat())
-            ).order_by(Event.time)
+            )
+            .order_by(Event.time)
         )
         events = result.scalars().all()
 
@@ -1675,7 +2159,11 @@ async def build_events_message(db: Database, target_date: date, tz: timezone):
         prefix = ""
         if e.end_date and e.date == target_date.isoformat():
             prefix = "(Открытие) "
-        elif e.end_date and e.end_date == target_date.isoformat() and e.end_date != e.date:
+        elif (
+            e.end_date
+            and e.end_date == target_date.isoformat()
+            and e.end_date != e.date
+        ):
             prefix = "(Закрытие) "
         title = f"{e.emoji} {e.title}" if e.emoji else e.title
         lines.append(f"{e.id}. {prefix}{title}")
@@ -1689,7 +2177,10 @@ async def build_events_message(db: Database, target_date: date, tz: timezone):
             price_parts = []
             if e.ticket_price_min is not None:
                 price_parts.append(str(e.ticket_price_min))
-            if e.ticket_price_max is not None and e.ticket_price_max != e.ticket_price_min:
+            if (
+                e.ticket_price_max is not None
+                and e.ticket_price_max != e.ticket_price_min
+            ):
                 price_parts.append(str(e.ticket_price_max))
             if price_parts:
                 lines.append("-".join(price_parts))
@@ -1702,11 +2193,9 @@ async def build_events_message(db: Database, target_date: date, tz: timezone):
     keyboard = [
         [
             types.InlineKeyboardButton(
-                text="\u274C", callback_data=f"del:{e.id}:{target_date.isoformat()}"
+                text="\u274c", callback_data=f"del:{e.id}:{target_date.isoformat()}"
             ),
-            types.InlineKeyboardButton(
-                text="\u270E", callback_data=f"edit:{e.id}"
-            ),
+            types.InlineKeyboardButton(text="\u270e", callback_data=f"edit:{e.id}"),
         ]
         for e in events
     ]
@@ -1717,10 +2206,14 @@ async def build_events_message(db: Database, target_date: date, tz: timezone):
     row = []
     if target_date > today:
         row.append(
-            types.InlineKeyboardButton(text="\u25C0", callback_data=f"nav:{prev_day.isoformat()}")
+            types.InlineKeyboardButton(
+                text="\u25c0", callback_data=f"nav:{prev_day.isoformat()}"
+            )
         )
     row.append(
-        types.InlineKeyboardButton(text="\u25B6", callback_data=f"nav:{next_day.isoformat()}")
+        types.InlineKeyboardButton(
+            text="\u25b6", callback_data=f"nav:{next_day.isoformat()}"
+        )
     )
     keyboard.append(row)
 
@@ -1780,7 +2273,10 @@ async def build_exhibitions_message(db: Database, tz: timezone):
             price_parts = []
             if e.ticket_price_min is not None:
                 price_parts.append(str(e.ticket_price_min))
-            if e.ticket_price_max is not None and e.ticket_price_max != e.ticket_price_min:
+            if (
+                e.ticket_price_max is not None
+                and e.ticket_price_max != e.ticket_price_min
+            ):
                 price_parts.append(str(e.ticket_price_max))
             if price_parts:
                 lines.append("-".join(price_parts))
@@ -1793,8 +2289,8 @@ async def build_exhibitions_message(db: Database, tz: timezone):
 
     keyboard = [
         [
-            types.InlineKeyboardButton(text="\u274C", callback_data=f"del:{e.id}:exh"),
-            types.InlineKeyboardButton(text="\u270E", callback_data=f"edit:{e.id}"),
+            types.InlineKeyboardButton(text="\u274c", callback_data=f"del:{e.id}:exh"),
+            types.InlineKeyboardButton(text="\u270e", callback_data=f"edit:{e.id}"),
         ]
         for e in events
     ]
@@ -1851,22 +2347,26 @@ async def show_edit_menu(user_id: int, event: Event, bot: Bot):
             row = []
     if row:
         keyboard.append(row)
-    keyboard.append([
-        types.InlineKeyboardButton(
-            text=(
-                "\U0001F6A9 Переключить на тихий режим"
-                if not event.silent
-                else "\U0001F910 Тихий режим"
-            ),
-            callback_data=f"togglesilent:{event.id}",
-        )
-    ])
-    keyboard.append([
-        types.InlineKeyboardButton(
-            text=("\u2705 Бесплатно" if event.is_free else "\u274C Бесплатно"),
-            callback_data=f"togglefree:{event.id}",
-        )
-    ])
+    keyboard.append(
+        [
+            types.InlineKeyboardButton(
+                text=(
+                    "\U0001f6a9 Переключить на тихий режим"
+                    if not event.silent
+                    else "\U0001f910 Тихий режим"
+                ),
+                callback_data=f"togglesilent:{event.id}",
+            )
+        ]
+    )
+    keyboard.append(
+        [
+            types.InlineKeyboardButton(
+                text=("\u2705 Бесплатно" if event.is_free else "\u274c Бесплатно"),
+                callback_data=f"togglefree:{event.id}",
+            )
+        ]
+    )
     keyboard.append(
         [types.InlineKeyboardButton(text="Done", callback_data=f"editdone:{event.id}")]
     )
@@ -1961,7 +2461,9 @@ async def handle_edit_message(message: types.Message, db: Database, bot: Bot):
     if field is None:
         return
     value = (message.text or message.caption or "").strip()
-    if not value:
+    if field == "ticket_link" and value in {"", "-"}:
+        value = ""
+    if not value and field != "ticket_link":
         await bot.send_message(message.chat.id, "No text supplied")
         return
     async with db.get_session() as session:
@@ -1979,7 +2481,10 @@ async def handle_edit_message(message: types.Message, db: Database, bot: Bot):
                 await bot.send_message(message.chat.id, "Invalid number")
                 return
         else:
-            setattr(event, field, value)
+            if field == "ticket_link" and value == "":
+                setattr(event, field, None)
+            else:
+                setattr(event, field, value)
         await session.commit()
         new_date = event.date.split("..", 1)[0]
         new_month = new_date[:7]
@@ -1994,6 +2499,25 @@ async def handle_edit_message(message: types.Message, db: Database, bot: Bot):
         await sync_weekend_page(db, new_w.isoformat())
     editing_sessions[message.from_user.id] = (eid, None)
     await show_edit_menu(message.from_user.id, event, bot)
+
+
+async def handle_daily_time_message(message: types.Message, db: Database, bot: Bot):
+    cid = daily_time_sessions.get(message.from_user.id)
+    if not cid:
+        return
+    value = (message.text or "").strip()
+    if not re.match(r"^\d{1,2}:\d{2}$", value):
+        await bot.send_message(message.chat.id, "Invalid time")
+        return
+    if len(value.split(":")[0]) == 1:
+        value = f"0{value}"
+    async with db.get_session() as session:
+        ch = await session.get(Channel, cid)
+        if ch:
+            ch.daily_time = value
+            await session.commit()
+    del daily_time_sessions[message.from_user.id]
+    await bot.send_message(message.chat.id, f"Time set to {value}")
 
 
 processed_media_groups: set[str] = set()
@@ -2041,19 +2565,27 @@ async def handle_forwarded(message: types.Message, db: Database, bot: Bot):
         media,
     )
     for saved, added, lines, status in results:
-        markup = None
+        buttons = []
         if (
             not saved.is_free
             and saved.ticket_price_min is None
             and saved.ticket_price_max is None
         ):
-            markup = types.InlineKeyboardMarkup(
-                inline_keyboard=[[
-                    types.InlineKeyboardButton(
-                        text="\u2753 Это бесплатное мероприятие", callback_data=f"markfree:{saved.id}"
-                    )
-                ]]
+            buttons.append(
+                types.InlineKeyboardButton(
+                    text="\u2753 Это бесплатное мероприятие",
+                    callback_data=f"markfree:{saved.id}",
+                )
             )
+        buttons.append(
+            types.InlineKeyboardButton(
+                text="\U0001f6a9 Переключить на тихий режим",
+                callback_data=f"togglesilent:{saved.id}",
+            )
+        )
+        markup = (
+            types.InlineKeyboardMarkup(inline_keyboard=[buttons]) if buttons else None
+        )
         await bot.send_message(
             message.chat.id,
             f"Event {status}\n" + "\n".join(lines),
@@ -2088,13 +2620,15 @@ async def update_source_page(path: str, title: str, new_html: str):
     tg = Telegraph(access_token=token)
     try:
         logging.info("Fetching telegraph page %s", path)
-        page = await asyncio.to_thread(
-            tg.get_page, path, return_html=True
-        )
+        page = await asyncio.to_thread(tg.get_page, path, return_html=True)
         html_content = page.get("content") or page.get("content_html") or ""
         cleaned = re.sub(r"</?tg-emoji[^>]*>", "", new_html)
-        cleaned = cleaned.replace("\U0001F193\U0001F193\U0001F193\U0001F193", "Бесплатно")
-        html_content += f"<p>{CONTENT_SEPARATOR}</p><p>" + cleaned.replace("\n", "<br/>") + "</p>"
+        cleaned = cleaned.replace(
+            "\U0001f193\U0001f193\U0001f193\U0001f193", "Бесплатно"
+        )
+        html_content += (
+            f"<p>{CONTENT_SEPARATOR}</p><p>" + cleaned.replace("\n", "<br/>") + "</p>"
+        )
         logging.info("Editing telegraph page %s", path)
         await asyncio.to_thread(
             tg.edit_page, path, title=title, html_content=html_content
@@ -2124,6 +2658,7 @@ async def create_source_page(
         if lines and lines[0].strip() == title.strip():
             return "\n".join(lines[1:]).lstrip()
         return line_text
+
     # Media uploads to Telegraph are flaky and consume bandwidth.
     # Skip uploading files for now to keep requests lightweight.
     if media:
@@ -2140,17 +2675,19 @@ async def create_source_page(
     if html_text:
         html_text = strip_title(html_text)
         cleaned = re.sub(r"</?tg-emoji[^>]*>", "", html_text)
-        cleaned = cleaned.replace("\U0001F193\U0001F193\U0001F193\U0001F193", "Бесплатно")
+        cleaned = cleaned.replace(
+            "\U0001f193\U0001f193\U0001f193\U0001f193", "Бесплатно"
+        )
         html_content += f"<p>{cleaned.replace('\n', '<br/>')}</p>"
     else:
         clean_text = strip_title(text)
-        clean_text = clean_text.replace("\U0001F193\U0001F193\U0001F193\U0001F193", "Бесплатно")
+        clean_text = clean_text.replace(
+            "\U0001f193\U0001f193\U0001f193\U0001f193", "Бесплатно"
+        )
         paragraphs = [f"<p>{html.escape(line)}</p>" for line in clean_text.splitlines()]
         html_content += "".join(paragraphs)
     try:
-        page = await asyncio.to_thread(
-            tg.create_page, title, html_content=html_content
-        )
+        page = await asyncio.to_thread(tg.create_page, title, html_content=html_content)
     except Exception as e:
         logging.error("Failed to create telegraph page: %s", e)
         return None
@@ -2215,8 +2752,17 @@ def create_app() -> web.Application:
     async def edit_message_wrapper(message: types.Message):
         await handle_edit_message(message, db, bot)
 
+    async def daily_time_wrapper(message: types.Message):
+        await handle_daily_time_message(message, db, bot)
+
     async def forward_wrapper(message: types.Message):
         await handle_forwarded(message, db, bot)
+
+    async def reg_daily_wrapper(message: types.Message):
+        await handle_regdailychannels(message, db, bot)
+
+    async def daily_wrapper(message: types.Message):
+        await handle_daily(message, db, bot)
 
     dp.message.register(start_wrapper, Command("start"))
     dp.message.register(register_wrapper, Command("register"))
@@ -2232,6 +2778,10 @@ def create_app() -> web.Application:
         or c.data.startswith("editdone:")
         or c.data.startswith("unset:")
         or c.data.startswith("set:")
+        or c.data.startswith("dailyset:")
+        or c.data.startswith("dailyunset:")
+        or c.data.startswith("dailytime:")
+        or c.data.startswith("dailysend:")
         or c.data.startswith("togglefree:")
         or c.data.startswith("markfree:")
         or c.data.startswith("togglesilent:"),
@@ -2243,9 +2793,16 @@ def create_app() -> web.Application:
     dp.message.register(list_events_wrapper, Command("events"))
     dp.message.register(set_channel_wrapper, Command("setchannel"))
     dp.message.register(channels_wrapper, Command("channels"))
+    dp.message.register(reg_daily_wrapper, Command("regdailychannels"))
+    dp.message.register(daily_wrapper, Command("daily"))
     dp.message.register(exhibitions_wrapper, Command("exhibitions"))
     dp.message.register(pages_wrapper, Command("pages"))
-    dp.message.register(edit_message_wrapper, lambda m: m.from_user.id in editing_sessions)
+    dp.message.register(
+        edit_message_wrapper, lambda m: m.from_user.id in editing_sessions
+    )
+    dp.message.register(
+        daily_time_wrapper, lambda m: m.from_user.id in daily_time_sessions
+    )
     dp.message.register(forward_wrapper, lambda m: bool(m.forward_date))
     dp.my_chat_member.register(partial(handle_my_chat_member, db=db))
 
@@ -2262,13 +2819,19 @@ def create_app() -> web.Application:
             hook,
             allowed_updates=["message", "callback_query", "my_chat_member"],
         )
+        app["daily_task"] = asyncio.create_task(daily_scheduler(db, bot))
 
     async def on_shutdown(app: web.Application):
         await bot.session.close()
+        if "daily_task" in app:
+            app["daily_task"].cancel()
+            with contextlib.suppress(Exception):
+                await app["daily_task"]
 
     app.on_startup.append(on_startup)
     app.on_shutdown.append(on_shutdown)
     return app
+
 
 if __name__ == "__main__":
     import sys

--- a/tests/test_bot.py
+++ b/tests/test_bot.py
@@ -8,6 +8,7 @@ import pytest
 from aiogram import Bot, types
 from sqlmodel import select
 from datetime import date, timedelta, timezone
+from typing import Any
 import main
 
 from main import (
@@ -37,6 +38,7 @@ from main import (
 
 FUTURE_DATE = (date.today() + timedelta(days=10)).isoformat()
 
+
 class DummyBot(Bot):
     def __init__(self, token: str):
         super().__init__(token)
@@ -44,7 +46,7 @@ class DummyBot(Bot):
         self.edits = []
 
     async def send_message(self, chat_id, text, **kwargs):
-        self.messages.append((chat_id, text))
+        self.messages.append((chat_id, text, kwargs))
 
     async def edit_message_reply_markup(
         self, chat_id: int | None = None, message_id: int | None = None, **kwargs
@@ -246,7 +248,7 @@ async def test_weekend_page_sync(tmp_path: Path, monkeypatch):
     async def fake_month(db_obj, month):
         called["month"] = month
 
-    async def fake_weekend(db_obj, start):
+    async def fake_weekend(db_obj, start, update_links=True):
         called["weekend"] = start
 
     monkeypatch.setattr("main.create_source_page", fake_create)
@@ -348,6 +350,50 @@ async def test_edit_event(tmp_path: Path, monkeypatch):
     async with db.get_session() as session:
         updated = await session.get(Event, event.id)
     assert updated.title == "New Title"
+
+
+@pytest.mark.asyncio
+async def test_edit_remove_ticket_link(tmp_path: Path, monkeypatch):
+    db = Database(str(tmp_path / "db.sqlite"))
+    await db.init()
+    bot = DummyBot("123:abc")
+
+    async def fake_create(title, text, source, html_text=None, media=None):
+        return "https://t.me/test", "path"
+
+    monkeypatch.setattr("main.create_source_page", fake_create)
+
+    msg = types.Message.model_validate(
+        {
+            "message_id": 1,
+            "date": 0,
+            "chat": {"id": 1, "type": "private"},
+            "from": {"id": 1, "is_bot": False, "first_name": "M"},
+            "text": "/addevent_raw Party|2025-07-16|18:00|Club",
+        }
+    )
+    await handle_add_event_raw(msg, db, bot)
+
+    async with db.get_session() as session:
+        event = (await session.execute(select(Event))).scalars().first()
+        event.ticket_link = "https://reg"
+        await session.commit()
+
+    editing_sessions[1] = (event.id, "ticket_link")
+    edit_msg = types.Message.model_validate(
+        {
+            "message_id": 2,
+            "date": 0,
+            "chat": {"id": 1, "type": "private"},
+            "from": {"id": 1, "is_bot": False, "first_name": "M"},
+            "text": "-",
+        }
+    )
+    await handle_edit_message(edit_msg, db, bot)
+
+    async with db.get_session() as session:
+        updated = await session.get(Event, event.id)
+    assert updated.ticket_link is None
 
 
 @pytest.mark.asyncio
@@ -455,13 +501,15 @@ async def test_ask4o_admin(tmp_path: Path, monkeypatch):
     await db.init()
     bot = DummyBot("123:abc")
 
-    start_msg = types.Message.model_validate({
-        "message_id": 1,
-        "date": 0,
-        "chat": {"id": 1, "type": "private"},
-        "from": {"id": 1, "is_bot": False, "first_name": "A"},
-        "text": "/start",
-    })
+    start_msg = types.Message.model_validate(
+        {
+            "message_id": 1,
+            "date": 0,
+            "chat": {"id": 1, "type": "private"},
+            "from": {"id": 1, "is_bot": False, "first_name": "A"},
+            "text": "/start",
+        }
+    )
     await handle_start(start_msg, db, bot)
 
     called = {}
@@ -472,13 +520,15 @@ async def test_ask4o_admin(tmp_path: Path, monkeypatch):
 
     monkeypatch.setattr("main.ask_4o", fake_ask)
 
-    msg = types.Message.model_validate({
-        "message_id": 2,
-        "date": 0,
-        "chat": {"id": 1, "type": "private"},
-        "from": {"id": 1, "is_bot": False, "first_name": "A"},
-        "text": "/ask4o hello",
-    })
+    msg = types.Message.model_validate(
+        {
+            "message_id": 2,
+            "date": 0,
+            "chat": {"id": 1, "type": "private"},
+            "from": {"id": 1, "is_bot": False, "first_name": "A"},
+            "text": "/ask4o hello",
+        }
+    )
 
     await handle_ask_4o(msg, db, bot)
 
@@ -500,13 +550,15 @@ async def test_ask4o_not_admin(tmp_path: Path, monkeypatch):
 
     monkeypatch.setattr("main.ask_4o", fake_ask)
 
-    msg = types.Message.model_validate({
-        "message_id": 1,
-        "date": 0,
-        "chat": {"id": 2, "type": "private"},
-        "from": {"id": 2, "is_bot": False, "first_name": "B"},
-        "text": "/ask4o hi",
-    })
+    msg = types.Message.model_validate(
+        {
+            "message_id": 1,
+            "date": 0,
+            "chat": {"id": 2, "type": "private"},
+            "from": {"id": 2, "is_bot": False, "first_name": "B"},
+            "text": "/ask4o hi",
+        }
+    )
 
     await handle_ask_4o(msg, db, bot)
 
@@ -549,6 +601,7 @@ async def test_telegraph_test(monkeypatch, capsys):
     class DummyTG:
         def __init__(self, access_token=None):
             self.access_token = access_token
+
         def create_page(self, title, html_content=None, **_):
             return {"url": "https://telegra.ph/test", "path": "test"}
 
@@ -556,7 +609,9 @@ async def test_telegraph_test(monkeypatch, capsys):
             pass
 
     monkeypatch.setenv("TELEGRAPH_TOKEN", "t")
-    monkeypatch.setattr("main.Telegraph", lambda access_token=None: DummyTG(access_token))
+    monkeypatch.setattr(
+        "main.Telegraph", lambda access_token=None: DummyTG(access_token)
+    )
 
     await telegraph_test()
     captured = capsys.readouterr()
@@ -570,16 +625,22 @@ async def test_create_source_page_photo(monkeypatch):
         def __init__(self, access_token=None):
             self.access_token = access_token
             self.upload_called = False
+
         def upload_file(self, f):
             self.upload_called = True
+
         def create_page(self, title, html_content=None, **_):
             assert "<img" not in html_content
             return {"url": "https://telegra.ph/test", "path": "test"}
 
     monkeypatch.setenv("TELEGRAPH_TOKEN", "t")
-    monkeypatch.setattr("main.Telegraph", lambda access_token=None: DummyTG(access_token))
+    monkeypatch.setattr(
+        "main.Telegraph", lambda access_token=None: DummyTG(access_token)
+    )
 
-    res = await main.create_source_page("Title", "text", None, media=(b"img", "photo.jpg"))
+    res = await main.create_source_page(
+        "Title", "text", None, media=(b"img", "photo.jpg")
+    )
     assert res == ("https://telegra.ph/test", "test")
 
 
@@ -610,13 +671,15 @@ async def test_forward_add_event(tmp_path: Path, monkeypatch):
     bot = DummyBot("123:abc")
 
     async def fake_parse(text: str) -> list[dict]:
-        return [{
-            "title": "Forwarded",
-            "short_description": "desc",
-            "date": "2025-07-16",
-            "time": "18:00",
-            "location_name": "Club",
-        }]
+        return [
+            {
+                "title": "Forwarded",
+                "short_description": "desc",
+                "date": "2025-07-16",
+                "time": "18:00",
+                "location_name": "Club",
+            }
+        ]
 
     async def fake_create(title, text, source, html_text=None, media=None):
         return "https://t.me/page", "p"
@@ -624,13 +687,15 @@ async def test_forward_add_event(tmp_path: Path, monkeypatch):
     monkeypatch.setattr("main.parse_event_via_4o", fake_parse)
     monkeypatch.setattr("main.create_source_page", fake_create)
 
-    start_msg = types.Message.model_validate({
-        "message_id": 1,
-        "date": 0,
-        "chat": {"id": 1, "type": "private"},
-        "from": {"id": 1, "is_bot": False, "first_name": "A"},
-        "text": "/start",
-    })
+    start_msg = types.Message.model_validate(
+        {
+            "message_id": 1,
+            "date": 0,
+            "chat": {"id": 1, "type": "private"},
+            "from": {"id": 1, "is_bot": False, "first_name": "A"},
+            "text": "/start",
+        }
+    )
     await handle_start(start_msg, db, bot)
 
     upd = DummyUpdate(-100123, "Chan")
@@ -669,13 +734,15 @@ async def test_forward_unregistered(tmp_path: Path, monkeypatch):
     bot = DummyBot("123:abc")
 
     async def fake_parse(text: str) -> list[dict]:
-        return [{
-            "title": "Fwd",
-            "short_description": "d",
-            "date": "2025-07-16",
-            "time": "18:00",
-            "location_name": "Club",
-        }]
+        return [
+            {
+                "title": "Fwd",
+                "short_description": "d",
+                "date": "2025-07-16",
+                "time": "18:00",
+                "location_name": "Club",
+            }
+        ]
 
     async def fake_create(title, text, source, html_text=None, media=None):
         return "https://t.me/page", "p"
@@ -683,13 +750,15 @@ async def test_forward_unregistered(tmp_path: Path, monkeypatch):
     monkeypatch.setattr("main.parse_event_via_4o", fake_parse)
     monkeypatch.setattr("main.create_source_page", fake_create)
 
-    start_msg = types.Message.model_validate({
-        "message_id": 1,
-        "date": 0,
-        "chat": {"id": 1, "type": "private"},
-        "from": {"id": 1, "is_bot": False, "first_name": "A"},
-        "text": "/start",
-    })
+    start_msg = types.Message.model_validate(
+        {
+            "message_id": 1,
+            "date": 0,
+            "chat": {"id": 1, "type": "private"},
+            "from": {"id": 1, "is_bot": False, "first_name": "A"},
+            "text": "/start",
+        }
+    )
     await handle_start(start_msg, db, bot)
 
     upd = DummyUpdate(-100123, "Chan")
@@ -723,13 +792,15 @@ async def test_media_group_caption_first(tmp_path: Path, monkeypatch):
     bot = DummyBot("123:abc")
 
     async def fake_parse(text: str) -> list[dict]:
-        return [{
-            "title": "MG",
-            "short_description": "d",
-            "date": "2025-07-16",
-            "time": "18:00",
-            "location_name": "Club",
-        }]
+        return [
+            {
+                "title": "MG",
+                "short_description": "d",
+                "date": "2025-07-16",
+                "time": "18:00",
+                "location_name": "Club",
+            }
+        ]
 
     async def fake_create(title, text, source, html_text=None, media=None):
         return "https://t.me/page", "p"
@@ -737,13 +808,15 @@ async def test_media_group_caption_first(tmp_path: Path, monkeypatch):
     monkeypatch.setattr("main.parse_event_via_4o", fake_parse)
     monkeypatch.setattr("main.create_source_page", fake_create)
 
-    start_msg = types.Message.model_validate({
-        "message_id": 1,
-        "date": 0,
-        "chat": {"id": 1, "type": "private"},
-        "from": {"id": 1, "is_bot": False, "first_name": "A"},
-        "text": "/start",
-    })
+    start_msg = types.Message.model_validate(
+        {
+            "message_id": 1,
+            "date": 0,
+            "chat": {"id": 1, "type": "private"},
+            "from": {"id": 1, "is_bot": False, "first_name": "A"},
+            "text": "/start",
+        }
+    )
     await handle_start(start_msg, db, bot)
 
     upd = DummyUpdate(-100123, "Chan")
@@ -797,13 +870,15 @@ async def test_media_group_caption_last(tmp_path: Path, monkeypatch):
     bot = DummyBot("123:abc")
 
     async def fake_parse(text: str) -> list[dict]:
-        return [{
-            "title": "MG",
-            "short_description": "d",
-            "date": "2025-07-16",
-            "time": "18:00",
-            "location_name": "Club",
-        }]
+        return [
+            {
+                "title": "MG",
+                "short_description": "d",
+                "date": "2025-07-16",
+                "time": "18:00",
+                "location_name": "Club",
+            }
+        ]
 
     async def fake_create(title, text, source, html_text=None, media=None):
         return "https://t.me/page", "p"
@@ -811,13 +886,15 @@ async def test_media_group_caption_last(tmp_path: Path, monkeypatch):
     monkeypatch.setattr("main.parse_event_via_4o", fake_parse)
     monkeypatch.setattr("main.create_source_page", fake_create)
 
-    start_msg = types.Message.model_validate({
-        "message_id": 1,
-        "date": 0,
-        "chat": {"id": 1, "type": "private"},
-        "from": {"id": 1, "is_bot": False, "first_name": "A"},
-        "text": "/start",
-    })
+    start_msg = types.Message.model_validate(
+        {
+            "message_id": 1,
+            "date": 0,
+            "chat": {"id": 1, "type": "private"},
+            "from": {"id": 1, "is_bot": False, "first_name": "A"},
+            "text": "/start",
+        }
+    )
     await handle_start(start_msg, db, bot)
 
     upd = DummyUpdate(-100123, "Chan")
@@ -864,8 +941,6 @@ async def test_media_group_caption_last(tmp_path: Path, monkeypatch):
     assert evs[0].source_post_url == "https://t.me/chan/11"
 
 
-
-
 @pytest.mark.asyncio
 async def test_mark_free(tmp_path: Path, monkeypatch):
     db = Database(str(tmp_path / "db.sqlite"))
@@ -904,8 +979,10 @@ async def test_mark_free(tmp_path: Path, monkeypatch):
             },
         }
     ).as_(bot)
+
     async def dummy_answer(*args, **kwargs):
         return None
+
     object.__setattr__(cb, "answer", dummy_answer)
     await process_request(cb, db, bot)
 
@@ -955,8 +1032,10 @@ async def test_toggle_silent(tmp_path: Path, monkeypatch):
             },
         }
     ).as_(bot)
+
     async def dummy_answer(*args, **kwargs):
         return None
+
     object.__setattr__(cb, "answer", dummy_answer)
     await process_request(cb, db, bot)
 
@@ -986,23 +1065,25 @@ async def test_exhibition_listing(tmp_path: Path, monkeypatch):
     await handle_start(start_msg, db, bot)
 
     async def fake_parse(text: str) -> list[dict]:
-        return [{
-            "title": "Expo",
-            "short_description": "desc",
-            "festival": "",
-            "date": "2025-07-10",
-            "end_date": "2025-07-20",
-            "time": "",
-            "location_name": "Hall",
-            "location_address": "Addr",
-            "city": "Калининград",
-            "ticket_price_min": None,
-            "ticket_price_max": None,
-            "ticket_link": None,
-            "event_type": "выставка",
-            "emoji": None,
-            "is_free": True,
-        }]
+        return [
+            {
+                "title": "Expo",
+                "short_description": "desc",
+                "festival": "",
+                "date": "2025-07-10",
+                "end_date": "2025-07-20",
+                "time": "",
+                "location_name": "Hall",
+                "location_address": "Addr",
+                "city": "Калининград",
+                "ticket_price_min": None,
+                "ticket_price_max": None,
+                "ticket_link": None,
+                "event_type": "выставка",
+                "emoji": None,
+                "is_free": True,
+            }
+        ]
 
     monkeypatch.setattr("main.parse_event_via_4o", fake_parse)
 
@@ -1204,6 +1285,138 @@ async def test_build_weekend_page_content(tmp_path: Path):
 
 
 @pytest.mark.asyncio
+async def test_weekend_nav_and_exhibitions(tmp_path: Path):
+    db = Database(str(tmp_path / "db.sqlite"))
+    await db.init()
+
+    saturday = date(2025, 7, 12)
+    next_sat = saturday + timedelta(days=7)
+    async with db.get_session() as session:
+        session.add(WeekendPage(start=saturday.isoformat(), url="u1", path="p1"))
+        session.add(WeekendPage(start=next_sat.isoformat(), url="u2", path="p2"))
+        session.add(MonthPage(month="2025-07", url="m1", path="mp1"))
+        session.add(MonthPage(month="2025-08", url="m2", path="mp2"))
+        session.add(
+            Event(
+                title="Expo",
+                description="d",
+                source_text="s",
+                date=(saturday - timedelta(days=1)).isoformat(),
+                end_date=(saturday + timedelta(days=10)).isoformat(),
+                time="10:00",
+                location_name="Hall",
+                event_type="выставка",
+            )
+        )
+        await session.commit()
+
+    _, content = await main.build_weekend_page_content(db, saturday.isoformat())
+    found_weekend = False
+    found_exh = False
+    for n in content:
+        if n.get("tag") == "h4" and any(
+            isinstance(c, dict) and c.get("attrs", {}).get("href") == "u2"
+            for c in n.get("children", [])
+        ):
+            found_weekend = True
+        if n.get("tag") == "h3" and "Постоянные" in "".join(n.get("children", [])):
+            found_exh = True
+    assert found_weekend
+    assert found_exh
+
+
+@pytest.mark.asyncio
+async def test_sync_weekend_page_first_creation_includes_nav(
+    tmp_path: Path, monkeypatch
+):
+    db = Database(str(tmp_path / "db.sqlite"))
+    await db.init()
+
+    saturday = date(2025, 7, 12)
+    next_sat = saturday + timedelta(days=7)
+    updates: list[list[dict]] = []
+
+    class DummyTG:
+        def create_page(self, title, content):
+            return {"url": "u1", "path": "p1"}
+
+        def edit_page(self, path, title=None, content=None):
+            updates.append(content)
+
+    monkeypatch.setattr("main.get_telegraph_token", lambda: "t")
+    monkeypatch.setattr("main.Telegraph", lambda access_token=None: DummyTG())
+
+    async with db.get_session() as session:
+        session.add(WeekendPage(start=next_sat.isoformat(), url="u2", path="p2"))
+        session.add(MonthPage(month="2025-07", url="m1", path="mp1"))
+        session.add(MonthPage(month="2025-08", url="m2", path="mp2"))
+        session.add(
+            Event(
+                title="Expo",
+                description="d",
+                source_text="s",
+                date=(saturday - timedelta(days=1)).isoformat(),
+                end_date=(saturday + timedelta(days=10)).isoformat(),
+                time="10:00",
+                location_name="Hall",
+                event_type="выставка",
+            )
+        )
+        await session.commit()
+
+    await main.sync_weekend_page(db, saturday.isoformat())
+    assert updates
+    content = updates[0]
+    found_weekend = any(
+        isinstance(n, dict)
+        and n.get("tag") == "h4"
+        and any(
+            isinstance(c, dict) and c.get("attrs", {}).get("href") == "u2"
+            for c in n.get("children", [])
+        )
+        for n in content
+    )
+    found_exh = any(
+        isinstance(n, dict)
+        and n.get("tag") == "h3"
+        and "Постоянные" in "".join(n.get("children", []))
+        for n in content
+    )
+    assert found_weekend
+    assert found_exh
+
+
+@pytest.mark.asyncio
+async def test_sync_weekend_page_updates_other_pages(tmp_path: Path, monkeypatch):
+    db = Database(str(tmp_path / "db.sqlite"))
+    await db.init()
+
+    saturday = date(2025, 7, 12)
+    next_sat = saturday + timedelta(days=7)
+
+    edits: list[tuple[str, str]] = []
+
+    class DummyTG:
+        def create_page(self, title, content):
+            edits.append(("create", "p1"))
+            return {"url": "u1", "path": "p1"}
+
+        def edit_page(self, path, title=None, content=None):
+            edits.append(("edit", path))
+
+    monkeypatch.setattr("main.get_telegraph_token", lambda: "t")
+    monkeypatch.setattr("main.Telegraph", lambda access_token=None: DummyTG())
+
+    async with db.get_session() as session:
+        session.add(WeekendPage(start=next_sat.isoformat(), url="u2", path="p2"))
+        await session.commit()
+
+    await main.sync_weekend_page(db, saturday.isoformat())
+
+    assert ("edit", "p2") in edits
+
+
+@pytest.mark.asyncio
 async def test_missing_added_at(tmp_path: Path):
     db = Database(str(tmp_path / "db.sqlite"))
     await db.init()
@@ -1277,7 +1490,10 @@ async def test_emoji_not_duplicated(tmp_path: Path):
 
     _, content = await main.build_month_page_content(db, "2025-07")
     h4 = next(n for n in content if n.get("tag") == "h4")
-    text = "".join(c if isinstance(c, str) else "".join(c.get("children", [])) for c in h4["children"])
+    text = "".join(
+        c if isinstance(c, str) else "".join(c.get("children", []))
+        for c in h4["children"]
+    )
     assert text.count("🎉") == 1
 
 
@@ -1319,7 +1535,9 @@ async def test_spacing_after_headers(tmp_path: Path):
     )
     assert content[idx + 1].get("tag") == "br"
     exh_idx = next(
-        i for i, n in enumerate(content) if n.get("tag") == "h3" and "Постоянные" in "".join(n.get("children", []))
+        i
+        for i, n in enumerate(content)
+        if n.get("tag") == "h3" and "Постоянные" in "".join(n.get("children", []))
     )
     assert content[exh_idx + 1].get("tag") == "br"
 
@@ -1466,6 +1684,7 @@ async def test_update_source_page_uses_content(monkeypatch):
     class DummyTG:
         def get_page(self, path, return_html=True):
             return {"content": "<p>old</p>"}
+
         def edit_page(self, path, title, html_content):
             events["html"] = html_content
 
@@ -1501,7 +1720,7 @@ async def test_nav_limits_past(tmp_path: Path):
     text, markup = await main.build_events_message(db, today, timezone.utc)
     row = markup.inline_keyboard[-1]
     assert len(row) == 1
-    assert row[0].text == "\u25B6"
+    assert row[0].text == "\u25b6"
 
 
 @pytest.mark.asyncio
@@ -1527,8 +1746,8 @@ async def test_nav_future_has_prev(tmp_path: Path):
     text, markup = await main.build_events_message(db, future, timezone.utc)
     row = markup.inline_keyboard[-1]
     assert len(row) == 2
-    assert row[0].text == "\u25C0"
-    assert row[1].text == "\u25B6"
+    assert row[0].text == "\u25c0"
+    assert row[1].text == "\u25b6"
 
 
 @pytest.mark.asyncio
@@ -1577,11 +1796,15 @@ async def test_delete_event_updates_month(tmp_path: Path, monkeypatch):
         }
     ).as_(bot)
     object.__setattr__(cb.message, "_bot", bot)
+
     async def dummy_edit(*args, **kwargs):
         return None
+
     object.__setattr__(cb.message, "edit_text", dummy_edit)
+
     async def dummy_answer(*args, **kwargs):
         return None
+
     object.__setattr__(cb, "answer", dummy_answer)
 
     await process_request(cb, db, bot)
@@ -1743,6 +1966,39 @@ async def test_extract_ticket_link_near_word(tmp_path: Path, monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_ticket_link_overrides_invalid(tmp_path: Path, monkeypatch):
+    db = Database(str(tmp_path / "db.sqlite"))
+    await db.init()
+    bot = DummyBot("123:abc")
+
+    async def fake_parse(text: str) -> list[dict]:
+        return [
+            {
+                "title": "T",
+                "short_description": "d",
+                "date": FUTURE_DATE,
+                "time": "18:00",
+                "location_name": "Hall",
+                "ticket_link": "Регистрация по ссылке",
+                "event_type": "встреча",
+                "emoji": None,
+                "is_free": True,
+            }
+        ]
+
+    async def fake_create(title, text, source, html_text=None, media=None):
+        return "url", "p"
+
+    monkeypatch.setattr("main.parse_event_via_4o", fake_parse)
+    monkeypatch.setattr("main.create_source_page", fake_create)
+
+    html = "Регистрация <a href='https://real'>по ссылке</a>"
+    results = await main.add_events_from_text(db, "text", None, html, None)
+    ev = results[0][0]
+    assert ev.ticket_link == "https://real"
+
+
+@pytest.mark.asyncio
 async def test_festival_expands_dates(tmp_path: Path, monkeypatch):
     db = Database(str(tmp_path / "db.sqlite"))
     await db.init()
@@ -1760,14 +2016,18 @@ async def test_festival_expands_dates(tmp_path: Path, monkeypatch):
         ]
 
     monkeypatch.setattr("main.parse_event_via_4o", fake_parse)
+
     async def fake_create(*args, **kwargs):
         return "u", "p"
+
     monkeypatch.setattr("main.create_source_page", fake_create)
 
     results = await main.add_events_from_text(db, "text", None, None, None)
     assert len(results) == 3
     async with db.get_session() as session:
-        dates = sorted((await session.execute(select(Event))).scalars(), key=lambda e: e.date)
+        dates = sorted(
+            (await session.execute(select(Event))).scalars(), key=lambda e: e.date
+        )
         assert [e.date for e in dates] == ["2025-08-01", "2025-08-02", "2025-08-03"]
 
 
@@ -1806,6 +2066,40 @@ async def test_exhibition_future_not_listed(tmp_path: Path):
 
 
 @pytest.mark.asyncio
+async def test_past_exhibition_not_listed_in_events(tmp_path: Path):
+    db = Database(str(tmp_path / "db.sqlite"))
+    await db.init()
+
+    past_start = (date.today() - timedelta(days=6)).isoformat()
+    future_end = (date.today() + timedelta(days=6)).isoformat()
+    async with db.get_session() as session:
+        session.add(
+            Event(
+                title="PastExpo",
+                description="d",
+                source_text="s",
+                date=past_start,
+                end_date=future_end,
+                time="10:00",
+                location_name="Hall",
+                event_type="выставка",
+            )
+        )
+        await session.commit()
+
+    _, content = await main.build_month_page_content(db, past_start[:7])
+    before_exh = True
+    found = False
+    for n in content:
+        if n.get("tag") == "h3" and "Постоянные" in "".join(n.get("children", [])):
+            before_exh = False
+        if before_exh and isinstance(n, dict) and n.get("tag") == "h4":
+            if any("PastExpo" in str(c) for c in n.get("children", [])):
+                found = True
+    assert not found
+
+
+@pytest.mark.asyncio
 async def test_month_links_future(tmp_path: Path, monkeypatch):
     db = Database(str(tmp_path / "db.sqlite"))
     await db.init()
@@ -1825,6 +2119,104 @@ async def test_month_links_future(tmp_path: Path, monkeypatch):
     title, content = await main.build_month_page_content(db, "2025-07")
     found = False
     for n in content:
-        if isinstance(n, dict) and n.get("tag") == "h4" and any("август" in str(c) for c in n.get("children", [])):
+        if (
+            isinstance(n, dict)
+            and n.get("tag") == "h4"
+            and any("август" in str(c) for c in n.get("children", []))
+        ):
             found = True
     assert found
+
+
+@pytest.mark.asyncio
+async def test_build_daily_posts(tmp_path: Path):
+    db = Database(str(tmp_path / "db.sqlite"))
+    await db.init()
+
+    today = date.today()
+    start = main.next_weekend_start(today)
+    async with db.get_session() as session:
+        session.add(
+            Event(
+                title="T",
+                description="d",
+                source_text="s",
+                date=today.isoformat(),
+                time="18:00",
+                location_name="Hall",
+            )
+        )
+        session.add(
+            Event(
+                title="S",
+                description="d2",
+                source_text="s2",
+                date=today.isoformat(),
+                time="19:00",
+                location_name="Hall",
+                silent=True,
+            )
+        )
+        session.add(MonthPage(month=today.strftime("%Y-%m"), url="m1", path="p1"))
+        session.add(
+            MonthPage(
+                month=main.next_month(today.strftime("%Y-%m")), url="m2", path="p2"
+            )
+        )
+        session.add(WeekendPage(start=start.isoformat(), url="w", path="wp"))
+        await session.commit()
+
+    posts = await main.build_daily_posts(db, timezone.utc)
+    assert posts
+    text, markup = posts[0]
+    assert "АНОНС" in text
+    assert markup.inline_keyboard[0]
+    assert text.count("\U0001f449") == 2
+
+
+@pytest.mark.asyncio
+async def test_send_daily_preview_disabled(tmp_path: Path):
+    db = Database(str(tmp_path / "db.sqlite"))
+    await db.init()
+    bot = DummyBot("123:abc")
+
+    async with db.get_session() as session:
+        session.add(
+            main.Channel(channel_id=1, title="ch", is_admin=True, daily_time="08:00")
+        )
+        session.add(
+            Event(
+                title="T",
+                description="d",
+                source_text="s",
+                date=date.today().isoformat(),
+                time="18:00",
+                location_name="Hall",
+            )
+        )
+        await session.commit()
+
+    await main.send_daily_announcement(db, bot, 1, timezone.utc)
+    assert bot.messages
+    assert bot.messages[-1][2].get("disable_web_page_preview") is True
+    async with db.get_session() as session:
+        ch = await session.get(main.Channel, 1)
+    assert ch.last_daily == date.today().isoformat()
+
+
+@pytest.mark.asyncio
+async def test_daily_test_send_no_record(tmp_path: Path):
+    db = Database(str(tmp_path / "db.sqlite"))
+    await db.init()
+    bot = DummyBot("123:abc")
+
+    async with db.get_session() as session:
+        session.add(
+            main.Channel(channel_id=1, title="ch", is_admin=True, daily_time="08:00")
+        )
+        await session.commit()
+
+    await main.send_daily_announcement(db, bot, 1, timezone.utc, record=False)
+    async with db.get_session() as session:
+        ch = await session.get(main.Channel, 1)
+    assert ch.last_daily is None


### PR DESCRIPTION
## Summary
- update `sync_weekend_page` to rebuild other weekend pages after editing
- adapt tests for new optional parameter and added regression test

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686c2cc61aec8332959080b5c255a6f8