### PR TITLE
Implement Catbox image host and daily counts

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,8 @@ Dates are shown as `DD.MM.YYYY` in bot messages. Telegraph pages and other
 public posts use the format "D месяц" (for example, "2 июля").
 
 See `docs/COMMANDS.md` for available bot commands, including `/events` to
-browse upcoming announcements.
+browse upcoming announcements. The command accepts dates like `2025-07-10`,
+`10.07.2025` or `2 августа`.
 
 ## Quick start
 
@@ -70,7 +71,7 @@ browse upcoming announcements.
 
 Each added event stores the original announcement text in a Telegraph page. The link is shown when the event is added and in the `/events` listing. Events may also contain ticket prices and a purchase link. Use the edit button in `/events` to change any field.
 Links from the announcement text are preserved on the Telegraph page whenever possible so readers can follow the original sources.
-If the original message contains a photo or video, the first media file is uploaded to Telegraph and shown at the top of the page.
+If the original message contains photos (under 5&nbsp;MB), they are uploaded to Catbox and displayed on the Telegraph page.
 Run `/exhibitions` to see all ongoing exhibitions (events with a start and end date).
 
 To verify Telegraph access manually run:

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -19,7 +19,7 @@ helper `python main.py test_telegraph` checks Telegraph access and creates a
 Telegraph token automatically if needed.
 
 Each event stores optional ticket information (`ticket_price_min`, `ticket_price_max`, `ticket_link`). If the event was forwarded from a channel, the link to that post is saved in `source_post_url`.
-Free events are marked with `is_free`. Telegraph pages are stored with both URL and path so they can be updated when the event description changes. If a message includes an image or short video, that media is uploaded to Telegraph and displayed at the start of the source page.
+Free events are marked with `is_free`. Telegraph pages are stored with both URL and path so they can be updated when the event description changes. If a message includes images (under 5&nbsp;MB each), they are uploaded to Catbox and embedded at the start of the source page.
 Events also keep `event_type` (one of six categories) and an `emoji` suggested by the LLM. Multi-day events store `end_date` and appear with "Открытие" or "Закрытие" on the respective days. `/exhibitions` lists active exhibitions.
 If a text describes several events at once the LLM returns an array of event objects and the bot creates separate entries and Telegraph pages for each of them.
 Channels where the bot is admin are tracked in the `channel` table. Use `/setchannel` to choose an admin channel and mark it as an announcement source. The `/channels` command lists all admin channels and shows which ones are registered.

--- a/docs/COMMANDS.md
+++ b/docs/COMMANDS.md
@@ -6,10 +6,11 @@
 | `/register` | - | Request moderator access if slots (<10) are free. |
 | `/requests` | - | Superadmin sees pending registrations with approve/reject buttons. |
 | `/tz <±HH:MM>` | required offset | Set timezone offset (superadmin only). |
-| `/addevent <text>` | event description | Parse text with model 4o and store one or several events. The original text is published to Telegraph (including the first photo or video if present) and the link is returned. Forwarded messages from moderators are processed the same way. |
+| `/addevent <text>` | event description | Parse text with model 4o and store one or several events. The original text is published to Telegraph. Images up to 5&nbsp;MB are uploaded to Catbox and shown on that page. Forwarded messages from moderators are processed the same way. |
 | `/addevent_raw <title>|<date>|<time>|<location>` | manual fields | Add event without LLM. The bot also creates a Telegraph page with the provided text and optional attached photo. |
+| `/images` | - | Toggle uploading photos to Catbox. |
 | `/ask4o <text>` | any text | Send query to model 4o and show plain response (superadmin only). |
-| `/events [DATE]` | optional date `YYYY-MM-DD` or `DD.MM.YYYY` | List events for the day with delete and edit buttons. Dates are shown as `DD.MM.YYYY`. Choosing **Edit** lists all fields with inline buttons including a toggle for "Бесплатно". |
+| `/events [DATE]` | optional date `YYYY-MM-DD`, `DD.MM.YYYY` or `D месяц [YYYY]` | List events for the day with delete and edit buttons. Dates are shown as `DD.MM.YYYY`. Choosing **Edit** lists all fields with inline buttons including a toggle for "Бесплатно". |
 | `/setchannel` | - | Choose one of the admin channels to register as an announcement source. |
 | `/channels` | - | List channels where the bot is admin and mark registered ones with a cancel button. |
 | `/regdailychannels` | - | Choose admin channels for daily announcements (default 08:00). |

--- a/docs/LOCATIONS.md
+++ b/docs/LOCATIONS.md
@@ -13,3 +13,7 @@ Evang. Lutheran Church, Mira 101, #Kaliningrad
 ```
 
 Edit this file to keep location names consistent when parsing events.
+
+Филиал Третьяковской галереи, Парадная наб. 3, #Калининград
+Евангелистко-Лютеранская церковь, Мира 101, #Калининград
+Книжная гостиная, Ленинский проспект 40, #Калининград

--- a/docs/PROMPTS.md
+++ b/docs/PROMPTS.md
@@ -15,7 +15,7 @@ festival          - festival name or empty string
 date              - single date or range (YYYY-MM-DD or YYYY-MM-DD..YYYY-MM-DD)
 time              - start time or time range (HH:MM or HH:MM..HH:MM)
 location_name     - venue name, use standard directory form if known
-location_address  - street address if present
+location_address  - street address if present (omit the city name)
 city              - city name
 ticket_price_min  - minimum ticket price as integer or null
 ticket_price_max  - maximum ticket price as integer or null

--- a/main.py
+++ b/main.py
@@ -1,12 +1,13 @@
 import logging
 import os
-from datetime import date, datetime, timedelta, timezone
-from typing import Optional, Tuple
+from datetime import date, datetime, timedelta, timezone, time
+from typing import Optional, Tuple, Iterable
 
 from aiogram import Bot, Dispatcher, types
 from aiogram.filters import Command
 from aiogram.webhook.aiohttp_server import SimpleRequestHandler, setup_application
-from aiohttp import web, ClientSession
+from aiohttp import web, ClientSession, FormData
+import imghdr
 from difflib import SequenceMatcher
 import json
 import re
@@ -32,6 +33,9 @@ CONTENT_SEPARATOR = "🟧" * 10
 editing_sessions: dict[int, tuple[int, str | None]] = {}
 # user_id -> channel_id for daily time editing
 daily_time_sessions: dict[int, int] = {}
+
+# toggle for uploading images to catbox
+CATBOX_ENABLED: bool = False
 
 
 class User(SQLModel, table=True):
@@ -89,6 +93,7 @@ class Event(SQLModel, table=True):
     source_text: str
     telegraph_url: Optional[str] = None
     source_post_url: Optional[str] = None
+    photo_count: int = 0
     added_at: datetime = Field(default_factory=datetime.utcnow)
 
 
@@ -161,6 +166,10 @@ class Database:
                 await conn.exec_driver_sql(
                     "ALTER TABLE event ADD COLUMN added_at VARCHAR"
                 )
+            if "photo_count" not in cols:
+                await conn.exec_driver_sql(
+                    "ALTER TABLE event ADD COLUMN photo_count INTEGER DEFAULT 0"
+                )
 
             result = await conn.exec_driver_sql("PRAGMA table_info(channel)")
             cols = [r[1] for r in result.fetchall()]
@@ -195,6 +204,25 @@ async def set_tz_offset(db: Database, value: str):
         await session.commit()
 
 
+async def get_catbox_enabled(db: Database) -> bool:
+    async with db.get_session() as session:
+        setting = await session.get(Setting, "catbox_enabled")
+        return setting.value == "1" if setting else False
+
+
+async def set_catbox_enabled(db: Database, value: bool):
+    async with db.get_session() as session:
+        setting = await session.get(Setting, "catbox_enabled")
+        if setting:
+            setting.value = "1" if value else "0"
+        else:
+            setting = Setting(key="catbox_enabled", value="1" if value else "0")
+            session.add(setting)
+        await session.commit()
+    global CATBOX_ENABLED
+    CATBOX_ENABLED = value
+
+
 def validate_offset(value: str) -> bool:
     if len(value) != 6 or value[0] not in "+-" or value[3] != ":":
         return False
@@ -211,6 +239,76 @@ def offset_to_timezone(value: str) -> timezone:
     hours = int(value[1:3])
     minutes = int(value[4:6])
     return timezone(sign * timedelta(hours=hours, minutes=minutes))
+
+
+async def extract_images(message: types.Message, bot: Bot) -> list[tuple[bytes, str]]:
+    """Download up to three images from the message."""
+    images: list[tuple[bytes, str]] = []
+    if message.photo:
+        bio = BytesIO()
+        await bot.download(message.photo[-1].file_id, destination=bio)
+        images.append((bio.getvalue(), "photo.jpg"))
+    if (
+        message.document
+        and message.document.mime_type
+        and message.document.mime_type.startswith("image/")
+    ):
+        bio = BytesIO()
+        await bot.download(message.document.file_id, destination=bio)
+        name = message.document.file_name or "image.jpg"
+        images.append((bio.getvalue(), name))
+    return images[:3]
+
+
+def normalize_hashtag_dates(text: str) -> str:
+    """Replace hashtags like '#1_августа' with '1 августа'."""
+    pattern = re.compile(
+        r"#(\d{1,2})_(%s)" % "|".join(MONTHS)
+    )
+    return re.sub(pattern, lambda m: f"{m.group(1)} {m.group(2)}", text)
+
+
+def strip_city_from_address(address: str | None, city: str | None) -> str | None:
+    """Remove the city name from the end of the address if duplicated."""
+    if not address or not city:
+        return address
+    city_clean = city.lstrip("#").strip().lower()
+    addr = address.strip()
+    if addr.lower().endswith(city_clean):
+        addr = re.sub(r",?\s*#?%s$" % re.escape(city_clean), "", addr, flags=re.IGNORECASE)
+    addr = addr.rstrip(", ")
+    return addr
+
+
+def parse_events_date(text: str, tz: timezone) -> date | None:
+    """Parse a date argument for /events allowing '2 августа [2025]'."""
+    text = text.strip().lower()
+    for fmt in ("%Y-%m-%d", "%d.%m.%Y"):
+        try:
+            return datetime.strptime(text, fmt).date()
+        except ValueError:
+            pass
+
+    m = re.match(r"(\d{1,2})\s+([а-яё]+)(?:\s+(\d{4}))?", text)
+    if not m:
+        return None
+    day = int(m.group(1))
+    month_name = m.group(2)
+    year_part = m.group(3)
+    month = {name: i + 1 for i, name in enumerate(MONTHS)}.get(month_name)
+    if not month:
+        return None
+    if year_part:
+        year = int(year_part)
+    else:
+        today = datetime.now(tz).date()
+        year = today.year
+        if month < today.month or (month == today.month and day < today.day):
+            year += 1
+    try:
+        return date(year, month, day)
+    except ValueError:
+        return None
 
 
 async def parse_event_via_4o(text: str) -> list[dict]:
@@ -643,6 +741,18 @@ async def handle_tz(message: types.Message, db: Database, bot: Bot):
     await bot.send_message(message.chat.id, f"Timezone set to {parts[1]}")
 
 
+async def handle_images(message: types.Message, db: Database, bot: Bot):
+    async with db.get_session() as session:
+        user = await session.get(User, message.from_user.id)
+        if not user or not user.is_superadmin:
+            await bot.send_message(message.chat.id, "Not authorized")
+            return
+    new_value = not CATBOX_ENABLED
+    await set_catbox_enabled(db, new_value)
+    status = "enabled" if new_value else "disabled"
+    await bot.send_message(message.chat.id, f"Image uploads {status}")
+
+
 async def handle_my_chat_member(update: types.ChatMemberUpdated, db: Database):
     if update.chat.type != "channel":
         return
@@ -1049,7 +1159,7 @@ async def add_events_from_text(
     text: str,
     source_link: str | None,
     html_text: str | None = None,
-    media: tuple[bytes, str] | None = None,
+    media: list[tuple[bytes, str]] | tuple[bytes, str] | None = None,
 ) -> list[tuple[Event, bool, list[str], str]]:
     try:
         parsed = await parse_event_via_4o(text)
@@ -1059,6 +1169,7 @@ async def add_events_from_text(
 
     results: list[tuple[Event, bool, list[str], str]] = []
     first = True
+    links_iter = iter(extract_links_from_html(html_text) if html_text else [])
     for data in parsed:
         date_str = data.get("date", "") or ""
         end_date = data.get("end_date") or None
@@ -1070,6 +1181,10 @@ async def add_events_from_text(
             if not end_date:
                 end_date = maybe_end
 
+        addr = data.get("location_address")
+        city = data.get("city")
+        addr = strip_city_from_address(addr, city)
+
         base_event = Event(
             title=data.get("title", ""),
             description=data.get("short_description", ""),
@@ -1077,8 +1192,8 @@ async def add_events_from_text(
             date=date_str,
             time=data.get("time", ""),
             location_name=data.get("location_name", ""),
-            location_address=data.get("location_address"),
-            city=data.get("city"),
+            location_address=addr,
+            city=city,
             ticket_price_min=data.get("ticket_price_min"),
             ticket_price_max=data.get("ticket_price_max"),
             ticket_link=data.get("ticket_link"),
@@ -1089,6 +1204,14 @@ async def add_events_from_text(
             source_text=text,
             source_post_url=source_link,
         )
+
+        if base_event.event_type == "выставка" and not base_event.end_date:
+            try:
+                start_dt = date.fromisoformat(base_event.date)
+            except ValueError:
+                start_dt = date.today()
+                base_event.date = start_dt.isoformat()
+            base_event.end_date = date(start_dt.year, 12, 31).isoformat()
 
         events_to_add = [base_event]
         if (
@@ -1111,8 +1234,11 @@ async def add_events_from_text(
                     events_to_add.append(copy_e)
 
         for event in events_to_add:
-            if (not is_valid_url(event.ticket_link)) and html_text:
-                extracted = extract_link_from_html(html_text)
+            if not is_valid_url(event.ticket_link):
+                try:
+                    extracted = next(links_iter)
+                except StopIteration:
+                    extracted = None
                 if extracted:
                     event.ticket_link = extracted
 
@@ -1131,10 +1257,21 @@ async def add_events_from_text(
                 saved, added = await upsert_event(session, event)
 
             media_arg = media if first else None
+            upload_info = ""
+            photo_count = saved.photo_count
             if saved.telegraph_url and saved.telegraph_path:
-                await update_source_page(
-                    saved.telegraph_path, saved.title or "Event", html_text or text
+                upload_info, added_count = await update_source_page(
+                    saved.telegraph_path,
+                    saved.title or "Event",
+                    html_text or text,
+                    media_arg,
                 )
+                if added_count:
+                    photo_count += added_count
+                    async with db.get_session() as session:
+                        saved.photo_count = photo_count
+                        session.add(saved)
+                        await session.commit()
             else:
                 res = await create_source_page(
                     saved.title or "Event",
@@ -1144,10 +1281,19 @@ async def add_events_from_text(
                     media_arg,
                 )
                 if res:
-                    url, path = res
+                    if len(res) == 4:
+                        url, path, upload_info, photo_count = res
+                    elif len(res) == 3:
+                        url, path, upload_info = res
+                        photo_count = 0
+                    else:
+                        url, path = res
+                        upload_info = ""
+                        photo_count = 0
                     async with db.get_session() as session:
                         saved.telegraph_url = url
                         saved.telegraph_path = path
+                        saved.photo_count = photo_count
                         session.add(saved)
                         await session.commit()
             await sync_month_page(db, saved.date[:7])
@@ -1179,6 +1325,8 @@ async def add_events_from_text(
                 lines.append(f"ticket_link: {saved.ticket_link}")
             if saved.telegraph_url:
                 lines.append(f"telegraph: {saved.telegraph_url}")
+            if upload_info:
+                lines.append(f"catbox: {upload_info}")
             status = "added" if added else "updated"
             results.append((saved, added, lines, status))
             first = False
@@ -1186,25 +1334,22 @@ async def add_events_from_text(
 
 
 async def handle_add_event(message: types.Message, db: Database, bot: Bot):
-    text = message.text.split(maxsplit=1)
-    if len(text) != 2:
+    parts = (message.text or message.caption or "").split(maxsplit=1)
+    if len(parts) != 2:
         await bot.send_message(message.chat.id, "Usage: /addevent <text>")
         return
-    media = None
-    if message.photo:
-        bio = BytesIO()
-        await bot.download(message.photo[-1].file_id, destination=bio)
-        media = (bio.getvalue(), "photo.jpg")
-    elif message.document and message.document.mime_type.startswith("image/"):
-        bio = BytesIO()
-        await bot.download(message.document.file_id, destination=bio)
-        media = (bio.getvalue(), "image.jpg")
-    elif message.video:
-        bio = BytesIO()
-        await bot.download(message.video.file_id, destination=bio)
-        media = (bio.getvalue(), "video.mp4")
-
-    results = await add_events_from_text(db, text[1], None, message.html_text, media)
+    images = await extract_images(message, bot)
+    media = images if images else None
+    html_text = message.html_text or message.caption_html
+    if html_text and html_text.startswith("/addevent"):
+        html_text = html_text[len("/addevent") :].lstrip()
+    results = await add_events_from_text(
+        db,
+        parts[1],
+        None,
+        html_text,
+        media,
+    )
     if not results:
         await bot.send_message(message.chat.id, "LLM error")
         return
@@ -1236,26 +1381,15 @@ async def handle_add_event(message: types.Message, db: Database, bot: Bot):
 
 
 async def handle_add_event_raw(message: types.Message, db: Database, bot: Bot):
-    parts = message.text.split(maxsplit=1)
+    parts = (message.text or message.caption or "").split(maxsplit=1)
     if len(parts) != 2 or "|" not in parts[1]:
         await bot.send_message(
             message.chat.id, "Usage: /addevent_raw title|date|time|location"
         )
         return
     title, date, time, location = (p.strip() for p in parts[1].split("|", 3))
-    media = None
-    if message.photo:
-        bio = BytesIO()
-        await bot.download(message.photo[-1].file_id, destination=bio)
-        media = (bio.getvalue(), "photo.jpg")
-    elif message.document and message.document.mime_type.startswith("image/"):
-        bio = BytesIO()
-        await bot.download(message.document.file_id, destination=bio)
-        media = (bio.getvalue(), "image.jpg")
-    elif message.video:
-        bio = BytesIO()
-        await bot.download(message.video.file_id, destination=bio)
-        media = (bio.getvalue(), "video.mp4")
+    images = await extract_images(message, bot)
+    media = images if images else None
 
     event = Event(
         title=title,
@@ -1269,18 +1403,32 @@ async def handle_add_event_raw(message: types.Message, db: Database, bot: Bot):
     async with db.get_session() as session:
         event, added = await upsert_event(session, event)
 
+    html_text = message.html_text or message.caption_html
+    if html_text and html_text.startswith("/addevent_raw"):
+        html_text = html_text[len("/addevent_raw") :].lstrip()
     res = await create_source_page(
         event.title or "Event",
         event.source_text,
         None,
-        event.source_text,
+        html_text or event.source_text,
         media,
     )
+    upload_info = ""
+    photo_count = 0
     if res:
-        url, path = res
+        if len(res) == 4:
+            url, path, upload_info, photo_count = res
+        elif len(res) == 3:
+            url, path, upload_info = res
+            photo_count = 0
+        else:
+            url, path = res
+            upload_info = ""
+            photo_count = 0
         async with db.get_session() as session:
             event.telegraph_url = url
             event.telegraph_path = path
+            event.photo_count = photo_count
             session.add(event)
             await session.commit()
     await sync_month_page(db, event.date[:7])
@@ -1295,6 +1443,8 @@ async def handle_add_event_raw(message: types.Message, db: Database, bot: Bot):
     ]
     if event.telegraph_url:
         lines.append(f"telegraph: {event.telegraph_url}")
+    if upload_info:
+        lines.append(f"catbox: {upload_info}")
     status = "added" if added else "updated"
     btns = []
     if (
@@ -1467,6 +1617,39 @@ def extract_link_from_html(html_text: str) -> str | None:
     return None
 
 
+def extract_links_from_html(html_text: str) -> list[str]:
+    """Return all registration or ticket links in order of appearance."""
+    pattern = re.compile(
+        r"<a[^>]+href=['\"]([^'\"]+)['\"][^>]*>(.*?)</a>",
+        re.IGNORECASE | re.DOTALL,
+    )
+    matches = list(pattern.finditer(html_text))
+    lower_html = html_text.lower()
+
+    def qualifies(label: str, start: int, end: int) -> bool:
+        text = label.lower()
+        if any(word in text for word in ["регистра", "ticket", "билет"]):
+            return True
+        context_before = lower_html[max(0, start - 60) : start]
+        context_after = lower_html[end : end + 60]
+        return "регистра" in context_before or "регистра" in context_after or "билет" in context_before or "билет" in context_after
+
+    prioritized: list[tuple[int, str]] = []
+    others: list[tuple[int, str]] = []
+    for m in matches:
+        href, label = m.group(1), m.group(2)
+        if qualifies(label, *m.span()):
+            prioritized.append((m.start(), href))
+        else:
+            others.append((m.start(), href))
+
+    prioritized.sort(key=lambda x: x[0])
+    others.sort(key=lambda x: x[0])
+    links = [h for _, h in prioritized]
+    links.extend(h for _, h in others)
+    return links
+
+
 def is_valid_url(text: str | None) -> bool:
     if not text:
         return False
@@ -1520,10 +1703,15 @@ def format_event_md(e: Event) -> str:
         if price:
             lines.append(f"Билеты {price}")
     if e.telegraph_url:
-        lines.append(f"[подробнее]({e.telegraph_url})")
+        cam = "\U0001f4f8" * max(0, e.photo_count)
+        prefix = f"{cam} " if cam else ""
+        lines.append(f"{prefix}[подробнее]({e.telegraph_url})")
     loc = e.location_name
-    if e.location_address:
-        loc += f", {e.location_address}"
+    addr = e.location_address
+    if addr and e.city:
+        addr = strip_city_from_address(addr, e.city)
+    if addr:
+        loc += f", {addr}"
     if e.city:
         loc += f", #{e.city}"
     date_part = e.date.split("..", 1)[0]
@@ -1586,8 +1774,11 @@ def format_event_daily(e: Event, highlight: bool = False) -> str:
             lines.append(f"Билеты {price}")
 
     loc = html.escape(e.location_name)
-    if e.location_address:
-        loc += f", {html.escape(e.location_address)}"
+    addr = e.location_address
+    if addr and e.city:
+        addr = strip_city_from_address(addr, e.city)
+    if addr:
+        loc += f", {html.escape(addr)}"
     if e.city:
         loc += f", #{html.escape(e.city)}"
     date_part = e.date.split("..", 1)[0]
@@ -1627,10 +1818,15 @@ def format_exhibition_md(e: Event) -> str:
     elif e.ticket_price_max is not None:
         lines.append(f"Билеты {e.ticket_price_max}")
     if e.telegraph_url:
-        lines.append(f"[подробнее]({e.telegraph_url})")
+        cam = "\U0001f4f8" * max(0, e.photo_count)
+        prefix = f"{cam} " if cam else ""
+        lines.append(f"{prefix}[подробнее]({e.telegraph_url})")
     loc = e.location_name
-    if e.location_address:
-        loc += f", {e.location_address}"
+    addr = e.location_address
+    if addr and e.city:
+        addr = strip_city_from_address(addr, e.city)
+    if addr:
+        loc += f", {addr}"
     if e.city:
         loc += f", #{e.city}"
     if e.end_date:
@@ -2038,7 +2234,10 @@ async def build_daily_posts(
     db: Database, tz: timezone
 ) -> list[tuple[str, types.InlineKeyboardMarkup | None]]:
     today = datetime.now(tz).date()
-    yesterday_utc = datetime.utcnow() - timedelta(days=1)
+    yesterday_start_local = datetime.combine(
+        today - timedelta(days=1), time(0, 0), tz
+    )
+    yesterday_utc = yesterday_start_local.astimezone(timezone.utc)
     async with db.get_session() as session:
         res_today = await session.execute(
             select(Event).where(Event.date == today.isoformat()).order_by(Event.time)
@@ -2062,6 +2261,37 @@ async def build_daily_posts(
         mp_cur = await session.get(MonthPage, cur_month)
         mp_next = await session.get(MonthPage, next_month(cur_month))
 
+        new_events = (
+            await session.execute(
+                select(Event).where(
+                    Event.added_at.is_not(None),
+                    Event.added_at >= yesterday_utc,
+                )
+            )
+        ).scalars().all()
+
+        weekend_count = 0
+        if wpage:
+            sat = w_start
+            sun = w_start + timedelta(days=1)
+            for e in new_events:
+                if e.date in {sat.isoformat(), sun.isoformat()} or (
+                    e.event_type == "выставка"
+                    and e.end_date
+                    and e.end_date >= sat.isoformat()
+                    and e.date <= sun.isoformat()
+                ):
+                    weekend_count += 1
+
+        cur_count = 0
+        next_count = 0
+        for e in new_events:
+            m = e.date[:7]
+            if m == cur_month:
+                cur_count += 1
+            elif m == next_month(cur_month):
+                next_count += 1
+
     lines1 = [
         f"<b>АНОНС на {format_day_pretty(today)} {today.year} #ежедневныйанонс</b>",
         DAYS_OF_WEEK[today.weekday()],
@@ -2082,19 +2312,24 @@ async def build_daily_posts(
     buttons = []
     if wpage:
         sunday = w_start + timedelta(days=1)
-        text = f"Мероприятия на выходные {w_start.day} {sunday.day} {MONTHS[w_start.month - 1]}"
+        prefix = f"(+{weekend_count}) " if weekend_count else ""
+        text = (
+            f"{prefix}Мероприятия на выходные {w_start.day} {sunday.day} {MONTHS[w_start.month - 1]}"
+        )
         buttons.append(types.InlineKeyboardButton(text=text, url=wpage.url))
     if mp_cur:
+        prefix = f"(+{cur_count}) " if cur_count else ""
         buttons.append(
             types.InlineKeyboardButton(
-                text=f"Мероприятия на {month_name_nominative(cur_month)}",
+                text=f"{prefix}Мероприятия на {month_name_nominative(cur_month)}",
                 url=mp_cur.url,
             )
         )
     if mp_next:
+        prefix = f"(+{next_count}) " if next_count else ""
         buttons.append(
             types.InlineKeyboardButton(
-                text=f"Мероприятия на {month_name_nominative(next_month(cur_month))}",
+                text=f"{prefix}Мероприятия на {month_name_nominative(next_month(cur_month))}",
                 url=mp_next.url,
             )
         )
@@ -2399,15 +2634,9 @@ async def handle_events(message: types.Message, db: Database, bot: Bot):
     tz = offset_to_timezone(offset)
 
     if len(parts) == 2:
-        text = parts[1]
-        for fmt in ("%Y-%m-%d", "%d.%m.%Y"):
-            try:
-                day = datetime.strptime(text, fmt).date()
-                break
-            except ValueError:
-                day = None
-        if day is None:
-            await bot.send_message(message.chat.id, "Usage: /events YYYY-MM-DD")
+        day = parse_events_date(parts[1], tz)
+        if not day:
+            await bot.send_message(message.chat.id, "Usage: /events <date>")
             return
     else:
         day = datetime.now(tz).date()
@@ -2573,8 +2802,8 @@ async def handle_forwarded(message: types.Message, db: Database, bot: Bot):
                 else:
                     cid = cid.lstrip("-")
                 link = f"https://t.me/c/{cid}/{msg_id}"
-    media = None
-    # Skip downloading attachments to avoid large file transfers
+    images = await extract_images(message, bot)
+    media = images if images else None
 
     results = await add_events_from_text(
         db,
@@ -2630,17 +2859,68 @@ async def telegraph_test():
     print("Edited", page["url"])
 
 
-async def update_source_page(path: str, title: str, new_html: str):
+async def update_source_page(
+    path: str,
+    title: str,
+    new_html: str,
+    media: list[tuple[bytes, str]] | tuple[bytes, str] | None = None,
+) -> tuple[str, int]:
     """Append text to an existing Telegraph page."""
     token = get_telegraph_token()
     if not token:
         logging.error("Telegraph token unavailable")
-        return
+        return "token missing"
     tg = Telegraph(access_token=token)
     try:
         logging.info("Fetching telegraph page %s", path)
         page = await asyncio.to_thread(tg.get_page, path, return_html=True)
         html_content = page.get("content") or page.get("content_html") or ""
+        catbox_msg = ""
+        images: list[tuple[bytes, str]] = []
+        if media:
+            images = [media] if isinstance(media, tuple) else list(media)
+        catbox_urls: list[str] = []
+        if CATBOX_ENABLED and images:
+            async with ClientSession() as session:
+                for data, name in images[:3]:
+                    if len(data) > 5 * 1024 * 1024:
+                        logging.warning("catbox skip %s: too large", name)
+                        catbox_msg += f"{name}: too large; "
+                        continue
+                    if not imghdr.what(None, data):
+                        logging.warning("catbox skip %s: not image", name)
+                        catbox_msg += f"{name}: not image; "
+                        continue
+                    try:
+                        form = FormData()
+                        form.add_field("reqtype", "fileupload")
+                        form.add_field("fileToUpload", data, filename=name)
+                        async with session.post(
+                            "https://catbox.moe/user/api.php", data=form
+                        ) as resp:
+                            text = await resp.text()
+                            if resp.status == 200 and text.startswith("http"):
+                                url = text.strip()
+                                catbox_urls.append(url)
+                                catbox_msg += "ok; "
+                                logging.info("catbox uploaded %s", url)
+                            else:
+                                catbox_msg += f"{name}: err {resp.status}; "
+                                logging.error(
+                                    "catbox upload failed %s: %s %s",
+                                    name,
+                                    resp.status,
+                                    text,
+                                )
+                    except Exception as e:
+                        catbox_msg += f"{name}: {e}; "
+                        logging.error("catbox error %s: %s", name, e)
+            catbox_msg = catbox_msg.strip("; ")
+        elif images:
+            catbox_msg = "disabled"
+        for url in catbox_urls:
+            html_content += f'<img src="{html.escape(url)}"/><p></p>'
+        new_html = normalize_hashtag_dates(new_html)
         cleaned = re.sub(r"</?tg-emoji[^>]*>", "", new_html)
         cleaned = cleaned.replace(
             "\U0001f193\U0001f193\U0001f193\U0001f193", "Бесплатно"
@@ -2653,8 +2933,10 @@ async def update_source_page(path: str, title: str, new_html: str):
             tg.edit_page, path, title=title, html_content=html_content
         )
         logging.info("Updated telegraph page %s", path)
+        return catbox_msg, len(catbox_urls)
     except Exception as e:
         logging.error("Failed to update telegraph page: %s", e)
+        return f"error: {e}", 0
 
 
 async def create_source_page(
@@ -2662,8 +2944,8 @@ async def create_source_page(
     text: str,
     source_url: str | None,
     html_text: str | None = None,
-    media: tuple[bytes, str] | None = None,
-) -> tuple[str, str] | None:
+    media: list[tuple[bytes, str]] | tuple[bytes, str] | None = None,
+) -> tuple[str, str, str, int] | None:
     """Create a Telegraph page with the original event text."""
     token = get_telegraph_token()
     if not token:
@@ -2678,10 +2960,49 @@ async def create_source_page(
             return "\n".join(lines[1:]).lstrip()
         return line_text
 
-    # Media uploads to Telegraph are flaky and consume bandwidth.
-    # Skip uploading files for now to keep requests lightweight.
+    images: list[tuple[bytes, str]] = []
     if media:
-        logging.info("Media upload skipped for telegraph page")
+        images = [media] if isinstance(media, tuple) else list(media)
+    catbox_urls: list[str] = []
+    catbox_msg = ""
+    if CATBOX_ENABLED and images:
+        async with ClientSession() as session:
+            for data, name in images[:3]:
+                if len(data) > 5 * 1024 * 1024:
+                    logging.warning("catbox skip %s: too large", name)
+                    catbox_msg += f"{name}: too large; "
+                    continue
+                if not imghdr.what(None, data):
+                    logging.warning("catbox skip %s: not image", name)
+                    catbox_msg += f"{name}: not image; "
+                    continue
+                try:
+                    form = FormData()
+                    form.add_field("reqtype", "fileupload")
+                    form.add_field("fileToUpload", data, filename=name)
+                    async with session.post(
+                        "https://catbox.moe/user/api.php", data=form
+                    ) as resp:
+                        text_r = await resp.text()
+                        if resp.status == 200 and text_r.startswith("http"):
+                            url = text_r.strip()
+                            catbox_urls.append(url)
+                            catbox_msg += "ok; "
+                            logging.info("catbox uploaded %s", url)
+                        else:
+                            catbox_msg += f"{name}: err {resp.status}; "
+                            logging.error(
+                                "catbox upload failed %s: %s %s",
+                                name,
+                                resp.status,
+                                text_r,
+                            )
+                except Exception as e:
+                    catbox_msg += f"{name}: {e}; "
+                    logging.error("catbox error %s: %s", name, e)
+        catbox_msg = catbox_msg.strip("; ")
+    elif images:
+        catbox_msg = "disabled"
 
     if source_url:
         html_content += (
@@ -2691,8 +3012,12 @@ async def create_source_page(
     else:
         html_content += f"<p><strong>{html.escape(title)}</strong></p>"
 
+    for url in catbox_urls:
+        html_content += f'<img src="{html.escape(url)}"/><p></p>'
+
     if html_text:
         html_text = strip_title(html_text)
+        html_text = normalize_hashtag_dates(html_text)
         cleaned = re.sub(r"</?tg-emoji[^>]*>", "", html_text)
         cleaned = cleaned.replace(
             "\U0001f193\U0001f193\U0001f193\U0001f193", "Бесплатно"
@@ -2700,6 +3025,7 @@ async def create_source_page(
         html_content += f"<p>{cleaned.replace('\n', '<br/>')}</p>"
     else:
         clean_text = strip_title(text)
+        clean_text = normalize_hashtag_dates(clean_text)
         clean_text = clean_text.replace(
             "\U0001f193\U0001f193\U0001f193\U0001f193", "Бесплатно"
         )
@@ -2711,7 +3037,7 @@ async def create_source_page(
         logging.error("Failed to create telegraph page: %s", e)
         return None
     logging.info("Created telegraph page %s", page.get("url"))
-    return page.get("url"), page.get("path")
+    return page.get("url"), page.get("path"), catbox_msg, len(catbox_urls)
 
 
 def create_app() -> web.Application:
@@ -2783,6 +3109,9 @@ def create_app() -> web.Application:
     async def daily_wrapper(message: types.Message):
         await handle_daily(message, db, bot)
 
+    async def images_wrapper(message: types.Message):
+        await handle_images(message, db, bot)
+
     dp.message.register(start_wrapper, Command("start"))
     dp.message.register(register_wrapper, Command("register"))
     dp.message.register(requests_wrapper, Command("requests"))
@@ -2811,6 +3140,7 @@ def create_app() -> web.Application:
     dp.message.register(ask_4o_wrapper, Command("ask4o"))
     dp.message.register(list_events_wrapper, Command("events"))
     dp.message.register(set_channel_wrapper, Command("setchannel"))
+    dp.message.register(images_wrapper, Command("images"))
     dp.message.register(channels_wrapper, Command("channels"))
     dp.message.register(reg_daily_wrapper, Command("regdailychannels"))
     dp.message.register(daily_wrapper, Command("daily"))
@@ -2832,6 +3162,8 @@ def create_app() -> web.Application:
     async def on_startup(app: web.Application):
         logging.info("Initializing database")
         await db.init()
+        global CATBOX_ENABLED
+        CATBOX_ENABLED = await get_catbox_enabled(db)
         hook = webhook.rstrip("/") + "/webhook"
         logging.info("Setting webhook to %s", hook)
         await bot.set_webhook(

--- a/tests/test_bot.py
+++ b/tests/test_bot.py
@@ -7,7 +7,7 @@ from pathlib import Path
 import pytest
 from aiogram import Bot, types
 from sqlmodel import select
-from datetime import date, timedelta, timezone
+from datetime import date, timedelta, timezone, datetime
 from typing import Any
 import main
 
@@ -52,6 +52,9 @@ class DummyBot(Bot):
         self, chat_id: int | None = None, message_id: int | None = None, **kwargs
     ):
         self.edits.append((chat_id, message_id, kwargs))
+
+    async def download(self, file_id, destination):
+        destination.write(b"img")
 
 
 class DummyChat:
@@ -496,6 +499,134 @@ async def test_events_list(tmp_path: Path, monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_events_russian_date_current_year(tmp_path: Path, monkeypatch):
+    db = Database(str(tmp_path / "db.sqlite"))
+    await db.init()
+    bot = DummyBot("123:abc")
+
+    async def fake_create(title, text, source, html_text=None, media=None):
+        return "u", "p"
+
+    monkeypatch.setattr("main.create_source_page", fake_create)
+
+    start_msg = types.Message.model_validate(
+        {
+            "message_id": 1,
+            "date": 0,
+            "chat": {"id": 1, "type": "private"},
+            "from": {"id": 1, "is_bot": False, "first_name": "A"},
+            "text": "/start",
+        }
+    )
+    await handle_start(start_msg, db, bot)
+
+    add_msg = types.Message.model_validate(
+        {
+            "message_id": 2,
+            "date": 0,
+            "chat": {"id": 1, "type": "private"},
+            "from": {"id": 1, "is_bot": False, "first_name": "A"},
+            "text": "/addevent_raw Party|2025-08-02|18:00|Club",
+        }
+    )
+    await handle_add_event_raw(add_msg, db, bot)
+
+    class FakeDate(date):
+        @classmethod
+        def today(cls):
+            return date(2025, 7, 15)
+
+    class FakeDatetime(datetime):
+        @classmethod
+        def now(cls, tz=None):
+            return datetime(2025, 7, 15, 12, 0, tzinfo=tz)
+
+    monkeypatch.setattr(main, "date", FakeDate)
+    monkeypatch.setattr(main, "datetime", FakeDatetime)
+
+    bot.messages.clear()
+    list_msg = types.Message.model_validate(
+        {
+            "message_id": 3,
+            "date": 0,
+            "chat": {"id": 1, "type": "private"},
+            "from": {"id": 1, "is_bot": False, "first_name": "A"},
+            "text": "/events 2 августа",
+        }
+    )
+
+    await handle_events(list_msg, db, bot)
+
+    assert bot.messages
+    text = bot.messages[-1][1]
+    assert "02.08.2025" in text
+
+
+@pytest.mark.asyncio
+async def test_events_russian_date_next_year(tmp_path: Path, monkeypatch):
+    db = Database(str(tmp_path / "db.sqlite"))
+    await db.init()
+    bot = DummyBot("123:abc")
+
+    async def fake_create(title, text, source, html_text=None, media=None):
+        return "u", "p"
+
+    monkeypatch.setattr("main.create_source_page", fake_create)
+
+    start_msg = types.Message.model_validate(
+        {
+            "message_id": 1,
+            "date": 0,
+            "chat": {"id": 1, "type": "private"},
+            "from": {"id": 1, "is_bot": False, "first_name": "A"},
+            "text": "/start",
+        }
+    )
+    await handle_start(start_msg, db, bot)
+
+    add_msg = types.Message.model_validate(
+        {
+            "message_id": 2,
+            "date": 0,
+            "chat": {"id": 1, "type": "private"},
+            "from": {"id": 1, "is_bot": False, "first_name": "A"},
+            "text": "/addevent_raw Party|2026-09-05|18:00|Club",
+        }
+    )
+    await handle_add_event_raw(add_msg, db, bot)
+
+    class FakeDate(date):
+        @classmethod
+        def today(cls):
+            return date(2025, 10, 10)
+
+    class FakeDatetime(datetime):
+        @classmethod
+        def now(cls, tz=None):
+            return datetime(2025, 10, 10, 12, 0, tzinfo=tz)
+
+    monkeypatch.setattr(main, "date", FakeDate)
+    monkeypatch.setattr(main, "datetime", FakeDatetime)
+
+    bot.messages.clear()
+    list_msg = types.Message.model_validate(
+        {
+            "message_id": 3,
+            "date": 0,
+            "chat": {"id": 1, "type": "private"},
+            "from": {"id": 1, "is_bot": False, "first_name": "A"},
+            "text": "/events 5 сентября",
+        }
+    )
+
+    await handle_events(list_msg, db, bot)
+
+    assert bot.messages
+    text = bot.messages[-1][1]
+    assert "05.09.2026" in text
+
+
+@pytest.mark.asyncio
 async def test_ask4o_admin(tmp_path: Path, monkeypatch):
     db = Database(str(tmp_path / "db.sqlite"))
     await db.init()
@@ -641,7 +772,77 @@ async def test_create_source_page_photo(monkeypatch):
     res = await main.create_source_page(
         "Title", "text", None, media=(b"img", "photo.jpg")
     )
-    assert res == ("https://telegra.ph/test", "test")
+    assert res == ("https://telegra.ph/test", "test", "disabled", 0)
+
+
+@pytest.mark.asyncio
+async def test_create_source_page_photo_catbox(monkeypatch):
+    class DummyTG:
+        def __init__(self, access_token=None):
+            self.access_token = access_token
+
+        def create_page(self, title, html_content=None, **_):
+            assert "<img" in html_content
+            return {"url": "https://telegra.ph/test", "path": "test"}
+
+    class DummyResp:
+        status = 200
+
+        async def text(self):
+            return "https://files.catbox.moe/img.jpg"
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb):
+            return False
+
+    class DummySession:
+        def __init__(self, *_, **__):
+            self.post_called = False
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb):
+            return False
+
+        def post(self, url, data=None):
+            self.post_called = True
+            return DummyResp()
+
+    monkeypatch.setenv("TELEGRAPH_TOKEN", "t")
+    monkeypatch.setattr(
+        "main.Telegraph", lambda access_token=None: DummyTG(access_token)
+    )
+    monkeypatch.setattr(main, "ClientSession", DummySession)
+    monkeypatch.setattr(main, "CATBOX_ENABLED", True)
+    monkeypatch.setattr(main, "imghdr", type("X", (), {"what": lambda *a, **k: "jpeg"}))
+
+    res = await main.create_source_page(
+        "Title", "text", None, media=(b"img", "photo.jpg")
+    )
+    assert res == ("https://telegra.ph/test", "test", "ok", 1)
+
+
+@pytest.mark.asyncio
+async def test_create_source_page_normalizes_hashtags(monkeypatch):
+    class DummyTG:
+        def __init__(self, access_token=None):
+            self.access_token = access_token
+
+        def create_page(self, title, html_content=None, **_):
+            assert "#1_августа" not in html_content
+            assert "1 августа" in html_content
+            return {"url": "https://telegra.ph/test", "path": "test"}
+
+    monkeypatch.setenv("TELEGRAPH_TOKEN", "t")
+    monkeypatch.setattr(
+        "main.Telegraph", lambda access_token=None: DummyTG(access_token)
+    )
+
+    res = await main.create_source_page("Title", "#1_августа text", None)
+    assert res == ("https://telegra.ph/test", "test", "", 0)
 
 
 def test_get_telegraph_token_creates(tmp_path, monkeypatch):
@@ -662,6 +863,98 @@ def test_get_telegraph_token_env(monkeypatch):
     monkeypatch.setenv("TELEGRAPH_TOKEN", "zzz")
     token = get_telegraph_token()
     assert token == "zzz"
+
+
+@pytest.mark.asyncio
+async def test_addevent_caption_photo(tmp_path: Path, monkeypatch):
+    db = Database(str(tmp_path / "db.sqlite"))
+    await db.init()
+    bot = DummyBot("123:abc")
+
+    async def fake_parse(text: str) -> list[dict]:
+        return [
+            {
+                "title": "T",
+                "short_description": "d",
+                "date": FUTURE_DATE,
+                "time": "18:00",
+                "location_name": "Hall",
+            }
+        ]
+
+    captured = {}
+
+    async def fake_create(title, text, source, html_text=None, media=None):
+        captured["media"] = media
+        return "u", "p"
+
+    monkeypatch.setattr("main.parse_event_via_4o", fake_parse)
+    monkeypatch.setattr("main.create_source_page", fake_create)
+
+    msg = types.Message.model_validate(
+        {
+            "message_id": 1,
+            "date": 0,
+            "chat": {"id": 1, "type": "private"},
+            "from": {"id": 1, "is_bot": False, "first_name": "A"},
+            "caption": "/addevent text",
+            "photo": [
+                {
+                    "file_id": "f1",
+                    "file_unique_id": "u1",
+                    "width": 100,
+                    "height": 100,
+                }
+            ],
+        }
+    )
+
+    await handle_add_event(msg, db, bot)
+
+    assert captured["media"] == [(b"img", "photo.jpg")]
+
+
+@pytest.mark.asyncio
+async def test_addevent_strips_command(tmp_path: Path, monkeypatch):
+    db = Database(str(tmp_path / "db.sqlite"))
+    await db.init()
+    bot = DummyBot("123:abc")
+
+    async def fake_parse(text: str) -> list[dict]:
+        return [
+            {
+                "title": "T",
+                "short_description": "d",
+                "date": FUTURE_DATE,
+                "time": "18:00",
+                "location_name": "Hall",
+            }
+        ]
+
+    captured = {}
+
+    async def fake_create(title, text, source, html_text=None, media=None):
+        captured["text"] = text
+        captured["html"] = html_text
+        return "u", "p"
+
+    monkeypatch.setattr("main.parse_event_via_4o", fake_parse)
+    monkeypatch.setattr("main.create_source_page", fake_create)
+
+    msg = types.Message.model_validate(
+        {
+            "message_id": 1,
+            "date": 0,
+            "chat": {"id": 1, "type": "private"},
+            "from": {"id": 1, "is_bot": False, "first_name": "A"},
+            "text": "/addevent\nSome info",
+        }
+    )
+
+    await handle_add_event(msg, db, bot)
+
+    assert captured["text"] == "Some info"
+    assert captured["html"] == "Some info"
 
 
 @pytest.mark.asyncio
@@ -725,6 +1018,77 @@ async def test_forward_add_event(tmp_path: Path, monkeypatch):
         ev = (await session.execute(select(Event))).scalars().first()
 
     assert ev.source_post_url == "https://t.me/chan/10"
+
+
+@pytest.mark.asyncio
+async def test_forward_add_event_photo(tmp_path: Path, monkeypatch):
+    db = Database(str(tmp_path / "db.sqlite"))
+    await db.init()
+    bot = DummyBot("123:abc")
+
+    async def fake_parse(text: str) -> list[dict]:
+        return [
+            {
+                "title": "Forwarded",
+                "short_description": "desc",
+                "date": FUTURE_DATE,
+                "time": "18:00",
+                "location_name": "Club",
+            }
+        ]
+
+    captured = {}
+
+    async def fake_add(db2, text, source_link, html_text=None, media=None):
+        captured["media"] = media
+        return []
+
+    monkeypatch.setattr("main.parse_event_via_4o", fake_parse)
+    monkeypatch.setattr("main.add_events_from_text", fake_add)
+
+    start_msg = types.Message.model_validate(
+        {
+            "message_id": 1,
+            "date": 0,
+            "chat": {"id": 1, "type": "private"},
+            "from": {"id": 1, "is_bot": False, "first_name": "A"},
+            "text": "/start",
+        }
+    )
+    await handle_start(start_msg, db, bot)
+
+    upd = DummyUpdate(-100123, "Chan")
+    await main.handle_my_chat_member(upd, db)
+
+    async with db.get_session() as session:
+        ch = await session.get(main.Channel, -100123)
+        ch.is_registered = True
+        await session.commit()
+
+    fwd_msg = types.Message.model_validate(
+        {
+            "message_id": 3,
+            "date": 0,
+            "forward_date": 0,
+            "forward_from_chat": {"id": -100123, "type": "channel", "username": "chan"},
+            "forward_from_message_id": 10,
+            "chat": {"id": 1, "type": "private"},
+            "from": {"id": 1, "is_bot": False, "first_name": "A"},
+            "text": "Some text",
+            "photo": [
+                {
+                    "file_id": "f2",
+                    "file_unique_id": "u2",
+                    "width": 50,
+                    "height": 50,
+                }
+            ],
+        }
+    )
+
+    await main.handle_forwarded(fwd_msg, db, bot)
+
+    assert captured["media"] == [(b"img", "photo.jpg")]
 
 
 @pytest.mark.asyncio
@@ -1626,6 +1990,21 @@ def test_registration_link_formatting():
     assert "Бесплатно [по регистрации](https://reg)" in md
 
 
+def test_format_event_no_city_dup():
+    e = Event(
+        title="T",
+        description="d",
+        source_text="s",
+        date="2025-07-10",
+        time="18:00",
+        location_name="Hall",
+        location_address="Addr, Калининград",
+        city="Калининград",
+    )
+    md = main.format_event_md(e)
+    assert md.count("Калининград") == 1
+
+
 @pytest.mark.asyncio
 async def test_date_range_parsing(tmp_path: Path, monkeypatch):
     db = Database(str(tmp_path / "db.sqlite"))
@@ -1732,6 +2111,22 @@ async def test_update_source_page_uses_content(monkeypatch):
     assert "<p>old</p>" in html
     assert "new" in html
     assert main.CONTENT_SEPARATOR in html
+
+
+@pytest.mark.asyncio
+async def test_update_source_page_normalizes_hashtags(monkeypatch):
+    class DummyTG:
+        def get_page(self, path, return_html=True):
+            return {"content": ""}
+
+        def edit_page(self, path, title, html_content):
+            assert "#1_августа" not in html_content
+            assert "1 августа" in html_content
+
+    monkeypatch.setattr("main.get_telegraph_token", lambda: "t")
+    monkeypatch.setattr("main.Telegraph", lambda access_token=None: DummyTG())
+
+    await main.update_source_page("p", "T", "#1_августа event")
 
 
 @pytest.mark.asyncio
@@ -2035,6 +2430,85 @@ async def test_ticket_link_overrides_invalid(tmp_path: Path, monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_multiple_ticket_links(tmp_path: Path, monkeypatch):
+    db = Database(str(tmp_path / "db.sqlite"))
+    await db.init()
+    bot = DummyBot("123:abc")
+
+    async def fake_parse(text: str) -> list[dict]:
+        return [
+            {
+                "title": "A",
+                "short_description": "d1",
+                "date": FUTURE_DATE,
+                "time": "18:00",
+                "location_name": "Hall",
+                "ticket_link": None,
+                "event_type": "концерт",
+                "emoji": None,
+                "is_free": True,
+            },
+            {
+                "title": "B",
+                "short_description": "d2",
+                "date": FUTURE_DATE,
+                "time": "19:00",
+                "location_name": "Hall",
+                "ticket_link": None,
+                "event_type": "концерт",
+                "emoji": None,
+                "is_free": True,
+            },
+        ]
+
+    async def fake_create(title, text, source, html_text=None, media=None):
+        return "url", "p"
+
+    monkeypatch.setattr("main.parse_event_via_4o", fake_parse)
+    monkeypatch.setattr("main.create_source_page", fake_create)
+
+    html = (
+        "Билеты <a href='https://l1'>купить</a>" 
+        " и ещё один концерт. Билеты <a href='https://l2'>здесь</a>"
+    )
+
+    results = await main.add_events_from_text(db, "text", None, html, None)
+    assert results[0][0].ticket_link == "https://l1"
+    assert results[1][0].ticket_link == "https://l2"
+
+
+@pytest.mark.asyncio
+async def test_add_event_strips_city_from_address(tmp_path: Path, monkeypatch):
+    db = Database(str(tmp_path / "db.sqlite"))
+    await db.init()
+
+    async def fake_parse(text: str) -> list[dict]:
+        return [
+            {
+                "title": "Show",
+                "short_description": "d",
+                "date": FUTURE_DATE,
+                "time": "18:00",
+                "location_name": "Hall",
+                "location_address": "Addr, Калининград",
+                "city": "Калининград",
+            }
+        ]
+
+    async def fake_create(*args, **kwargs):
+        return "u", "p"
+
+    monkeypatch.setattr("main.parse_event_via_4o", fake_parse)
+    monkeypatch.setattr("main.create_source_page", fake_create)
+
+    results = await main.add_events_from_text(db, "t", None, None, None)
+    ev = results[0][0]
+    assert ev.location_address == "Addr"
+    md = main.format_event_md(ev)
+    assert md.count("Калининград") == 1
+
+
+@pytest.mark.asyncio
 async def test_festival_expands_dates(tmp_path: Path, monkeypatch):
     db = Database(str(tmp_path / "db.sqlite"))
     await db.init()
@@ -2136,6 +2610,46 @@ async def test_past_exhibition_not_listed_in_events(tmp_path: Path):
 
 
 @pytest.mark.asyncio
+async def test_exhibition_auto_year_end(tmp_path: Path, monkeypatch):
+    db = Database(str(tmp_path / "db.sqlite"))
+    await db.init()
+
+    async def fake_parse(text: str) -> list[dict]:
+        return [
+            {
+                "title": "AutoExpo",
+                "short_description": "d",
+                "location_name": "Hall",
+                "event_type": "выставка",
+            }
+        ]
+
+    async def fake_create(*args, **kwargs):
+        return "u", "p"
+
+    monkeypatch.setattr("main.parse_event_via_4o", fake_parse)
+    monkeypatch.setattr("main.create_source_page", fake_create)
+
+    results = await main.add_events_from_text(db, "text", None, None, None)
+    assert results
+    ev = results[0][0]
+    today = date.today()
+    assert ev.date == today.isoformat()
+    assert ev.end_date == date(today.year, 12, 31).isoformat()
+
+    _, content = await main.build_month_page_content(db, today.strftime("%Y-%m"))
+    found = False
+    exh_section = False
+    for n in content:
+        if n.get("tag") == "h3" and "Постоянные" in "".join(n.get("children", [])):
+            exh_section = True
+        elif exh_section and isinstance(n, dict) and n.get("tag") == "h4":
+            if any("AutoExpo" in str(c) for c in n.get("children", [])):
+                found = True
+    assert found
+
+
+@pytest.mark.asyncio
 async def test_month_links_future(tmp_path: Path, monkeypatch):
     db = Database(str(tmp_path / "db.sqlite"))
     await db.init()
@@ -2193,6 +2707,17 @@ async def test_build_daily_posts(tmp_path: Path):
                 silent=True,
             )
         )
+        session.add(
+            Event(
+                title="W",
+                description="weekend",
+                source_text="s3",
+                date=start.isoformat(),
+                time="12:00",
+                location_name="Hall",
+                added_at=datetime.utcnow(),
+            )
+        )
         session.add(MonthPage(month=today.strftime("%Y-%m"), url="m1", path="p1"))
         session.add(
             MonthPage(
@@ -2208,6 +2733,8 @@ async def test_build_daily_posts(tmp_path: Path):
     assert "АНОНС" in text
     assert markup.inline_keyboard[0]
     assert text.count("\U0001f449") == 2
+    first_btn = markup.inline_keyboard[0][0].text
+    assert first_btn.startswith("(+1)")
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- record number of Catbox images for each event
- show 📸 icons for month and weekend page links
- count newly added events for daily announcement buttons
- fix ticket link assignment and update daily counter format
- add standard locations for 4o prompt
- normalize date hashtags on source pages
- avoid city duplication in addresses
- strip `/addevent` command from saved Telegraph text
- allow `/events` to accept natural language dates
- auto-fill year-end for exhibitions with missing dates

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686cfa3c36888332a692ce6c2e968df0