### PR TITLE
propagate 4o errors

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,4 @@ telegraph==2.2.0
 markdown>=3.5
 ics==0.7.2
 supabase==2.16.0
+icalendar==6.0.1

--- a/tests/test_bot.py
+++ b/tests/test_bot.py
@@ -2871,6 +2871,31 @@ async def test_build_daily_posts(tmp_path: Path):
     assert first_btn.startswith("(+1)")
 
 
+@pytest.mark.asyncio
+async def test_build_daily_posts_tomorrow(tmp_path: Path):
+    db = Database(str(tmp_path / "db.sqlite"))
+    await db.init()
+
+    today = date.today()
+    tomorrow = today + timedelta(days=1)
+    async with db.get_session() as session:
+        session.add(
+            Event(
+                title="T",
+                description="d",
+                source_text="s",
+                date=tomorrow.isoformat(),
+                time="18:00",
+                location_name="Hall",
+            )
+        )
+        await session.commit()
+
+    now = datetime.now(timezone.utc) + timedelta(days=1)
+    posts = await main.build_daily_posts(db, timezone.utc, now)
+    assert posts and tomorrow.strftime("%d") in posts[0][0]
+
+
 
 @pytest.mark.asyncio
 async def test_daily_weekend_date_link(tmp_path: Path):
@@ -2946,3 +2971,79 @@ async def test_daily_test_send_no_record(tmp_path: Path):
     async with db.get_session() as session:
         ch = await session.get(main.Channel, 1)
     assert ch.last_daily is None
+
+
+@pytest.mark.asyncio
+async def test_upload_ics_content_type(tmp_path: Path, monkeypatch):
+    db = Database(str(tmp_path / "db.sqlite"))
+    await db.init()
+
+    event = Event(
+        id=1,
+        title="T",
+        description="d",
+        source_text="s",
+        date=date.today().isoformat(),
+        time="10:00",
+        location_name="Hall",
+    )
+
+    class DummyBucket:
+        def __init__(self):
+            self.upload_args = None
+
+        def upload(self, path, data, options):
+            self.upload_args = (path, data, options)
+
+        def get_public_url(self, path):
+            return f"https://test/{path}"
+
+        def remove(self, paths):
+            pass
+
+    class DummyStorage:
+        def __init__(self):
+            self.bucket = DummyBucket()
+
+        def from_(self, bucket):
+            return self.bucket
+
+    class DummyClient:
+        def __init__(self):
+            self.storage = DummyStorage()
+
+    dummy = DummyClient()
+    monkeypatch.setattr(main, "get_supabase_client", lambda: dummy)
+
+    url = await main.upload_ics(event, db)
+    assert url.endswith(".ics")
+    opts = dummy.storage.bucket.upload_args[2]
+    assert opts["content-type"] == main.ICS_CONTENT_TYPE
+    assert opts["content-disposition"].startswith("inline;")
+    assert "filename=\"" in opts["content-disposition"]
+
+
+@pytest.mark.asyncio
+async def test_build_ics_content_headers(tmp_path: Path):
+    db = Database(str(tmp_path / "db.sqlite"))
+    await db.init()
+    event = Event(
+        id=1,
+        title="T",
+        description="d",
+        source_text="s",
+        date=date.today().isoformat(),
+        time="10:00",
+        location_name="Hall",
+    )
+
+    content = await main.build_ics_content(db, event)
+    assert content.endswith("\r\n")
+    lines = content.split("\r\n")
+    assert lines[0] == "BEGIN:VCALENDAR"
+    assert lines[1] == "VERSION:2.0"
+    assert lines[2].startswith("PRODID:")
+    assert lines[3] == "CALSCALE:GREGORIAN"
+    assert lines[4] == "METHOD:PUBLISH"
+    assert lines[5].startswith("X-WR-CALNAME:")
+    assert any(l.startswith("DTSTAMP:") for l in lines)


### PR DESCRIPTION
## Summary
- allow forcing a custom 'now' when building daily posts for previewing tomorrow
- show "Test tomorrow" button in daily channel list and handle the callback
- automatically upload an ICS file when adding an event so Telegraph pages include a calendar link
- set the ICS upload header to `text/calendar; charset=utf-8`
- include Content-Disposition header for ICS files and add DTSTAMP/CALSCALE/METHOD
- test that uploaded ICS files use these headers and that generated ICS contains standard fields
- build ICS files manually so header order matches iOS requirements and lines end with CRLF
- check header order in tests
- fix ics generation

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686efa246ec083328f3232b880dac395