### PR TITLE
propagate 4o errors

### DIFF
--- a/main.py
+++ b/main.py
@@ -2,13 +2,16 @@ import logging
 import os
 from datetime import date, datetime, timedelta, timezone, time
 from typing import Optional, Tuple, Iterable
-from ics import Calendar, Event as IcsEvent
+import uuid
+import textwrap
 from supabase import create_client, Client
 
 from aiogram import Bot, Dispatcher, types
 from aiogram.filters import Command
 from aiogram.webhook.aiohttp_server import SimpleRequestHandler, setup_application
-from aiohttp import web, ClientSession, FormData
+from aiohttp import web, FormData, ClientSession, TCPConnector
+from aiogram.client.session.aiohttp import AiohttpSession
+import socket
 import imghdr
 from difflib import SequenceMatcher
 import json
@@ -30,6 +33,9 @@ TELEGRAPH_TOKEN_FILE = os.getenv("TELEGRAPH_TOKEN_FILE", "/data/telegraph_token.
 SUPABASE_URL = os.getenv("SUPABASE_URL")
 SUPABASE_KEY = os.getenv("SUPABASE_KEY")
 SUPABASE_BUCKET = os.getenv("SUPABASE_BUCKET", "events-ics")
+ICS_CONTENT_TYPE = "text/calendar; charset=utf-8"
+ICS_CONTENT_DISP_TEMPLATE = 'inline; filename="{name}"'
+ICS_CALNAME = "kenigevents"
 
 # currently active timezone offset for date calculations
 LOCAL_TZ = timezone.utc
@@ -45,6 +51,24 @@ daily_time_sessions: dict[int, int] = {}
 # toggle for uploading images to catbox
 CATBOX_ENABLED: bool = False
 _supabase_client: Client | None = None
+
+
+class IPv4AiohttpSession(AiohttpSession):
+    """Aiohttp session that forces IPv4 connections."""
+
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+        self._connector_init["family"] = socket.AF_INET
+
+
+def create_ipv4_session(session_cls: type[ClientSession] = ClientSession) -> ClientSession:
+    """Return ClientSession that forces IPv4 connections."""
+    connector = TCPConnector(family=socket.AF_INET)
+    try:
+        return session_cls(connector=connector)
+    except TypeError:
+        return session_cls()
+
 
 
 class User(SQLModel, table=True):
@@ -442,30 +466,61 @@ async def build_ics_content(db: Database, event: Event) -> str:
         end_dt = datetime.combine(datetime.fromisoformat(event.date), end_t, tzinfo=tz)
     else:
         end_dt = start_dt + timedelta(hours=1)
-    start = start_dt.astimezone(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
-    end = end_dt.astimezone(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
-    cal = Calendar()
-    ics_event = IcsEvent()
+
+    def fmt(dt: datetime) -> str:
+        return dt.astimezone(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+
     title = event.title
     if event.location_name:
         title = f"{title} в {event.location_name}"
-    ics_event.name = title
-    ics_event.begin = start
-    ics_event.end = end
-    desc = event.description
+
+    desc = event.description or ""
     link = event.source_post_url or event.telegraph_url
     if link:
-        desc = f"{desc}\n\n{link}"
-    ics_event.description = desc
+        desc = f"{desc}\n\n{link}" if desc else link
+
     loc_parts = []
     if event.location_address:
         loc_parts.append(event.location_address)
     if event.city:
         loc_parts.append(event.city)
-    ics_event.location = ", ".join(loc_parts)
-    ics_event.url = event.source_post_url or event.telegraph_url
-    cal.events.add(ics_event)
-    return cal.serialize()
+    location = ", ".join(loc_parts)
+
+    uid = f"{uuid.uuid4()}@{event.id}.ics"
+    dtstamp = datetime.utcnow().strftime("%Y%m%dT%H%M%SZ")
+
+    lines = [
+        "BEGIN:VCALENDAR",
+        "VERSION:2.0",
+        "PRODID:-//events-bot//RU",
+        "CALSCALE:GREGORIAN",
+        "METHOD:PUBLISH",
+        f"X-WR-CALNAME:{ICS_CALNAME}",
+        "BEGIN:VEVENT",
+        f"UID:{uid}",
+        f"DTSTAMP:{dtstamp}",
+        f"DTSTART:{fmt(start_dt)}",
+        f"DTEND:{fmt(end_dt)}",
+        f"SUMMARY:{title}",
+        f"DESCRIPTION:{desc}",
+    ]
+    if location:
+        lines.append(f"LOCATION:{location}")
+    if link:
+        lines.append(f"URL:{link}")
+    lines += [
+        "END:VEVENT",
+        "END:VCALENDAR",
+    ]
+
+    def fold(s: str) -> str:
+        if len(s) <= 75:
+            return s
+        parts = textwrap.wrap(s, 73)
+        return "\r\n ".join(parts)
+
+    lines = [fold(l) for l in lines]
+    return "\r\n".join(lines) + "\r\n"
 
 
 async def upload_ics(event: Event, db: Database) -> str | None:
@@ -490,7 +545,11 @@ async def upload_ics(event: Event, db: Database) -> str | None:
         client.storage.from_(SUPABASE_BUCKET).upload(
             path,
             content.encode("utf-8"),
-            {"content-type": "text/calendar", "upsert": "true"},
+            {
+                "content-type": ICS_CONTENT_TYPE,
+                "content-disposition": ICS_CONTENT_DISP_TEMPLATE.format(name=path),
+                "upsert": "true",
+            },
         )
         url = client.storage.from_(SUPABASE_BUCKET).get_public_url(path)
         logging.info("ICS uploaded: %s", url)
@@ -542,7 +601,7 @@ async def parse_event_via_4o(text: str) -> list[dict]:
         "temperature": 0,
     }
     logging.info("Sending 4o parse request to %s", url)
-    async with ClientSession() as session:
+    async with create_ipv4_session(ClientSession) as session:
         resp = await session.post(url, json=payload, headers=headers)
         resp.raise_for_status()
         data = await resp.json()
@@ -584,7 +643,7 @@ async def ask_4o(text: str) -> str:
         "temperature": 0,
     }
     logging.info("Sending 4o ask request to %s", url)
-    async with ClientSession() as session:
+    async with create_ipv4_session(ClientSession) as session:
         resp = await session.post(url, json=payload, headers=headers)
         resp.raise_for_status()
         data = await resp.json()
@@ -963,6 +1022,13 @@ async def process_request(callback: types.CallbackQuery, db: Database, bot: Bot)
         tz = offset_to_timezone(offset)
         await send_daily_announcement(db, bot, cid, tz, record=False)
         await callback.answer("Sent")
+    elif data.startswith("dailysendtom:"):
+        cid = int(data.split(":")[1])
+        offset = await get_tz_offset(db)
+        tz = offset_to_timezone(offset)
+        now = datetime.now(tz) + timedelta(days=1)
+        await send_daily_announcement(db, bot, cid, tz, record=False, now=now)
+        await callback.answer("Sent")
 
 
 async def handle_tz(message: types.Message, db: Database, bot: Bot):
@@ -1159,6 +1225,10 @@ async def send_daily_list(
                 ),
                 types.InlineKeyboardButton(
                     text="Test", callback_data=f"dailysend:{ch.channel_id}"
+                ),
+                types.InlineKeyboardButton(
+                    text="Test tomorrow",
+                    callback_data=f"dailysendtom:{ch.channel_id}",
                 ),
             ]
         )
@@ -1407,11 +1477,15 @@ async def add_events_from_text(
     source_link: str | None,
     html_text: str | None = None,
     media: list[tuple[bytes, str]] | tuple[bytes, str] | None = None,
+    *,
+    raise_exc: bool = False,
 ) -> list[tuple[Event, bool, list[str], str]]:
     try:
         parsed = await parse_event_via_4o(text)
     except Exception as e:
         logging.error("LLM error: %s", e)
+        if raise_exc:
+            raise
         return []
 
     results: list[tuple[Event, bool, list[str], str]] = []
@@ -1522,6 +1596,15 @@ async def add_events_from_text(
                         session.add(saved)
                         await session.commit()
             else:
+                if not saved.ics_url:
+                    ics = await upload_ics(saved, db)
+                    if ics:
+                        async with db.get_session() as session:
+                            obj = await session.get(Event, saved.id)
+                            if obj:
+                                obj.ics_url = ics
+                                await session.commit()
+                                saved.ics_url = ics
                 res = await create_source_page(
                     saved.title or "Event",
                     saved.source_text,
@@ -1594,13 +1677,18 @@ async def handle_add_event(message: types.Message, db: Database, bot: Bot):
     html_text = message.html_text or message.caption_html
     if html_text and html_text.startswith("/addevent"):
         html_text = html_text[len("/addevent") :].lstrip()
-    results = await add_events_from_text(
-        db,
-        parts[1],
-        None,
-        html_text,
-        media,
-    )
+    try:
+        results = await add_events_from_text(
+            db,
+            parts[1],
+            None,
+            html_text,
+            media,
+            raise_exc=True,
+        )
+    except Exception as e:
+        await bot.send_message(message.chat.id, f"LLM error: {e}")
+        return
     if not results:
         await bot.send_message(message.chat.id, "LLM error")
         return
@@ -1653,6 +1741,16 @@ async def handle_add_event_raw(message: types.Message, db: Database, bot: Bot):
     )
     async with db.get_session() as session:
         event, added = await upsert_event(session, event)
+
+    if not event.ics_url:
+        ics = await upload_ics(event, db)
+        if ics:
+            async with db.get_session() as session:
+                obj = await session.get(Event, event.id)
+                if obj:
+                    obj.ics_url = ics
+                    await session.commit()
+                    event.ics_url = ics
 
     html_text = message.html_text or message.caption_html
     if html_text and html_text.startswith("/addevent_raw"):
@@ -1909,21 +2007,24 @@ def is_valid_url(text: str | None) -> bool:
     return bool(re.match(r"https?://", text))
 
 
-def recent_cutoff(tz: timezone) -> datetime:
+def recent_cutoff(tz: timezone, now: datetime | None = None) -> datetime:
+    """Return UTC datetime for the start of the previous day in the given tz."""
+    if now is None:
+        now = datetime.now(tz)
     start_local = datetime.combine(
-        datetime.now(tz).date() - timedelta(days=1),
+        now.date() - timedelta(days=1),
         time(0, 0),
         tz,
     )
     return start_local.astimezone(timezone.utc).replace(tzinfo=None)
 
 
-def is_recent(e: Event, tz: timezone | None = None) -> bool:
+def is_recent(e: Event, tz: timezone | None = None, now: datetime | None = None) -> bool:
     if e.added_at is None or e.silent:
         return False
     if tz is None:
         tz = LOCAL_TZ
-    start = recent_cutoff(tz)
+    start = recent_cutoff(tz, now)
     return e.added_at >= start
 
 
@@ -2512,10 +2613,14 @@ async def sync_weekend_page(db: Database, start: str, update_links: bool = True)
 
 
 async def build_daily_posts(
-    db: Database, tz: timezone
+    db: Database,
+    tz: timezone,
+    now: datetime | None = None,
 ) -> list[tuple[str, types.InlineKeyboardMarkup | None]]:
-    today = datetime.now(tz).date()
-    yesterday_utc = recent_cutoff(tz)
+    if now is None:
+        now = datetime.now(tz)
+    today = now.date()
+    yesterday_utc = recent_cutoff(tz, now)
     async with db.get_session() as session:
         res_today = await session.execute(
             select(Event).where(Event.date == today.isoformat()).order_by(Event.time)
@@ -2648,8 +2753,9 @@ async def send_daily_announcement(
     tz: timezone,
     *,
     record: bool = True,
+    now: datetime | None = None,
 ):
-    posts = await build_daily_posts(db, tz)
+    posts = await build_daily_posts(db, tz, now)
     for text, markup in posts:
         await bot.send_message(
             channel_id,
@@ -2658,11 +2764,11 @@ async def send_daily_announcement(
             parse_mode="HTML",
             disable_web_page_preview=True,
         )
-    if record:
+    if record and now is None:
         async with db.get_session() as session:
             ch = await session.get(Channel, channel_id)
             if ch:
-                ch.last_daily = datetime.now(tz).date().isoformat()
+                ch.last_daily = (now or datetime.now(tz)).date().isoformat()
                 await session.commit()
 
 
@@ -3412,7 +3518,8 @@ def create_app() -> web.Application:
     if not webhook:
         raise RuntimeError("WEBHOOK_URL is missing")
 
-    bot = Bot(token)
+    session = IPv4AiohttpSession()
+    bot = Bot(token, session=session)
     logging.info("DB_PATH=%s", DB_PATH)
     logging.info("FOUR_O_TOKEN found: %s", bool(os.getenv("FOUR_O_TOKEN")))
     dp = Dispatcher()
@@ -3493,6 +3600,7 @@ def create_app() -> web.Application:
         or c.data.startswith("dailyunset:")
         or c.data.startswith("dailytime:")
         or c.data.startswith("dailysend:")
+        or c.data.startswith("dailysendtom:")
         or c.data.startswith("togglefree:")
         or c.data.startswith("markfree:")
         or c.data.startswith("togglesilent:")

--- a/tests/test_bot.py
+++ b/tests/test_bot.py
@@ -2871,6 +2871,31 @@ async def test_build_daily_posts(tmp_path: Path):
     assert first_btn.startswith("(+1)")
 
 
+@pytest.mark.asyncio
+async def test_build_daily_posts_tomorrow(tmp_path: Path):
+    db = Database(str(tmp_path / "db.sqlite"))
+    await db.init()
+
+    today = date.today()
+    tomorrow = today + timedelta(days=1)
+    async with db.get_session() as session:
+        session.add(
+            Event(
+                title="T",
+                description="d",
+                source_text="s",
+                date=tomorrow.isoformat(),
+                time="18:00",
+                location_name="Hall",
+            )
+        )
+        await session.commit()
+
+    now = datetime.now(timezone.utc) + timedelta(days=1)
+    posts = await main.build_daily_posts(db, timezone.utc, now)
+    assert posts and tomorrow.strftime("%d") in posts[0][0]
+
+
 
 @pytest.mark.asyncio
 async def test_daily_weekend_date_link(tmp_path: Path):
@@ -2946,3 +2971,78 @@ async def test_daily_test_send_no_record(tmp_path: Path):
     async with db.get_session() as session:
         ch = await session.get(main.Channel, 1)
     assert ch.last_daily is None
+
+
+@pytest.mark.asyncio
+async def test_upload_ics_content_type(tmp_path: Path, monkeypatch):
+    db = Database(str(tmp_path / "db.sqlite"))
+    await db.init()
+
+    event = Event(
+        id=1,
+        title="T",
+        description="d",
+        source_text="s",
+        date=date.today().isoformat(),
+        time="10:00",
+        location_name="Hall",
+    )
+
+    class DummyBucket:
+        def __init__(self):
+            self.upload_args = None
+
+        def upload(self, path, data, options):
+            self.upload_args = (path, data, options)
+
+        def get_public_url(self, path):
+            return f"https://test/{path}"
+
+        def remove(self, paths):
+            pass
+
+    class DummyStorage:
+        def __init__(self):
+            self.bucket = DummyBucket()
+
+        def from_(self, bucket):
+            return self.bucket
+
+    class DummyClient:
+        def __init__(self):
+            self.storage = DummyStorage()
+
+    dummy = DummyClient()
+    monkeypatch.setattr(main, "get_supabase_client", lambda: dummy)
+
+    url = await main.upload_ics(event, db)
+    assert url.endswith(".ics")
+    opts = dummy.storage.bucket.upload_args[2]
+    assert opts["content-type"] == main.ICS_CONTENT_TYPE
+    assert opts["content-disposition"].startswith("inline;")
+    assert "filename=\"" in opts["content-disposition"]
+
+
+@pytest.mark.asyncio
+async def test_build_ics_content_headers(tmp_path: Path):
+    db = Database(str(tmp_path / "db.sqlite"))
+    await db.init()
+    event = Event(
+        id=1,
+        title="T",
+        description="d",
+        source_text="s",
+        date=date.today().isoformat(),
+        time="10:00",
+        location_name="Hall",
+    )
+
+    content = await main.build_ics_content(db, event)
+    assert content.endswith("\r\n")
+    lines = content.split("\r\n")
+    assert lines[0] == "BEGIN:VCALENDAR"
+    assert lines[1] == "VERSION:2.0"
+    assert lines[2].startswith("PRODID:")
+    assert lines[3] == "CALSCALE:GREGORIAN"
+    assert lines[4] == "METHOD:PUBLISH"
+    assert any(l.startswith("DTSTAMP:") for l in lines)


### PR DESCRIPTION
## Summary
- allow forcing a custom 'now' when building daily posts for previewing tomorrow
- show "Test tomorrow" button in daily channel list and handle the callback
- automatically upload an ICS file when adding an event so Telegraph pages include a calendar link
- set the ICS upload header to `text/calendar; charset=utf-8`
- include Content-Disposition header for ICS files and add DTSTAMP/CALSCALE/METHOD
- test that uploaded ICS files use these headers and that generated ICS contains standard fields
- build ICS files manually so header order matches iOS requirements and lines end with CRLF
- check header order in tests

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686efa246ec083328f3232b880dac395