### PR TITLE
Fix Supabase upload options for calendar ICS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,3 +37,10 @@
 - Added `is_free` field with inline toggle in the edit menu.
 - 4o parsing detects free events; if unclear a button appears to mark the event as free.
 - Telegraph pages keep original links and append new text when events are updated.
+
+## v0.3.4 - Calendar files
+- Events can upload an ICS file to Supabase during editing.
+- Added `ics_url` column and buttons to create or delete the file.
+- Use `SUPABASE_BUCKET` to configure the storage bucket (defaults to `events-ics`).
+- Calendar files include a link back to the event and are saved as `Event-<id>-dd-mm-yyyy.ics`.
+- Telegraph pages show a calendar link under the main image when an ICS file exists.

--- a/README.md
+++ b/README.md
@@ -30,7 +30,11 @@ browse upcoming announcements. The command accepts dates like `2025-07-10`,
    export WEBHOOK_URL=https://your-app.fly.dev
    export DB_PATH=/data/db.sqlite
    export FOUR_O_TOKEN=sk-...
-   export FOUR_O_URL=https://api.openai.com/v1/chat/completions
+  export FOUR_O_URL=https://api.openai.com/v1/chat/completions
+  export SUPABASE_URL=https://<project>.supabase.co
+  export SUPABASE_KEY=service_role_key
+  # Optional: custom bucket name (defaults to events-ics)
+  export SUPABASE_BUCKET=events-ics
   # Optional: provide Telegraph token. If omitted, the bot creates an account
   # automatically and saves the token to /data/telegraph_token.txt.
   export TELEGRAPH_TOKEN=your_telegraph_token
@@ -49,8 +53,11 @@ browse upcoming announcements. The command accepts dates like `2025-07-10`,
    fly secrets set TELEGRAM_BOT_TOKEN=xxx
    fly secrets set WEBHOOK_URL=https://<app>.fly.dev
    fly secrets set FOUR_O_TOKEN=xxxxx
-   fly secrets set FOUR_O_URL=https://api.openai.com/v1/chat/completions
-   fly secrets set DB_PATH=/data/db.sqlite
+    fly secrets set FOUR_O_URL=https://api.openai.com/v1/chat/completions
+    fly secrets set DB_PATH=/data/db.sqlite
+    # Optional: enable calendar files
+    fly secrets set SUPABASE_URL=https://<project>.supabase.co
+    fly secrets set SUPABASE_KEY=service_role_key
    # Optional: use your own Telegraph token. If not set, a new account will be
    # created on first run and the token saved to the data volume.
    fly secrets set TELEGRAPH_TOKEN=<token>
@@ -72,6 +79,8 @@ browse upcoming announcements. The command accepts dates like `2025-07-10`,
 Each added event stores the original announcement text in a Telegraph page. The link is shown when the event is added and in the `/events` listing. Events may also contain ticket prices and a purchase link. Use the edit button in `/events` to change any field.
 Links from the announcement text are preserved on the Telegraph page whenever possible so readers can follow the original sources.
 If the original message contains photos (under 5&nbsp;MB), they are uploaded to Catbox and displayed on the Telegraph page.
+Editing an event lets you create or delete an ICS file for calendars. The file is uploaded to Supabase when `SUPABASE_URL` and `SUPABASE_KEY` are set. Files are named `Event-<id>-dd-mm-yyyy.ics` and include a link back to the event. Set `SUPABASE_BUCKET` if you use a bucket name other than `events-ics`.
+When a calendar file exists the Telegraph page shows a link right under the title image: "📅 Добавить в календарь на телефоне (ICS)".
 Events may note support for the Пушкинская карта, shown as a separate line in postings.
 Run `/exhibitions` to see all ongoing exhibitions (events with a start and end date).
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -22,6 +22,8 @@ Each event stores optional ticket information (`ticket_price_min`, `ticket_price
 Free events are marked with `is_free`. Telegraph pages are stored with both URL and path so they can be updated when the event description changes. If a message includes images (under 5&nbsp;MB each), they are uploaded to Catbox and embedded at the start of the source page.
 Events also keep `event_type` (one of six categories) and an `emoji` suggested by the LLM. Multi-day events store `end_date` and appear with "Открытие" or "Закрытие" on the respective days. `/exhibitions` lists active exhibitions.
 `pushkin_card` marks events that accept the Пушкинская карта.
+`ics_url` stores a link to a calendar file uploaded to Supabase. Moderators can generate or remove this file when editing an event. Calendar files are named `Event-<id>-dd-mm-yyyy.ics` and include a link back to the event page.
+When present the link is inserted into the Telegraph source page below the title image so readers can quickly add the event to their phone calendar.
 If a text describes several events at once the LLM returns an array of event objects and the bot creates separate entries and Telegraph pages for each of them.
 Channels where the bot is admin are tracked in the `channel` table. Use `/setchannel` to choose an admin channel and mark it as an announcement source. The `/channels` command lists all admin channels and shows which ones are registered.
 `docs/LOCATIONS.md` contains standard venue names; its contents are appended to the 4o prompt so events use consistent `location_name` values.

--- a/docs/USER_STORIES.md
+++ b/docs/USER_STORIES.md
@@ -28,3 +28,5 @@
 |US-24|System|parse event type and emoji via 4o|categorise events|
 |US-25|System|store start and end dates for multi-day events|show opening and closing|
 |US-26|User|view exhibitions with `/exhibitions`|see ongoing exhibitions|
+|US-27|User/Admin|add event to calendar via ICS|quick calendar save|
+|US-28|User|follow the calendar link on a Telegraph page|ICS download on phone|

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,5 @@ pytest==8.1.1
 pytest-asyncio==0.23.6
 telegraph==2.2.0
 markdown>=3.5
+ics==0.7.2
+supabase==2.16.0

--- a/tests/test_bot.py
+++ b/tests/test_bot.py
@@ -180,7 +180,7 @@ async def test_add_event_raw(tmp_path: Path, monkeypatch):
     await db.init()
     bot = DummyBot("123:abc")
 
-    async def fake_create(title, text, source, html_text=None, media=None):
+    async def fake_create(title, text, source, html_text=None, media=None, ics_url=None):
         return "https://t.me/test", "path"
 
     monkeypatch.setattr("main.create_source_page", fake_create)
@@ -211,7 +211,7 @@ async def test_month_page_sync(tmp_path: Path, monkeypatch):
     await db.init()
     bot = DummyBot("123:abc")
 
-    async def fake_create(title, text, source, html_text=None, media=None):
+    async def fake_create(title, text, source, html_text=None, media=None, ics_url=None):
         return "https://t.me/test", "path"
 
     called = {}
@@ -243,7 +243,7 @@ async def test_weekend_page_sync(tmp_path: Path, monkeypatch):
     await db.init()
     bot = DummyBot("123:abc")
 
-    async def fake_create(title, text, source, html_text=None, media=None):
+    async def fake_create(title, text, source, html_text=None, media=None, ics_url=None):
         return "url", "p"
 
     called = {}
@@ -279,7 +279,7 @@ async def test_add_event_raw_update(tmp_path: Path, monkeypatch):
     await db.init()
     bot = DummyBot("123:abc")
 
-    async def fake_create(title, text, source, html_text=None, media=None):
+    async def fake_create(title, text, source, html_text=None, media=None, ics_url=None):
         return "https://t.me/test", "path"
 
     monkeypatch.setattr("main.create_source_page", fake_create)
@@ -319,7 +319,7 @@ async def test_edit_event(tmp_path: Path, monkeypatch):
     await db.init()
     bot = DummyBot("123:abc")
 
-    async def fake_create(title, text, source, html_text=None, media=None):
+    async def fake_create(title, text, source, html_text=None, media=None, ics_url=None):
         return "https://t.me/test", "path"
 
     monkeypatch.setattr("main.create_source_page", fake_create)
@@ -361,7 +361,7 @@ async def test_edit_remove_ticket_link(tmp_path: Path, monkeypatch):
     await db.init()
     bot = DummyBot("123:abc")
 
-    async def fake_create(title, text, source, html_text=None, media=None):
+    async def fake_create(title, text, source, html_text=None, media=None, ics_url=None):
         return "https://t.me/test", "path"
 
     monkeypatch.setattr("main.create_source_page", fake_create)
@@ -405,7 +405,7 @@ async def test_edit_event_forwarded(tmp_path: Path, monkeypatch):
     await db.init()
     bot = DummyBot("123:abc")
 
-    async def fake_create(title, text, source, html_text=None, media=None):
+    async def fake_create(title, text, source, html_text=None, media=None, ics_url=None):
         return "https://t.me/test", "path"
 
     monkeypatch.setattr("main.create_source_page", fake_create)
@@ -449,7 +449,7 @@ async def test_edit_boolean_fields(tmp_path: Path, monkeypatch):
     await db.init()
     bot = DummyBot("123:abc")
 
-    async def fake_create(title, text, source, html_text=None, media=None):
+    async def fake_create(title, text, source, html_text=None, media=None, ics_url=None):
         return "https://t.me/test", "path"
 
     monkeypatch.setattr("main.create_source_page", fake_create)
@@ -505,7 +505,7 @@ async def test_events_list(tmp_path: Path, monkeypatch):
     await db.init()
     bot = DummyBot("123:abc")
 
-    async def fake_create(title, text, source, html_text=None, media=None):
+    async def fake_create(title, text, source, html_text=None, media=None, ics_url=None):
         return "https://t.me/test", "path"
 
     monkeypatch.setattr("main.create_source_page", fake_create)
@@ -560,7 +560,7 @@ async def test_events_russian_date_current_year(tmp_path: Path, monkeypatch):
     await db.init()
     bot = DummyBot("123:abc")
 
-    async def fake_create(title, text, source, html_text=None, media=None):
+    async def fake_create(title, text, source, html_text=None, media=None, ics_url=None):
         return "u", "p"
 
     monkeypatch.setattr("main.create_source_page", fake_create)
@@ -624,7 +624,7 @@ async def test_events_russian_date_next_year(tmp_path: Path, monkeypatch):
     await db.init()
     bot = DummyBot("123:abc")
 
-    async def fake_create(title, text, source, html_text=None, media=None):
+    async def fake_create(title, text, source, html_text=None, media=None, ics_url=None):
         return "u", "p"
 
     monkeypatch.setattr("main.create_source_page", fake_create)
@@ -940,7 +940,7 @@ async def test_addevent_caption_photo(tmp_path: Path, monkeypatch):
 
     captured = {}
 
-    async def fake_create(title, text, source, html_text=None, media=None):
+    async def fake_create(title, text, source, html_text=None, media=None, ics_url=None):
         captured["media"] = media
         return "u", "p"
 
@@ -989,7 +989,7 @@ async def test_addevent_strips_command(tmp_path: Path, monkeypatch):
 
     captured = {}
 
-    async def fake_create(title, text, source, html_text=None, media=None):
+    async def fake_create(title, text, source, html_text=None, media=None, ics_url=None):
         captured["text"] = text
         captured["html"] = html_text
         return "u", "p"
@@ -1030,7 +1030,7 @@ async def test_forward_add_event(tmp_path: Path, monkeypatch):
             }
         ]
 
-    async def fake_create(title, text, source, html_text=None, media=None):
+    async def fake_create(title, text, source, html_text=None, media=None, ics_url=None):
         return "https://t.me/page", "p"
 
     monkeypatch.setattr("main.parse_event_via_4o", fake_parse)
@@ -1164,7 +1164,7 @@ async def test_forward_unregistered(tmp_path: Path, monkeypatch):
             }
         ]
 
-    async def fake_create(title, text, source, html_text=None, media=None):
+    async def fake_create(title, text, source, html_text=None, media=None, ics_url=None):
         return "https://t.me/page", "p"
 
     monkeypatch.setattr("main.parse_event_via_4o", fake_parse)
@@ -1222,7 +1222,7 @@ async def test_media_group_caption_first(tmp_path: Path, monkeypatch):
             }
         ]
 
-    async def fake_create(title, text, source, html_text=None, media=None):
+    async def fake_create(title, text, source, html_text=None, media=None, ics_url=None):
         return "https://t.me/page", "p"
 
     monkeypatch.setattr("main.parse_event_via_4o", fake_parse)
@@ -1300,7 +1300,7 @@ async def test_media_group_caption_last(tmp_path: Path, monkeypatch):
             }
         ]
 
-    async def fake_create(title, text, source, html_text=None, media=None):
+    async def fake_create(title, text, source, html_text=None, media=None, ics_url=None):
         return "https://t.me/page", "p"
 
     monkeypatch.setattr("main.parse_event_via_4o", fake_parse)
@@ -1367,7 +1367,7 @@ async def test_mark_free(tmp_path: Path, monkeypatch):
     await db.init()
     bot = DummyBot("123:abc")
 
-    async def fake_create(title, text, source, html_text=None, media=None):
+    async def fake_create(title, text, source, html_text=None, media=None, ics_url=None):
         return "https://t.me/test", "path"
 
     monkeypatch.setattr("main.create_source_page", fake_create)
@@ -1420,7 +1420,7 @@ async def test_toggle_silent(tmp_path: Path, monkeypatch):
     await db.init()
     bot = DummyBot("123:abc")
 
-    async def fake_create(title, text, source, html_text=None, media=None):
+    async def fake_create(title, text, source, html_text=None, media=None, ics_url=None):
         return "https://t.me/test", "path"
 
     monkeypatch.setattr("main.create_source_page", fake_create)
@@ -1507,7 +1507,7 @@ async def test_exhibition_listing(tmp_path: Path, monkeypatch):
 
     monkeypatch.setattr("main.parse_event_via_4o", fake_parse)
 
-    async def fake_create(title, text, source, html_text=None, media=None):
+    async def fake_create(title, text, source, html_text=None, media=None, ics_url=None):
         return "url", "p"
 
     monkeypatch.setattr("main.create_source_page", fake_create)
@@ -1595,7 +1595,7 @@ async def test_multiple_events(tmp_path: Path, monkeypatch):
             },
         ]
 
-    async def fake_create(title, text, source, html_text=None, media=None):
+    async def fake_create(title, text, source, html_text=None, media=None, ics_url=None):
         return f"url/{title}", title
 
     monkeypatch.setattr("main.parse_event_via_4o", fake_parse)
@@ -2105,7 +2105,7 @@ async def test_date_range_parsing(tmp_path: Path, monkeypatch):
             }
         ]
 
-    async def fake_create(title, text, source, html_text=None, media=None):
+    async def fake_create(title, text, source, html_text=None, media=None, ics_url=None):
         return "url", "p"
 
     monkeypatch.setattr("main.parse_event_via_4o", fake_parse)
@@ -2211,6 +2211,34 @@ async def test_update_source_page_normalizes_hashtags(monkeypatch):
     await main.update_source_page("p", "T", "#1_августа event")
 
 
+def test_apply_ics_link_insert_and_remove():
+    html = "<p><strong>T</strong></p><p></p><p>body</p>"
+    added = main.apply_ics_link(html, "http://x")
+    assert "Добавить в календарь" in added
+    removed = main.apply_ics_link(added, None)
+    assert "Добавить в календарь" not in removed
+
+
+@pytest.mark.asyncio
+async def test_update_source_page_ics(monkeypatch):
+    edited = {}
+
+    class DummyTG:
+        def get_page(self, path, return_html=True):
+            return {"content": "<p>T</p><p></p><p>body</p>"}
+
+        def edit_page(self, path, title, html_content):
+            edited["html"] = html_content
+
+    monkeypatch.setattr("main.get_telegraph_token", lambda: "t")
+    monkeypatch.setattr("main.Telegraph", lambda access_token=None: DummyTG())
+
+    await main.update_source_page_ics("p", "T", "http://x")
+    assert "Добавить в календарь" in edited.get("html", "")
+    await main.update_source_page_ics("p", "T", None)
+    assert "Добавить в календарь" not in edited.get("html", "")
+
+
 @pytest.mark.asyncio
 async def test_nav_limits_past(tmp_path: Path):
     db = Database(str(tmp_path / "db.sqlite"))
@@ -2269,7 +2297,7 @@ async def test_delete_event_updates_month(tmp_path: Path, monkeypatch):
     await db.init()
     bot = DummyBot("123:abc")
 
-    async def fake_create(title, text, source, html_text=None, media=None):
+    async def fake_create(title, text, source, html_text=None, media=None, ics_url=None):
         return "url", "p"
 
     called = {}
@@ -2331,7 +2359,7 @@ async def test_title_duplicate_update(tmp_path: Path, monkeypatch):
     await db.init()
     bot = DummyBot("123:abc")
 
-    async def fake_create(title, text, source, html_text=None, media=None):
+    async def fake_create(title, text, source, html_text=None, media=None, ics_url=None):
         return "url", "p"
 
     monkeypatch.setattr("main.create_source_page", fake_create)
@@ -2371,7 +2399,7 @@ async def test_llm_duplicate_check(tmp_path: Path, monkeypatch):
     await db.init()
     bot = DummyBot("123:abc")
 
-    async def fake_create(title, text, source, html_text=None, media=None):
+    async def fake_create(title, text, source, html_text=None, media=None, ics_url=None):
         return "url", "p"
 
     called = {"cnt": 0}
@@ -2433,7 +2461,7 @@ async def test_extract_ticket_link(tmp_path: Path, monkeypatch):
             }
         ]
 
-    async def fake_create(title, text, source, html_text=None, media=None):
+    async def fake_create(title, text, source, html_text=None, media=None, ics_url=None):
         return "url", "p"
 
     monkeypatch.setattr("main.parse_event_via_4o", fake_parse)
@@ -2466,7 +2494,7 @@ async def test_extract_ticket_link_near_word(tmp_path: Path, monkeypatch):
             }
         ]
 
-    async def fake_create(title, text, source, html_text=None, media=None):
+    async def fake_create(title, text, source, html_text=None, media=None, ics_url=None):
         return "url", "p"
 
     monkeypatch.setattr("main.parse_event_via_4o", fake_parse)
@@ -2499,7 +2527,7 @@ async def test_ticket_link_overrides_invalid(tmp_path: Path, monkeypatch):
             }
         ]
 
-    async def fake_create(title, text, source, html_text=None, media=None):
+    async def fake_create(title, text, source, html_text=None, media=None, ics_url=None):
         return "url", "p"
 
     monkeypatch.setattr("main.parse_event_via_4o", fake_parse)
@@ -2543,7 +2571,7 @@ async def test_multiple_ticket_links(tmp_path: Path, monkeypatch):
             },
         ]
 
-    async def fake_create(title, text, source, html_text=None, media=None):
+    async def fake_create(title, text, source, html_text=None, media=None, ics_url=None):
         return "url", "p"
 
     monkeypatch.setattr("main.parse_event_via_4o", fake_parse)


### PR DESCRIPTION
## Summary
- send string for `upsert` header when uploading calendar files to Supabase
- calendar ICS files include event link and location details and are named `Event-<id>-dd-mm-yyyy.ics`
- Telegraph pages now show a calendar icon link below the event image
- document ICS link on the Telegraph page and new user story
- mention Supabase secrets in the deployment instructions

## Testing
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686ec692312c8332947abe630ed40e1b