### PR TITLE
Fix Supabase upload options for calendar ICS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,3 +37,9 @@
 - Added `is_free` field with inline toggle in the edit menu.
 - 4o parsing detects free events; if unclear a button appears to mark the event as free.
 - Telegraph pages keep original links and append new text when events are updated.
+
+## v0.3.4 - Calendar files
+- Events can upload an ICS file to Supabase during editing.
+- Added `ics_url` column and buttons to create or delete the file.
+- Use `SUPABASE_BUCKET` to configure the storage bucket (defaults to `events-ics`).
+- Calendar files include a link back to the event and are saved as `Event-<id>-dd-mm-yyyy.ics`.

--- a/README.md
+++ b/README.md
@@ -30,7 +30,11 @@ browse upcoming announcements. The command accepts dates like `2025-07-10`,
    export WEBHOOK_URL=https://your-app.fly.dev
    export DB_PATH=/data/db.sqlite
    export FOUR_O_TOKEN=sk-...
-   export FOUR_O_URL=https://api.openai.com/v1/chat/completions
+  export FOUR_O_URL=https://api.openai.com/v1/chat/completions
+  export SUPABASE_URL=https://<project>.supabase.co
+  export SUPABASE_KEY=service_role_key
+  # Optional: custom bucket name (defaults to events-ics)
+  export SUPABASE_BUCKET=events-ics
   # Optional: provide Telegraph token. If omitted, the bot creates an account
   # automatically and saves the token to /data/telegraph_token.txt.
   export TELEGRAPH_TOKEN=your_telegraph_token
@@ -72,6 +76,7 @@ browse upcoming announcements. The command accepts dates like `2025-07-10`,
 Each added event stores the original announcement text in a Telegraph page. The link is shown when the event is added and in the `/events` listing. Events may also contain ticket prices and a purchase link. Use the edit button in `/events` to change any field.
 Links from the announcement text are preserved on the Telegraph page whenever possible so readers can follow the original sources.
 If the original message contains photos (under 5&nbsp;MB), they are uploaded to Catbox and displayed on the Telegraph page.
+Editing an event lets you create or delete an ICS file for calendars. The file is uploaded to Supabase when `SUPABASE_URL` and `SUPABASE_KEY` are set. Files are named `Event-<id>-dd-mm-yyyy.ics` and include a link back to the event. Set `SUPABASE_BUCKET` if you use a bucket name other than `events-ics`.
 Events may note support for the Пушкинская карта, shown as a separate line in postings.
 Run `/exhibitions` to see all ongoing exhibitions (events with a start and end date).
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -22,6 +22,7 @@ Each event stores optional ticket information (`ticket_price_min`, `ticket_price
 Free events are marked with `is_free`. Telegraph pages are stored with both URL and path so they can be updated when the event description changes. If a message includes images (under 5&nbsp;MB each), they are uploaded to Catbox and embedded at the start of the source page.
 Events also keep `event_type` (one of six categories) and an `emoji` suggested by the LLM. Multi-day events store `end_date` and appear with "Открытие" or "Закрытие" on the respective days. `/exhibitions` lists active exhibitions.
 `pushkin_card` marks events that accept the Пушкинская карта.
+`ics_url` stores a link to a calendar file uploaded to Supabase. Moderators can generate or remove this file when editing an event. Calendar files are named `Event-<id>-dd-mm-yyyy.ics` and include a link back to the event page.
 If a text describes several events at once the LLM returns an array of event objects and the bot creates separate entries and Telegraph pages for each of them.
 Channels where the bot is admin are tracked in the `channel` table. Use `/setchannel` to choose an admin channel and mark it as an announcement source. The `/channels` command lists all admin channels and shows which ones are registered.
 `docs/LOCATIONS.md` contains standard venue names; its contents are appended to the 4o prompt so events use consistent `location_name` values.

--- a/docs/USER_STORIES.md
+++ b/docs/USER_STORIES.md
@@ -28,3 +28,4 @@
 |US-24|System|parse event type and emoji via 4o|categorise events|
 |US-25|System|store start and end dates for multi-day events|show opening and closing|
 |US-26|User|view exhibitions with `/exhibitions`|see ongoing exhibitions|
+|US-27|User/Admin|add event to calendar via ICS|quick calendar save|

--- a/main.py
+++ b/main.py
@@ -2,6 +2,8 @@ import logging
 import os
 from datetime import date, datetime, timedelta, timezone, time
 from typing import Optional, Tuple, Iterable
+from ics import Calendar, Event as IcsEvent
+from supabase import create_client, Client
 
 from aiogram import Bot, Dispatcher, types
 from aiogram.filters import Command
@@ -25,6 +27,9 @@ logging.basicConfig(level=logging.INFO)
 
 DB_PATH = os.getenv("DB_PATH", "/data/db.sqlite")
 TELEGRAPH_TOKEN_FILE = os.getenv("TELEGRAPH_TOKEN_FILE", "/data/telegraph_token.txt")
+SUPABASE_URL = os.getenv("SUPABASE_URL")
+SUPABASE_KEY = os.getenv("SUPABASE_KEY")
+SUPABASE_BUCKET = os.getenv("SUPABASE_BUCKET", "events-ics")
 
 # separator inserted between versions on Telegraph source pages
 CONTENT_SEPARATOR = "🟧" * 10
@@ -36,6 +41,7 @@ daily_time_sessions: dict[int, int] = {}
 
 # toggle for uploading images to catbox
 CATBOX_ENABLED: bool = False
+_supabase_client: Client | None = None
 
 
 class User(SQLModel, table=True):
@@ -93,6 +99,7 @@ class Event(SQLModel, table=True):
     telegraph_path: Optional[str] = None
     source_text: str
     telegraph_url: Optional[str] = None
+    ics_url: Optional[str] = None
     source_post_url: Optional[str] = None
     photo_count: int = 0
     added_at: datetime = Field(default_factory=datetime.utcnow)
@@ -175,6 +182,10 @@ class Database:
                 await conn.exec_driver_sql(
                     "ALTER TABLE event ADD COLUMN pushkin_card BOOLEAN DEFAULT 0"
                 )
+            if "ics_url" not in cols:
+                await conn.exec_driver_sql(
+                    "ALTER TABLE event ADD COLUMN ics_url VARCHAR"
+                )
 
             result = await conn.exec_driver_sql("PRAGMA table_info(channel)")
             cols = [r[1] for r in result.fetchall()]
@@ -226,6 +237,13 @@ async def set_catbox_enabled(db: Database, value: bool):
         await session.commit()
     global CATBOX_ENABLED
     CATBOX_ENABLED = value
+
+
+def get_supabase_client() -> Client | None:
+    global _supabase_client
+    if _supabase_client is None and SUPABASE_URL and SUPABASE_KEY:
+        _supabase_client = create_client(SUPABASE_URL, SUPABASE_KEY)
+    return _supabase_client
 
 
 def validate_offset(value: str) -> bool:
@@ -324,6 +342,76 @@ def parse_events_date(text: str, tz: timezone) -> date | None:
         return date(year, month, day)
     except ValueError:
         return None
+
+
+async def build_ics_content(db: Database, event: Event) -> str:
+    offset = await get_tz_offset(db)
+    tz = offset_to_timezone(offset)
+    start_dt = datetime.combine(
+        datetime.fromisoformat(event.date),
+        datetime.strptime(event.time, "%H:%M").time(),
+        tzinfo=tz,
+    )
+    end_dt = start_dt + timedelta(hours=1)
+    start = start_dt.astimezone(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+    end = end_dt.astimezone(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+    cal = Calendar()
+    ics_event = IcsEvent()
+    title = event.title
+    if event.location_name:
+        title = f"{title} в {event.location_name}"
+    ics_event.name = title
+    ics_event.begin = start
+    ics_event.end = end
+    desc = event.description
+    link = event.source_post_url or event.telegraph_url
+    if link:
+        desc = f"{desc}\n\n{link}"
+    ics_event.description = desc
+    loc_parts = []
+    if event.location_address:
+        loc_parts.append(event.location_address)
+    if event.city:
+        loc_parts.append(event.city)
+    ics_event.location = ", ".join(loc_parts)
+    ics_event.url = event.source_post_url or event.telegraph_url
+    cal.events.add(ics_event)
+    return cal.serialize()
+
+
+async def upload_ics(event: Event, db: Database) -> str | None:
+    client = get_supabase_client()
+    if not client:
+        logging.error("Supabase client not configured")
+        return None
+    content = await build_ics_content(db, event)
+    try:
+        d = datetime.fromisoformat(event.date)
+        path = f"Event-{event.id}-{d.day:02d}-{d.month:02d}-{d.year}.ics"
+    except Exception:
+        path = f"Event-{event.id}.ics"
+    try:
+        client.storage.from_(SUPABASE_BUCKET).upload(
+            path,
+            content.encode("utf-8"),
+            {"content-type": "text/calendar", "upsert": "true"},
+        )
+        url = client.storage.from_(SUPABASE_BUCKET).get_public_url(path)
+    except Exception as e:
+        logging.error("Failed to upload ics: %s", e)
+        return None
+    return url
+
+
+async def delete_ics(event: Event):
+    client = get_supabase_client()
+    if not client or not event.ics_url:
+        return
+    path = event.ics_url.split("/")[-1]
+    try:
+        client.storage.from_(SUPABASE_BUCKET).remove([path])
+    except Exception as e:
+        logging.error("Failed to delete ics: %s", e)
 
 
 async def parse_event_via_4o(text: str) -> list[dict]:
@@ -646,6 +734,29 @@ async def process_request(callback: types.CallbackQuery, db: Database, bot: Bot)
         except Exception as e:
             logging.error("failed to update silent button: %s", e)
         await callback.answer("Toggled")
+    elif data.startswith("createics:"):
+        eid = int(data.split(":")[1])
+        async with db.get_session() as session:
+            event = await session.get(Event, eid)
+            if event:
+                url = await upload_ics(event, db)
+                if url:
+                    event.ics_url = url
+                    await session.commit()
+        if event:
+            await show_edit_menu(callback.from_user.id, event, bot)
+        await callback.answer("Created")
+    elif data.startswith("delics:"):
+        eid = int(data.split(":")[1])
+        async with db.get_session() as session:
+            event = await session.get(Event, eid)
+            if event and event.ics_url:
+                await delete_ics(event)
+                event.ics_url = None
+                await session.commit()
+        if event:
+            await show_edit_menu(callback.from_user.id, event, bot)
+        await callback.answer("Deleted")
     elif data.startswith("markfree:"):
         eid = int(data.split(":")[1])
         async with db.get_session() as session:
@@ -2634,6 +2745,7 @@ async def show_edit_menu(user_id: int, event: Event, bot: Bot):
         f"ticket_link: {event.ticket_link or ''}",
         f"is_free: {event.is_free}",
         f"pushkin_card: {event.pushkin_card}",
+        f"ics_url: {event.ics_url or ''}",
     ]
     fields = [
         "title",
@@ -2686,6 +2798,24 @@ async def show_edit_menu(user_id: int, event: Event, bot: Bot):
             )
         ]
     )
+    if event.ics_url:
+        keyboard.append(
+            [
+                types.InlineKeyboardButton(
+                    text="Delete ICS",
+                    callback_data=f"delics:{event.id}",
+                )
+            ]
+        )
+    else:
+        keyboard.append(
+            [
+                types.InlineKeyboardButton(
+                    text="Create ICS",
+                    callback_data=f"createics:{event.id}",
+                )
+            ]
+        )
     keyboard.append(
         [types.InlineKeyboardButton(text="Done", callback_data=f"editdone:{event.id}")]
     )
@@ -3203,7 +3333,9 @@ def create_app() -> web.Application:
         or c.data.startswith("dailysend:")
         or c.data.startswith("togglefree:")
         or c.data.startswith("markfree:")
-        or c.data.startswith("togglesilent:"),
+        or c.data.startswith("togglesilent:")
+        or c.data.startswith("createics:")
+        or c.data.startswith("delics:"),
     )
     dp.message.register(tz_wrapper, Command("tz"))
     dp.message.register(add_event_wrapper, Command("addevent"))

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,5 @@ pytest==8.1.1
 pytest-asyncio==0.23.6
 telegraph==2.2.0
 markdown>=3.5
+ics==0.7.2
+supabase==2.16.0


### PR DESCRIPTION
## Summary
- send string for `upsert` header when uploading calendar files to Supabase
- calendar ICS files include event link and location details and are named `Event-<id>-dd-mm-yyyy.ics`

## Testing
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686ec692312c8332947abe630ed40e1b