### PR TITLE
Implement calendar asset channel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,3 +45,8 @@
 - Calendar files include a link back to the event and are saved as `Event-<id>-dd-mm-yyyy.ics`.
 - Telegraph pages show a calendar link under the main image when an ICS file exists.
 - Startup no longer fails when setting the webhook times out.
+
+## v0.3.5 - Calendar asset channel
+- `/setchannel` lets you mark a channel as the calendar asset source.
+- `/channels` shows the asset channel with a disable button.
+- Calendar files are posted to this channel and linked from month and weekend pages.

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This is an MVP using **aiogram 3** and SQLite. It is designed for deployment on
 Fly.io with a webhook.
 
 Forwarded posts from moderators or admins are treated the same as the `/addevent` command.
-Use `/setchannel` to pick one of the channels where the bot has admin rights and mark it as a source for announcement posts. `/channels` lists all admin channels and lets you cancel registration.
+Use `/setchannel` to pick one of the channels where the bot has admin rights and register it either as an announcement source or as the calendar asset channel. `/channels` lists all admin channels and lets you disable these roles.
 
 Bot messages display dates in the format `DD.MM.YYYY`. Public pages such as
 Telegraph posts use the short form "D месяц" (e.g. `2 июля`).

--- a/docs/COMMANDS.md
+++ b/docs/COMMANDS.md
@@ -11,8 +11,8 @@
 | `/images` | - | Toggle uploading photos to Catbox. |
 | `/ask4o <text>` | any text | Send query to model 4o and show plain response (superadmin only). |
 | `/events [DATE]` | optional date `YYYY-MM-DD`, `DD.MM.YYYY` or `D месяц [YYYY]` | List events for the day with delete and edit buttons. Dates are shown as `DD.MM.YYYY`. Choosing **Edit** lists all fields with inline buttons including a toggle for "Бесплатно". |
-| `/setchannel` | - | Choose one of the admin channels to register as an announcement source. |
-| `/channels` | - | List channels where the bot is admin and mark registered ones with a cancel button. |
+| `/setchannel` | - | Choose an admin channel and register it as an announcement or calendar asset source. |
+| `/channels` | - | List admin channels showing registered and asset ones with disable buttons. |
 | `/regdailychannels` | - | Choose admin channels for daily announcements (default 08:00). |
 | `/daily` | - | Manage daily announcement channels: cancel, change time, test send. |
 | `/exhibitions` | - | List active exhibitions similar to `/events`; each entry shows the period `c <start>` / `по <end>` and includes edit/delete buttons. |

--- a/docs/USER_STORIES.md
+++ b/docs/USER_STORIES.md
@@ -31,3 +31,4 @@
 |US-27|User/Admin|add event to calendar via ICS|quick calendar save|
 |US-28|User|follow the calendar link on a Telegraph page|ICS download on phone|
 |US-29|Moderator|manage recurring events|confirm regular schedule|
+|US-30|Admin|register calendar asset channel|ICS files available in Telegram|

--- a/tests/test_bot.py
+++ b/tests/test_bot.py
@@ -1095,7 +1095,7 @@ async def test_forward_add_event_photo(tmp_path: Path, monkeypatch):
 
     captured = {}
 
-    async def fake_add(db2, text, source_link, html_text=None, media=None):
+    async def fake_add(db2, text, source_link, html_text=None, media=None, **kwargs):
         captured["media"] = media
         return []
 


### PR DESCRIPTION
## Summary
- add calendar asset channel support
- show asset channel in channel listing
- let /setchannel mark a channel as asset
- publish calendar files to asset channel
- link asset files from month and weekend pages
- update docs and changelog

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6872a6c81b7083328218fa673f3e39fc