### PR TITLE
Fix Supabase upload options for calendar ICS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,3 +37,11 @@
 - Added `is_free` field with inline toggle in the edit menu.
 - 4o parsing detects free events; if unclear a button appears to mark the event as free.
 - Telegraph pages keep original links and append new text when events are updated.
+
+## v0.3.4 - Calendar files
+- Events can upload an ICS file to Supabase during editing.
+- Added `ics_url` column and buttons to create or delete the file.
+- Use `SUPABASE_BUCKET` to configure the storage bucket (defaults to `events-ics`).
+- Calendar files include a link back to the event and are saved as `Event-<id>-dd-mm-yyyy.ics`.
+- Telegraph pages show a calendar link under the main image when an ICS file exists.
+- Startup no longer fails when setting the webhook times out.

--- a/README.md
+++ b/README.md
@@ -30,7 +30,11 @@ browse upcoming announcements. The command accepts dates like `2025-07-10`,
    export WEBHOOK_URL=https://your-app.fly.dev
    export DB_PATH=/data/db.sqlite
    export FOUR_O_TOKEN=sk-...
-   export FOUR_O_URL=https://api.openai.com/v1/chat/completions
+  export FOUR_O_URL=https://api.openai.com/v1/chat/completions
+  export SUPABASE_URL=https://<project>.supabase.co
+  export SUPABASE_KEY=service_role_key
+  # Optional: custom bucket name (defaults to events-ics)
+  export SUPABASE_BUCKET=events-ics
   # Optional: provide Telegraph token. If omitted, the bot creates an account
   # automatically and saves the token to /data/telegraph_token.txt.
   export TELEGRAPH_TOKEN=your_telegraph_token
@@ -49,8 +53,11 @@ browse upcoming announcements. The command accepts dates like `2025-07-10`,
    fly secrets set TELEGRAM_BOT_TOKEN=xxx
    fly secrets set WEBHOOK_URL=https://<app>.fly.dev
    fly secrets set FOUR_O_TOKEN=xxxxx
-   fly secrets set FOUR_O_URL=https://api.openai.com/v1/chat/completions
-   fly secrets set DB_PATH=/data/db.sqlite
+    fly secrets set FOUR_O_URL=https://api.openai.com/v1/chat/completions
+    fly secrets set DB_PATH=/data/db.sqlite
+    # Optional: enable calendar files
+    fly secrets set SUPABASE_URL=https://<project>.supabase.co
+    fly secrets set SUPABASE_KEY=service_role_key
    # Optional: use your own Telegraph token. If not set, a new account will be
    # created on first run and the token saved to the data volume.
    fly secrets set TELEGRAPH_TOKEN=<token>
@@ -72,6 +79,8 @@ browse upcoming announcements. The command accepts dates like `2025-07-10`,
 Each added event stores the original announcement text in a Telegraph page. The link is shown when the event is added and in the `/events` listing. Events may also contain ticket prices and a purchase link. Use the edit button in `/events` to change any field.
 Links from the announcement text are preserved on the Telegraph page whenever possible so readers can follow the original sources.
 If the original message contains photos (under 5&nbsp;MB), they are uploaded to Catbox and displayed on the Telegraph page.
+Editing an event lets you create or delete an ICS file for calendars. The file is uploaded to Supabase when `SUPABASE_URL` and `SUPABASE_KEY` are set. Files are named `Event-<id>-dd-mm-yyyy.ics` and include a link back to the event. Set `SUPABASE_BUCKET` if you use a bucket name other than `events-ics`.
+When a calendar file exists the Telegraph page shows a link right under the title image: "📅 Добавить в календарь на телефоне (ICS)".
 Events may note support for the Пушкинская карта, shown as a separate line in postings.
 Run `/exhibitions` to see all ongoing exhibitions (events with a start and end date).
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -22,6 +22,8 @@ Each event stores optional ticket information (`ticket_price_min`, `ticket_price
 Free events are marked with `is_free`. Telegraph pages are stored with both URL and path so they can be updated when the event description changes. If a message includes images (under 5&nbsp;MB each), they are uploaded to Catbox and embedded at the start of the source page.
 Events also keep `event_type` (one of six categories) and an `emoji` suggested by the LLM. Multi-day events store `end_date` and appear with "Открытие" or "Закрытие" on the respective days. `/exhibitions` lists active exhibitions.
 `pushkin_card` marks events that accept the Пушкинская карта.
+`ics_url` stores a link to a calendar file uploaded to Supabase. Moderators can generate or remove this file when editing an event. Calendar files are named `Event-<id>-dd-mm-yyyy.ics` and include a link back to the event page.
+When present the link is inserted into the Telegraph source page below the title image so readers can quickly add the event to their phone calendar.
 If a text describes several events at once the LLM returns an array of event objects and the bot creates separate entries and Telegraph pages for each of them.
 Channels where the bot is admin are tracked in the `channel` table. Use `/setchannel` to choose an admin channel and mark it as an announcement source. The `/channels` command lists all admin channels and shows which ones are registered.
 `docs/LOCATIONS.md` contains standard venue names; its contents are appended to the 4o prompt so events use consistent `location_name` values.

--- a/docs/USER_STORIES.md
+++ b/docs/USER_STORIES.md
@@ -28,3 +28,5 @@
 |US-24|System|parse event type and emoji via 4o|categorise events|
 |US-25|System|store start and end dates for multi-day events|show opening and closing|
 |US-26|User|view exhibitions with `/exhibitions`|see ongoing exhibitions|
+|US-27|User/Admin|add event to calendar via ICS|quick calendar save|
+|US-28|User|follow the calendar link on a Telegraph page|ICS download on phone|

--- a/main.py
+++ b/main.py
@@ -2,6 +2,8 @@ import logging
 import os
 from datetime import date, datetime, timedelta, timezone, time
 from typing import Optional, Tuple, Iterable
+from ics import Calendar, Event as IcsEvent
+from supabase import create_client, Client
 
 from aiogram import Bot, Dispatcher, types
 from aiogram.filters import Command
@@ -25,6 +27,9 @@ logging.basicConfig(level=logging.INFO)
 
 DB_PATH = os.getenv("DB_PATH", "/data/db.sqlite")
 TELEGRAPH_TOKEN_FILE = os.getenv("TELEGRAPH_TOKEN_FILE", "/data/telegraph_token.txt")
+SUPABASE_URL = os.getenv("SUPABASE_URL")
+SUPABASE_KEY = os.getenv("SUPABASE_KEY")
+SUPABASE_BUCKET = os.getenv("SUPABASE_BUCKET", "events-ics")
 
 # separator inserted between versions on Telegraph source pages
 CONTENT_SEPARATOR = "🟧" * 10
@@ -36,6 +41,7 @@ daily_time_sessions: dict[int, int] = {}
 
 # toggle for uploading images to catbox
 CATBOX_ENABLED: bool = False
+_supabase_client: Client | None = None
 
 
 class User(SQLModel, table=True):
@@ -93,6 +99,7 @@ class Event(SQLModel, table=True):
     telegraph_path: Optional[str] = None
     source_text: str
     telegraph_url: Optional[str] = None
+    ics_url: Optional[str] = None
     source_post_url: Optional[str] = None
     photo_count: int = 0
     added_at: datetime = Field(default_factory=datetime.utcnow)
@@ -175,6 +182,10 @@ class Database:
                 await conn.exec_driver_sql(
                     "ALTER TABLE event ADD COLUMN pushkin_card BOOLEAN DEFAULT 0"
                 )
+            if "ics_url" not in cols:
+                await conn.exec_driver_sql(
+                    "ALTER TABLE event ADD COLUMN ics_url VARCHAR"
+                )
 
             result = await conn.exec_driver_sql("PRAGMA table_info(channel)")
             cols = [r[1] for r in result.fetchall()]
@@ -226,6 +237,13 @@ async def set_catbox_enabled(db: Database, value: bool):
         await session.commit()
     global CATBOX_ENABLED
     CATBOX_ENABLED = value
+
+
+def get_supabase_client() -> Client | None:
+    global _supabase_client
+    if _supabase_client is None and SUPABASE_URL and SUPABASE_KEY:
+        _supabase_client = create_client(SUPABASE_URL, SUPABASE_KEY)
+    return _supabase_client
 
 
 def validate_offset(value: str) -> bool:
@@ -285,6 +303,80 @@ def strip_city_from_address(address: str | None, city: str | None) -> str | None
     return addr
 
 
+ICS_LABEL = "Добавить в календарь на телефоне (ICS)"
+MONTH_NAV_START = "<!--month-nav-start-->"
+MONTH_NAV_END = "<!--month-nav-end-->"
+
+
+def parse_time_range(value: str) -> tuple[time, time | None] | None:
+    """Return start and optional end time from text like '10:00' or '10:00-12:00'."""
+    value = value.strip()
+    parts = [p.strip() for p in value.split("-", 1)]
+    try:
+        start = datetime.strptime(parts[0], "%H:%M").time()
+    except ValueError:
+        return None
+    end: time | None = None
+    if len(parts) == 2:
+        try:
+            end = datetime.strptime(parts[1], "%H:%M").time()
+        except ValueError:
+            end = None
+    return start, end
+
+
+def apply_ics_link(html_content: str, url: str | None) -> str:
+    """Insert or remove the ICS link block in Telegraph HTML."""
+    idx = html_content.find(ICS_LABEL)
+    if idx != -1:
+        start = html_content.rfind("<p", 0, idx)
+        end = html_content.find("</p>", idx)
+        if start != -1 and end != -1:
+            html_content = html_content[:start] + html_content[end + 4 :]
+    if not url:
+        return html_content
+    link_html = (
+        f'<p>\U0001f4c5 <a href="{html.escape(url)}">{ICS_LABEL}</a></p>'
+    )
+    idx = html_content.find("</p>")
+    if idx == -1:
+        return link_html + html_content
+    pos = idx + 4
+    img_pattern = re.compile(r"<img[^>]+><p></p>")
+    for m in img_pattern.finditer(html_content, pos):
+        pos = m.end()
+    return html_content[:pos] + link_html + html_content[pos:]
+
+
+def apply_month_nav(html_content: str, html_block: str | None) -> str:
+    """Insert or replace the month navigation block."""
+    start = html_content.find(MONTH_NAV_START)
+    if start != -1:
+        end = html_content.find(MONTH_NAV_END, start)
+        if end != -1:
+            html_content = html_content[:start] + html_content[end + len(MONTH_NAV_END) :]
+    if html_block:
+        html_content += f"{MONTH_NAV_START}{html_block}{MONTH_NAV_END}"
+    return html_content
+
+
+async def build_month_nav_html(db: Database) -> str:
+    async with db.get_session() as session:
+        result = await session.execute(select(MonthPage).order_by(MonthPage.month))
+        months = result.scalars().all()
+    today_month = date.today().strftime("%Y-%m")
+    future_months = [m for m in months if m.month >= today_month]
+    if not future_months:
+        return ""
+    links: list[str] = []
+    for idx, p in enumerate(future_months):
+        name = month_name_nominative(p.month)
+        links.append(f'<a href="{html.escape(p.url)}">{name}</a>')
+        if idx < len(future_months) - 1:
+            links.append(" ")
+    return "<br/><h4>" + "".join(links) + "</h4>"
+
+
 def parse_bool_text(value: str) -> bool | None:
     """Convert text to boolean if possible."""
     normalized = value.strip().lower()
@@ -324,6 +416,92 @@ def parse_events_date(text: str, tz: timezone) -> date | None:
         return date(year, month, day)
     except ValueError:
         return None
+
+
+async def build_ics_content(db: Database, event: Event) -> str:
+    offset = await get_tz_offset(db)
+    tz = offset_to_timezone(offset)
+    time_range = parse_time_range(event.time)
+    if not time_range:
+        raise ValueError("bad time")
+    start_t, end_t = time_range
+    start_dt = datetime.combine(
+        datetime.fromisoformat(event.date),
+        start_t,
+        tzinfo=tz,
+    )
+    if end_t:
+        end_dt = datetime.combine(datetime.fromisoformat(event.date), end_t, tzinfo=tz)
+    else:
+        end_dt = start_dt + timedelta(hours=1)
+    start = start_dt.astimezone(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+    end = end_dt.astimezone(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+    cal = Calendar()
+    ics_event = IcsEvent()
+    title = event.title
+    if event.location_name:
+        title = f"{title} в {event.location_name}"
+    ics_event.name = title
+    ics_event.begin = start
+    ics_event.end = end
+    desc = event.description
+    link = event.source_post_url or event.telegraph_url
+    if link:
+        desc = f"{desc}\n\n{link}"
+    ics_event.description = desc
+    loc_parts = []
+    if event.location_address:
+        loc_parts.append(event.location_address)
+    if event.city:
+        loc_parts.append(event.city)
+    ics_event.location = ", ".join(loc_parts)
+    ics_event.url = event.source_post_url or event.telegraph_url
+    cal.events.add(ics_event)
+    return cal.serialize()
+
+
+async def upload_ics(event: Event, db: Database) -> str | None:
+    client = get_supabase_client()
+    if not client:
+        logging.error("Supabase client not configured")
+        return None
+    if event.end_date:
+        logging.info("skip ics for multi-day event %s", event.id)
+        return None
+    if not parse_time_range(event.time):
+        logging.info("skip ics for unclear time %s", event.id)
+        return None
+    content = await build_ics_content(db, event)
+    try:
+        d = datetime.fromisoformat(event.date)
+        path = f"Event-{event.id}-{d.day:02d}-{d.month:02d}-{d.year}.ics"
+    except Exception:
+        path = f"Event-{event.id}.ics"
+    try:
+        logging.info("Uploading ICS to %s/%s", SUPABASE_BUCKET, path)
+        client.storage.from_(SUPABASE_BUCKET).upload(
+            path,
+            content.encode("utf-8"),
+            {"content-type": "text/calendar", "upsert": "true"},
+        )
+        url = client.storage.from_(SUPABASE_BUCKET).get_public_url(path)
+        logging.info("ICS uploaded: %s", url)
+    except Exception as e:
+        logging.error("Failed to upload ics: %s", e)
+        return None
+    return url
+
+
+async def delete_ics(event: Event):
+    client = get_supabase_client()
+    if not client or not event.ics_url:
+        return
+    path = event.ics_url.split("/")[-1]
+    try:
+        logging.info("Deleting ICS %s from %s", path, SUPABASE_BUCKET)
+        client.storage.from_(SUPABASE_BUCKET).remove([path])
+    except Exception as e:
+        logging.error("Failed to delete ics: %s", e)
 
 
 async def parse_event_via_4o(text: str) -> list[dict]:
@@ -646,6 +824,43 @@ async def process_request(callback: types.CallbackQuery, db: Database, bot: Bot)
         except Exception as e:
             logging.error("failed to update silent button: %s", e)
         await callback.answer("Toggled")
+    elif data.startswith("createics:"):
+        eid = int(data.split(":")[1])
+        async with db.get_session() as session:
+            event = await session.get(Event, eid)
+            if event:
+                url = await upload_ics(event, db)
+                if url:
+                    event.ics_url = url
+                    await session.commit()
+                    logging.info("ICS saved for event %s: %s", eid, url)
+                    if event.telegraph_path:
+                        await update_source_page_ics(
+                            event.telegraph_path, event.title or "Event", url
+                        )
+                else:
+                    logging.warning("ICS creation failed for event %s", eid)
+        if event:
+            await show_edit_menu(callback.from_user.id, event, bot)
+        await callback.answer("Created")
+    elif data.startswith("delics:"):
+        eid = int(data.split(":")[1])
+        async with db.get_session() as session:
+            event = await session.get(Event, eid)
+            if event and event.ics_url:
+                await delete_ics(event)
+                event.ics_url = None
+                await session.commit()
+                logging.info("ICS removed for event %s", eid)
+                if event.telegraph_path:
+                    await update_source_page_ics(
+                        event.telegraph_path, event.title or "Event", None
+                    )
+            elif event:
+                logging.debug("deleteics: no file for event %s", eid)
+        if event:
+            await show_edit_menu(callback.from_user.id, event, bot)
+        await callback.answer("Deleted")
     elif data.startswith("markfree:"):
         eid = int(data.split(":")[1])
         async with db.get_session() as session:
@@ -1290,6 +1505,7 @@ async def add_events_from_text(
                     saved.title or "Event",
                     html_text or text,
                     media_arg,
+                    db,
                 )
                 if added_count:
                     photo_count += added_count
@@ -1304,6 +1520,8 @@ async def add_events_from_text(
                     source_link,
                     html_text,
                     media_arg,
+                    saved.ics_url,
+                    db,
                 )
                 if res:
                     if len(res) == 4:
@@ -1437,6 +1655,8 @@ async def handle_add_event_raw(message: types.Message, db: Database, bot: Bot):
         None,
         html_text or event.source_text,
         media,
+        event.ics_url,
+        db,
     )
     upload_info = ""
     photo_count = 0
@@ -2634,6 +2854,7 @@ async def show_edit_menu(user_id: int, event: Event, bot: Bot):
         f"ticket_link: {event.ticket_link or ''}",
         f"is_free: {event.is_free}",
         f"pushkin_card: {event.pushkin_card}",
+        f"ics_url: {event.ics_url or ''}",
     ]
     fields = [
         "title",
@@ -2686,6 +2907,24 @@ async def show_edit_menu(user_id: int, event: Event, bot: Bot):
             )
         ]
     )
+    if event.ics_url:
+        keyboard.append(
+            [
+                types.InlineKeyboardButton(
+                    text="Delete ICS",
+                    callback_data=f"delics:{event.id}",
+                )
+            ]
+        )
+    else:
+        keyboard.append(
+            [
+                types.InlineKeyboardButton(
+                    text="Create ICS",
+                    callback_data=f"createics:{event.id}",
+                )
+            ]
+        )
     keyboard.append(
         [types.InlineKeyboardButton(text="Done", callback_data=f"editdone:{event.id}")]
     )
@@ -2843,18 +3082,23 @@ processed_media_groups: set[str] = set()
 
 
 async def handle_forwarded(message: types.Message, db: Database, bot: Bot):
+    logging.info("forwarded message from %s", message.from_user.id)
     text = message.text or message.caption
     if message.media_group_id:
         if message.media_group_id in processed_media_groups:
+            logging.debug("skip already processed album %s", message.media_group_id)
             return
         if not text:
             # wait for the part of the album that contains the caption
+            logging.debug("waiting for caption in album %s", message.media_group_id)
             return
         processed_media_groups.add(message.media_group_id)
     if not text:
+        logging.debug("forwarded message has no text")
         return
     async with db.get_session() as session:
         if not await session.get(User, message.from_user.id):
+            logging.debug("user %s not registered", message.from_user.id)
             return
     link = None
     if message.forward_from_chat and message.forward_from_message_id:
@@ -2863,6 +3107,7 @@ async def handle_forwarded(message: types.Message, db: Database, bot: Bot):
         async with db.get_session() as session:
             ch = await session.get(Channel, chat.id)
             allowed = ch.is_registered if ch else False
+        logging.debug("forward from chat %s allowed=%s", chat.id, allowed)
         if allowed:
             if chat.username:
                 link = f"https://t.me/{chat.username}/{msg_id}"
@@ -2883,6 +3128,7 @@ async def handle_forwarded(message: types.Message, db: Database, bot: Bot):
         message.html_text or message.caption_html,
         media,
     )
+    logging.info("forward parsed %d events", len(results))
     for saved, added, lines, status in results:
         buttons = []
         if (
@@ -2935,6 +3181,7 @@ async def update_source_page(
     title: str,
     new_html: str,
     media: list[tuple[bytes, str]] | tuple[bytes, str] | None = None,
+    db: Database | None = None,
 ) -> tuple[str, int]:
     """Append text to an existing Telegraph page."""
     token = get_telegraph_token()
@@ -2999,6 +3246,9 @@ async def update_source_page(
         html_content += (
             f"<p>{CONTENT_SEPARATOR}</p><p>" + cleaned.replace("\n", "<br/>") + "</p>"
         )
+        if db:
+            nav_html = await build_month_nav_html(db)
+            html_content = apply_month_nav(html_content, nav_html)
         logging.info("Editing telegraph page %s", path)
         await asyncio.to_thread(
             tg.edit_page, path, title=title, html_content=html_content
@@ -3010,12 +3260,33 @@ async def update_source_page(
         return f"error: {e}", 0
 
 
+async def update_source_page_ics(path: str, title: str, url: str | None):
+    """Insert or remove the ICS link in a Telegraph page."""
+    token = get_telegraph_token()
+    if not token:
+        logging.error("Telegraph token unavailable")
+        return
+    tg = Telegraph(access_token=token)
+    try:
+        logging.info("Editing telegraph ICS for %s", path)
+        page = await asyncio.to_thread(tg.get_page, path, return_html=True)
+        html_content = page.get("content") or page.get("content_html") or ""
+        html_content = apply_ics_link(html_content, url)
+        await asyncio.to_thread(
+            tg.edit_page, path, title=title, html_content=html_content
+        )
+    except Exception as e:
+        logging.error("Failed to update ICS link: %s", e)
+
+
 async def create_source_page(
     title: str,
     text: str,
     source_url: str | None,
     html_text: str | None = None,
     media: list[tuple[bytes, str]] | tuple[bytes, str] | None = None,
+    ics_url: str | None = None,
+    db: Database | None = None,
 ) -> tuple[str, str, str, int] | None:
     """Create a Telegraph page with the original event text."""
     token = get_telegraph_token()
@@ -3086,6 +3357,8 @@ async def create_source_page(
     for url in catbox_urls:
         html_content += f'<img src="{html.escape(url)}"/><p></p>'
 
+    html_content = apply_ics_link(html_content, ics_url)
+
     if html_text:
         html_text = strip_title(html_text)
         html_text = normalize_hashtag_dates(html_text)
@@ -3102,6 +3375,10 @@ async def create_source_page(
         )
         paragraphs = [f"<p>{html.escape(line)}</p>" for line in clean_text.splitlines()]
         html_content += "".join(paragraphs)
+
+    if db:
+        nav_html = await build_month_nav_html(db)
+        html_content = apply_month_nav(html_content, nav_html)
     try:
         page = await asyncio.to_thread(tg.create_page, title, html_content=html_content)
     except Exception as e:
@@ -3203,7 +3480,9 @@ def create_app() -> web.Application:
         or c.data.startswith("dailysend:")
         or c.data.startswith("togglefree:")
         or c.data.startswith("markfree:")
-        or c.data.startswith("togglesilent:"),
+        or c.data.startswith("togglesilent:")
+        or c.data.startswith("createics:")
+        or c.data.startswith("delics:"),
     )
     dp.message.register(tz_wrapper, Command("tz"))
     dp.message.register(add_event_wrapper, Command("addevent"))
@@ -3237,10 +3516,13 @@ def create_app() -> web.Application:
         CATBOX_ENABLED = await get_catbox_enabled(db)
         hook = webhook.rstrip("/") + "/webhook"
         logging.info("Setting webhook to %s", hook)
-        await bot.set_webhook(
-            hook,
-            allowed_updates=["message", "callback_query", "my_chat_member"],
-        )
+        try:
+            await bot.set_webhook(
+                hook,
+                allowed_updates=["message", "callback_query", "my_chat_member"],
+            )
+        except Exception as e:
+            logging.error("Failed to set webhook: %s", e)
         app["daily_task"] = asyncio.create_task(daily_scheduler(db, bot))
 
     async def on_shutdown(app: web.Application):

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,5 @@ pytest==8.1.1
 pytest-asyncio==0.23.6
 telegraph==2.2.0
 markdown>=3.5
+ics==0.7.2
+supabase==2.16.0

--- a/tests/test_bot.py
+++ b/tests/test_bot.py
@@ -180,7 +180,7 @@ async def test_add_event_raw(tmp_path: Path, monkeypatch):
     await db.init()
     bot = DummyBot("123:abc")
 
-    async def fake_create(title, text, source, html_text=None, media=None):
+    async def fake_create(title, text, source, html_text=None, media=None, ics_url=None, db=None):
         return "https://t.me/test", "path"
 
     monkeypatch.setattr("main.create_source_page", fake_create)
@@ -211,7 +211,7 @@ async def test_month_page_sync(tmp_path: Path, monkeypatch):
     await db.init()
     bot = DummyBot("123:abc")
 
-    async def fake_create(title, text, source, html_text=None, media=None):
+    async def fake_create(title, text, source, html_text=None, media=None, ics_url=None, db=None):
         return "https://t.me/test", "path"
 
     called = {}
@@ -243,7 +243,7 @@ async def test_weekend_page_sync(tmp_path: Path, monkeypatch):
     await db.init()
     bot = DummyBot("123:abc")
 
-    async def fake_create(title, text, source, html_text=None, media=None):
+    async def fake_create(title, text, source, html_text=None, media=None, ics_url=None, db=None):
         return "url", "p"
 
     called = {}
@@ -279,7 +279,7 @@ async def test_add_event_raw_update(tmp_path: Path, monkeypatch):
     await db.init()
     bot = DummyBot("123:abc")
 
-    async def fake_create(title, text, source, html_text=None, media=None):
+    async def fake_create(title, text, source, html_text=None, media=None, ics_url=None, db=None):
         return "https://t.me/test", "path"
 
     monkeypatch.setattr("main.create_source_page", fake_create)
@@ -319,7 +319,7 @@ async def test_edit_event(tmp_path: Path, monkeypatch):
     await db.init()
     bot = DummyBot("123:abc")
 
-    async def fake_create(title, text, source, html_text=None, media=None):
+    async def fake_create(title, text, source, html_text=None, media=None, ics_url=None, db=None):
         return "https://t.me/test", "path"
 
     monkeypatch.setattr("main.create_source_page", fake_create)
@@ -361,7 +361,7 @@ async def test_edit_remove_ticket_link(tmp_path: Path, monkeypatch):
     await db.init()
     bot = DummyBot("123:abc")
 
-    async def fake_create(title, text, source, html_text=None, media=None):
+    async def fake_create(title, text, source, html_text=None, media=None, ics_url=None, db=None):
         return "https://t.me/test", "path"
 
     monkeypatch.setattr("main.create_source_page", fake_create)
@@ -405,7 +405,7 @@ async def test_edit_event_forwarded(tmp_path: Path, monkeypatch):
     await db.init()
     bot = DummyBot("123:abc")
 
-    async def fake_create(title, text, source, html_text=None, media=None):
+    async def fake_create(title, text, source, html_text=None, media=None, ics_url=None, db=None):
         return "https://t.me/test", "path"
 
     monkeypatch.setattr("main.create_source_page", fake_create)
@@ -449,7 +449,7 @@ async def test_edit_boolean_fields(tmp_path: Path, monkeypatch):
     await db.init()
     bot = DummyBot("123:abc")
 
-    async def fake_create(title, text, source, html_text=None, media=None):
+    async def fake_create(title, text, source, html_text=None, media=None, ics_url=None, db=None):
         return "https://t.me/test", "path"
 
     monkeypatch.setattr("main.create_source_page", fake_create)
@@ -505,7 +505,7 @@ async def test_events_list(tmp_path: Path, monkeypatch):
     await db.init()
     bot = DummyBot("123:abc")
 
-    async def fake_create(title, text, source, html_text=None, media=None):
+    async def fake_create(title, text, source, html_text=None, media=None, ics_url=None, db=None):
         return "https://t.me/test", "path"
 
     monkeypatch.setattr("main.create_source_page", fake_create)
@@ -560,7 +560,7 @@ async def test_events_russian_date_current_year(tmp_path: Path, monkeypatch):
     await db.init()
     bot = DummyBot("123:abc")
 
-    async def fake_create(title, text, source, html_text=None, media=None):
+    async def fake_create(title, text, source, html_text=None, media=None, ics_url=None, db=None):
         return "u", "p"
 
     monkeypatch.setattr("main.create_source_page", fake_create)
@@ -624,7 +624,7 @@ async def test_events_russian_date_next_year(tmp_path: Path, monkeypatch):
     await db.init()
     bot = DummyBot("123:abc")
 
-    async def fake_create(title, text, source, html_text=None, media=None):
+    async def fake_create(title, text, source, html_text=None, media=None, ics_url=None, db=None):
         return "u", "p"
 
     monkeypatch.setattr("main.create_source_page", fake_create)
@@ -940,7 +940,7 @@ async def test_addevent_caption_photo(tmp_path: Path, monkeypatch):
 
     captured = {}
 
-    async def fake_create(title, text, source, html_text=None, media=None):
+    async def fake_create(title, text, source, html_text=None, media=None, ics_url=None, db=None):
         captured["media"] = media
         return "u", "p"
 
@@ -989,7 +989,7 @@ async def test_addevent_strips_command(tmp_path: Path, monkeypatch):
 
     captured = {}
 
-    async def fake_create(title, text, source, html_text=None, media=None):
+    async def fake_create(title, text, source, html_text=None, media=None, ics_url=None, db=None):
         captured["text"] = text
         captured["html"] = html_text
         return "u", "p"
@@ -1030,7 +1030,7 @@ async def test_forward_add_event(tmp_path: Path, monkeypatch):
             }
         ]
 
-    async def fake_create(title, text, source, html_text=None, media=None):
+    async def fake_create(title, text, source, html_text=None, media=None, ics_url=None, db=None):
         return "https://t.me/page", "p"
 
     monkeypatch.setattr("main.parse_event_via_4o", fake_parse)
@@ -1164,7 +1164,7 @@ async def test_forward_unregistered(tmp_path: Path, monkeypatch):
             }
         ]
 
-    async def fake_create(title, text, source, html_text=None, media=None):
+    async def fake_create(title, text, source, html_text=None, media=None, ics_url=None, db=None):
         return "https://t.me/page", "p"
 
     monkeypatch.setattr("main.parse_event_via_4o", fake_parse)
@@ -1222,7 +1222,7 @@ async def test_media_group_caption_first(tmp_path: Path, monkeypatch):
             }
         ]
 
-    async def fake_create(title, text, source, html_text=None, media=None):
+    async def fake_create(title, text, source, html_text=None, media=None, ics_url=None, db=None):
         return "https://t.me/page", "p"
 
     monkeypatch.setattr("main.parse_event_via_4o", fake_parse)
@@ -1300,7 +1300,7 @@ async def test_media_group_caption_last(tmp_path: Path, monkeypatch):
             }
         ]
 
-    async def fake_create(title, text, source, html_text=None, media=None):
+    async def fake_create(title, text, source, html_text=None, media=None, ics_url=None, db=None):
         return "https://t.me/page", "p"
 
     monkeypatch.setattr("main.parse_event_via_4o", fake_parse)
@@ -1367,7 +1367,7 @@ async def test_mark_free(tmp_path: Path, monkeypatch):
     await db.init()
     bot = DummyBot("123:abc")
 
-    async def fake_create(title, text, source, html_text=None, media=None):
+    async def fake_create(title, text, source, html_text=None, media=None, ics_url=None, db=None):
         return "https://t.me/test", "path"
 
     monkeypatch.setattr("main.create_source_page", fake_create)
@@ -1420,7 +1420,7 @@ async def test_toggle_silent(tmp_path: Path, monkeypatch):
     await db.init()
     bot = DummyBot("123:abc")
 
-    async def fake_create(title, text, source, html_text=None, media=None):
+    async def fake_create(title, text, source, html_text=None, media=None, ics_url=None, db=None):
         return "https://t.me/test", "path"
 
     monkeypatch.setattr("main.create_source_page", fake_create)
@@ -1507,7 +1507,7 @@ async def test_exhibition_listing(tmp_path: Path, monkeypatch):
 
     monkeypatch.setattr("main.parse_event_via_4o", fake_parse)
 
-    async def fake_create(title, text, source, html_text=None, media=None):
+    async def fake_create(title, text, source, html_text=None, media=None, ics_url=None, db=None):
         return "url", "p"
 
     monkeypatch.setattr("main.create_source_page", fake_create)
@@ -1595,7 +1595,7 @@ async def test_multiple_events(tmp_path: Path, monkeypatch):
             },
         ]
 
-    async def fake_create(title, text, source, html_text=None, media=None):
+    async def fake_create(title, text, source, html_text=None, media=None, ics_url=None, db=None):
         return f"url/{title}", title
 
     monkeypatch.setattr("main.parse_event_via_4o", fake_parse)
@@ -2105,7 +2105,7 @@ async def test_date_range_parsing(tmp_path: Path, monkeypatch):
             }
         ]
 
-    async def fake_create(title, text, source, html_text=None, media=None):
+    async def fake_create(title, text, source, html_text=None, media=None, ics_url=None, db=None):
         return "url", "p"
 
     monkeypatch.setattr("main.parse_event_via_4o", fake_parse)
@@ -2211,6 +2211,58 @@ async def test_update_source_page_normalizes_hashtags(monkeypatch):
     await main.update_source_page("p", "T", "#1_августа event")
 
 
+def test_apply_ics_link_insert_and_remove():
+    html = "<p><strong>T</strong></p><p></p><p>body</p>"
+    added = main.apply_ics_link(html, "http://x")
+    assert "Добавить в календарь" in added
+    removed = main.apply_ics_link(added, None)
+    assert "Добавить в календарь" not in removed
+
+
+@pytest.mark.asyncio
+async def test_update_source_page_ics(monkeypatch):
+    edited = {}
+
+    class DummyTG:
+        def get_page(self, path, return_html=True):
+            return {"content": "<p>T</p><p></p><p>body</p>"}
+
+        def edit_page(self, path, title, html_content):
+            edited["html"] = html_content
+
+    monkeypatch.setattr("main.get_telegraph_token", lambda: "t")
+    monkeypatch.setattr("main.Telegraph", lambda access_token=None: DummyTG())
+
+    await main.update_source_page_ics("p", "T", "http://x")
+    assert "Добавить в календарь" in edited.get("html", "")
+    await main.update_source_page_ics("p", "T", None)
+    assert "Добавить в календарь" not in edited.get("html", "")
+
+
+@pytest.mark.asyncio
+async def test_create_source_page_adds_nav(tmp_path: Path, monkeypatch):
+    captured = {}
+
+    class DummyTG:
+        def create_page(self, title, html_content=None, **_):
+            captured["html"] = html_content
+            return {"url": "https://telegra.ph/test", "path": "p"}
+
+    monkeypatch.setenv("TELEGRAPH_TOKEN", "t")
+    monkeypatch.setattr("main.Telegraph", lambda access_token=None: DummyTG())
+
+    db = Database(str(tmp_path / "db.sqlite"))
+    await db.init()
+    async with db.get_session() as session:
+        session.add(MonthPage(month="2025-07", url="u1", path="p1"))
+        session.add(MonthPage(month="2025-08", url="u2", path="p2"))
+        await session.commit()
+
+    res = await main.create_source_page("T", "text", None, db=db)
+    assert "u1" in captured.get("html", "")
+    assert res[0] == "https://telegra.ph/test"
+
+
 @pytest.mark.asyncio
 async def test_nav_limits_past(tmp_path: Path):
     db = Database(str(tmp_path / "db.sqlite"))
@@ -2269,7 +2321,7 @@ async def test_delete_event_updates_month(tmp_path: Path, monkeypatch):
     await db.init()
     bot = DummyBot("123:abc")
 
-    async def fake_create(title, text, source, html_text=None, media=None):
+    async def fake_create(title, text, source, html_text=None, media=None, ics_url=None, db=None):
         return "url", "p"
 
     called = {}
@@ -2331,7 +2383,7 @@ async def test_title_duplicate_update(tmp_path: Path, monkeypatch):
     await db.init()
     bot = DummyBot("123:abc")
 
-    async def fake_create(title, text, source, html_text=None, media=None):
+    async def fake_create(title, text, source, html_text=None, media=None, ics_url=None, db=None):
         return "url", "p"
 
     monkeypatch.setattr("main.create_source_page", fake_create)
@@ -2371,7 +2423,7 @@ async def test_llm_duplicate_check(tmp_path: Path, monkeypatch):
     await db.init()
     bot = DummyBot("123:abc")
 
-    async def fake_create(title, text, source, html_text=None, media=None):
+    async def fake_create(title, text, source, html_text=None, media=None, ics_url=None, db=None):
         return "url", "p"
 
     called = {"cnt": 0}
@@ -2433,7 +2485,7 @@ async def test_extract_ticket_link(tmp_path: Path, monkeypatch):
             }
         ]
 
-    async def fake_create(title, text, source, html_text=None, media=None):
+    async def fake_create(title, text, source, html_text=None, media=None, ics_url=None, db=None):
         return "url", "p"
 
     monkeypatch.setattr("main.parse_event_via_4o", fake_parse)
@@ -2466,7 +2518,7 @@ async def test_extract_ticket_link_near_word(tmp_path: Path, monkeypatch):
             }
         ]
 
-    async def fake_create(title, text, source, html_text=None, media=None):
+    async def fake_create(title, text, source, html_text=None, media=None, ics_url=None, db=None):
         return "url", "p"
 
     monkeypatch.setattr("main.parse_event_via_4o", fake_parse)
@@ -2499,7 +2551,7 @@ async def test_ticket_link_overrides_invalid(tmp_path: Path, monkeypatch):
             }
         ]
 
-    async def fake_create(title, text, source, html_text=None, media=None):
+    async def fake_create(title, text, source, html_text=None, media=None, ics_url=None, db=None):
         return "url", "p"
 
     monkeypatch.setattr("main.parse_event_via_4o", fake_parse)
@@ -2543,7 +2595,7 @@ async def test_multiple_ticket_links(tmp_path: Path, monkeypatch):
             },
         ]
 
-    async def fake_create(title, text, source, html_text=None, media=None):
+    async def fake_create(title, text, source, html_text=None, media=None, ics_url=None, db=None):
         return "url", "p"
 
     monkeypatch.setattr("main.parse_event_via_4o", fake_parse)
@@ -2577,7 +2629,7 @@ async def test_add_event_strips_city_from_address(tmp_path: Path, monkeypatch):
             }
         ]
 
-    async def fake_create(*args, **kwargs):
+    async def fake_create(*args, db=None, **kwargs):
         return "u", "p"
 
     monkeypatch.setattr("main.parse_event_via_4o", fake_parse)
@@ -2609,7 +2661,7 @@ async def test_festival_expands_dates(tmp_path: Path, monkeypatch):
 
     monkeypatch.setattr("main.parse_event_via_4o", fake_parse)
 
-    async def fake_create(*args, **kwargs):
+    async def fake_create(*args, db=None, **kwargs):
         return "u", "p"
 
     monkeypatch.setattr("main.create_source_page", fake_create)
@@ -2706,7 +2758,7 @@ async def test_exhibition_auto_year_end(tmp_path: Path, monkeypatch):
             }
         ]
 
-    async def fake_create(*args, **kwargs):
+    async def fake_create(*args, db=None, **kwargs):
         return "u", "p"
 
     monkeypatch.setattr("main.parse_event_via_4o", fake_parse)


### PR DESCRIPTION
## Summary
- add info-level logging around ICS file upload and deletion
- note parsed events when forwarding messages
- log reasons when forwarded posts are ignored
- add month navigation links at the bottom of Telegraph source pages
- handle webhook setup failures gracefully

## Testing
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686ec692312c8332947abe630ed40e1b