### PR TITLE
Implement calendar asset channel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,3 +45,9 @@
 - Calendar files include a link back to the event and are saved as `Event-<id>-dd-mm-yyyy.ics`.
 - Telegraph pages show a calendar link under the main image when an ICS file exists.
 - Startup no longer fails when setting the webhook times out.
+
+## v0.3.5 - Calendar asset channel
+- `/setchannel` lets you mark a channel as the calendar asset source.
+- `/channels` shows the asset channel with a disable button.
+- Calendar files are posted to this channel and linked from month and weekend pages.
+- Forwarded posts from the asset channel show a calendar button.

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This is an MVP using **aiogram 3** and SQLite. It is designed for deployment on
 Fly.io with a webhook.
 
 Forwarded posts from moderators or admins are treated the same as the `/addevent` command.
-Use `/setchannel` to pick one of the channels where the bot has admin rights and mark it as a source for announcement posts. `/channels` lists all admin channels and lets you cancel registration.
+Use `/setchannel` to pick one of the channels where the bot has admin rights and register it either as an announcement source or as the calendar asset channel. `/channels` lists all admin channels and lets you disable these roles. When the asset channel is set, forwarded posts from it get a **Добавить в календарь** button linking to the calendar file.
 
 Bot messages display dates in the format `DD.MM.YYYY`. Public pages such as
 Telegraph posts use the short form "D месяц" (e.g. `2 июля`).

--- a/docs/COMMANDS.md
+++ b/docs/COMMANDS.md
@@ -11,8 +11,8 @@
 | `/images` | - | Toggle uploading photos to Catbox. |
 | `/ask4o <text>` | any text | Send query to model 4o and show plain response (superadmin only). |
 | `/events [DATE]` | optional date `YYYY-MM-DD`, `DD.MM.YYYY` or `D месяц [YYYY]` | List events for the day with delete and edit buttons. Dates are shown as `DD.MM.YYYY`. Choosing **Edit** lists all fields with inline buttons including a toggle for "Бесплатно". |
-| `/setchannel` | - | Choose one of the admin channels to register as an announcement source. |
-| `/channels` | - | List channels where the bot is admin and mark registered ones with a cancel button. |
+| `/setchannel` | - | Choose an admin channel and register it as an announcement or calendar asset source. |
+| `/channels` | - | List admin channels showing registered and asset ones with disable buttons. |
 | `/regdailychannels` | - | Choose admin channels for daily announcements (default 08:00). |
 | `/daily` | - | Manage daily announcement channels: cancel, change time, test send. |
 | `/exhibitions` | - | List active exhibitions similar to `/events`; each entry shows the period `c <start>` / `по <end>` and includes edit/delete buttons. |

--- a/docs/USER_STORIES.md
+++ b/docs/USER_STORIES.md
@@ -31,3 +31,4 @@
 |US-27|User/Admin|add event to calendar via ICS|quick calendar save|
 |US-28|User|follow the calendar link on a Telegraph page|ICS download on phone|
 |US-29|Moderator|manage recurring events|confirm regular schedule|
+|US-30|Admin|register calendar asset channel|ICS files available in Telegram|

--- a/main.py
+++ b/main.py
@@ -39,6 +39,8 @@ ICS_CONTENT_DISP_TEMPLATE = 'inline; filename="{name}"'
 ICS_CALNAME = "kenigevents"
 
 
+
+
 def fold_unicode_line(line: str, limit: int = 74) -> str:
     """Return a folded iCalendar line without splitting UTF-8 code points."""
     encoded = line.encode("utf-8")
@@ -110,8 +112,21 @@ class Channel(SQLModel, table=True):
     username: Optional[str] = None
     is_admin: bool = False
     is_registered: bool = False
+    is_asset: bool = False
     daily_time: Optional[str] = None
     last_daily: Optional[str] = None
+
+
+def build_channel_post_url(ch: Channel, message_id: int) -> str:
+    """Return https://t.me/... link for a channel message."""
+    if ch.username:
+        return f"https://t.me/{ch.username}/{message_id}"
+    cid = str(ch.channel_id)
+    if cid.startswith("-100"):
+        cid = cid[4:]
+    else:
+        cid = cid.lstrip("-")
+    return f"https://t.me/c/{cid}/{message_id}"
 
 
 class Setting(SQLModel, table=True):
@@ -143,6 +158,10 @@ class Event(SQLModel, table=True):
     telegraph_url: Optional[str] = None
     ics_url: Optional[str] = None
     source_post_url: Optional[str] = None
+    ics_post_url: Optional[str] = None
+    ics_post_id: Optional[int] = None
+    source_chat_id: Optional[int] = None
+    source_message_id: Optional[int] = None
     photo_count: int = 0
     added_at: datetime = Field(default_factory=datetime.utcnow)
 
@@ -228,6 +247,22 @@ class Database:
                 await conn.exec_driver_sql(
                     "ALTER TABLE event ADD COLUMN ics_url VARCHAR"
                 )
+            if "ics_post_url" not in cols:
+                await conn.exec_driver_sql(
+                    "ALTER TABLE event ADD COLUMN ics_post_url VARCHAR"
+                )
+            if "ics_post_id" not in cols:
+                await conn.exec_driver_sql(
+                    "ALTER TABLE event ADD COLUMN ics_post_id INTEGER"
+                )
+            if "source_chat_id" not in cols:
+                await conn.exec_driver_sql(
+                    "ALTER TABLE event ADD COLUMN source_chat_id INTEGER"
+                )
+            if "source_message_id" not in cols:
+                await conn.exec_driver_sql(
+                    "ALTER TABLE event ADD COLUMN source_message_id INTEGER"
+                )
 
             result = await conn.exec_driver_sql("PRAGMA table_info(channel)")
             cols = [r[1] for r in result.fetchall()]
@@ -238,6 +273,10 @@ class Database:
             if "last_daily" not in cols:
                 await conn.exec_driver_sql(
                     "ALTER TABLE channel ADD COLUMN last_daily VARCHAR"
+                )
+            if "is_asset" not in cols:
+                await conn.exec_driver_sql(
+                    "ALTER TABLE channel ADD COLUMN is_asset BOOLEAN DEFAULT 0"
                 )
 
     def get_session(self) -> AsyncSession:
@@ -291,6 +330,30 @@ def get_supabase_client() -> Client | None:
     if _supabase_client is None and SUPABASE_URL and SUPABASE_KEY:
         _supabase_client = create_client(SUPABASE_URL, SUPABASE_KEY)
     return _supabase_client
+
+
+async def get_asset_channel(db: Database) -> Channel | None:
+    async with db.get_session() as session:
+        result = await session.execute(
+            select(Channel).where(Channel.is_asset.is_(True))
+        )
+        return result.scalars().first()
+
+
+def build_asset_caption(event: Event, day: date) -> str:
+    """Return HTML caption for a calendar asset post."""
+    loc = html.escape(event.location_name or "")
+    addr = event.location_address
+    if addr and event.city:
+        addr = strip_city_from_address(addr, event.city)
+    if addr:
+        loc += f", {html.escape(addr)}"
+    if event.city:
+        loc += f", #{html.escape(event.city)}"
+    return (
+        f"<b>{html.escape(event.title)}</b>\n"
+        f"<i>{format_day_pretty(day)} {event.time} {loc}</i>"
+    )
 
 
 def validate_offset(value: str) -> bool:
@@ -610,6 +673,60 @@ async def upload_ics(event: Event, db: Database) -> str | None:
     return url
 
 
+async def post_ics_asset(event: Event, db: Database, bot: Bot) -> tuple[str, int] | None:
+    channel = await get_asset_channel(db)
+    if not channel:
+        return None
+    try:
+        content = await build_ics_content(db, event)
+    except Exception as e:
+        logging.error("failed to build ics content: %s", e)
+        return None
+    try:
+        d = datetime.fromisoformat(event.date)
+        name = f"Event-{event.id}-{d.day:02d}-{d.month:02d}-{d.year}.ics"
+    except Exception:
+        d = date.today()
+        name = f"Event-{event.id}.ics"
+    file = types.BufferedInputFile(content.encode("utf-8"), filename=name)
+    caption = build_asset_caption(event, d)
+    try:
+        msg = await bot.send_document(
+            channel.channel_id,
+            file,
+            caption=caption,
+            parse_mode="HTML",
+        )
+        url = build_channel_post_url(channel, msg.message_id)
+        return url, msg.message_id
+    except Exception as e:
+        logging.error("failed to post ics to asset channel: %s", e)
+        return None
+
+
+async def add_calendar_button(event: Event, bot: Bot):
+    """Attach calendar link button to the original channel post."""
+    if not (
+        event.source_chat_id
+        and event.source_message_id
+        and event.ics_post_url
+    ):
+        return
+    markup = types.InlineKeyboardMarkup(
+        inline_keyboard=[
+            [types.InlineKeyboardButton(text="Добавить в календарь", url=event.ics_post_url)]
+        ]
+    )
+    try:
+        await bot.edit_message_reply_markup(
+            chat_id=event.source_chat_id,
+            message_id=event.source_message_id,
+            reply_markup=markup,
+        )
+    except Exception as e:
+        logging.error("failed to set calendar button: %s", e)
+
+
 async def delete_ics(event: Event):
     client = get_supabase_client()
     if not client or not event.ics_url:
@@ -620,6 +737,32 @@ async def delete_ics(event: Event):
         client.storage.from_(SUPABASE_BUCKET).remove([path])
     except Exception as e:
         logging.error("Failed to delete ics: %s", e)
+
+
+async def delete_asset_post(event: Event, db: Database, bot: Bot):
+    if not event.ics_post_id:
+        return
+    channel = await get_asset_channel(db)
+    if not channel:
+        return
+    try:
+        await bot.delete_message(channel.channel_id, event.ics_post_id)
+    except Exception as e:
+        logging.error("failed to delete asset message: %s", e)
+
+
+async def remove_calendar_button(event: Event, bot: Bot):
+    """Remove calendar button from the original channel post."""
+    if not (event.source_chat_id and event.source_message_id):
+        return
+    try:
+        await bot.edit_message_reply_markup(
+            chat_id=event.source_chat_id,
+            message_id=event.source_message_id,
+            reply_markup=None,
+        )
+    except Exception as e:
+        logging.error("failed to remove calendar button: %s", e)
 
 
 async def parse_event_via_4o(text: str) -> list[dict]:
@@ -952,10 +1095,22 @@ async def process_request(callback: types.CallbackQuery, db: Database, bot: Bot)
                     event.ics_url = url
                     await session.commit()
                     logging.info("ICS saved for event %s: %s", eid, url)
+                    posted = await post_ics_asset(event, db, bot)
+                    if posted:
+                        url_p, msg_id = posted
+                        event.ics_post_url = url_p
+                        event.ics_post_id = msg_id
+                        await session.commit()
+                        await add_calendar_button(event, bot)
                     if event.telegraph_path:
                         await update_source_page_ics(
                             event.telegraph_path, event.title or "Event", url
                         )
+                    month = event.date.split("..", 1)[0][:7]
+                    await sync_month_page(db, month)
+                    w_start = weekend_start_for_date(datetime.fromisoformat(event.date).date())
+                    if w_start:
+                        await sync_weekend_page(db, w_start.isoformat())
                 else:
                     logging.warning("ICS creation failed for event %s", eid)
         if event:
@@ -970,10 +1125,20 @@ async def process_request(callback: types.CallbackQuery, db: Database, bot: Bot)
                 event.ics_url = None
                 await session.commit()
                 logging.info("ICS removed for event %s", eid)
+                await delete_asset_post(event, db, bot)
+                event.ics_post_url = None
+                event.ics_post_id = None
+                await session.commit()
+                await remove_calendar_button(event, bot)
                 if event.telegraph_path:
                     await update_source_page_ics(
                         event.telegraph_path, event.title or "Event", None
                     )
+                month = event.date.split("..", 1)[0][:7]
+                await sync_month_page(db, month)
+                w_start = weekend_start_for_date(datetime.fromisoformat(event.date).date())
+                if w_start:
+                    await sync_weekend_page(db, w_start.isoformat())
             elif event:
                 logging.debug("deleteics: no file for event %s", eid)
         if event:
@@ -1034,6 +1199,16 @@ async def process_request(callback: types.CallbackQuery, db: Database, bot: Bot)
                 await session.commit()
         await send_channels_list(callback.message, db, bot, edit=True)
         await callback.answer("Removed")
+    elif data.startswith("assetunset:"):
+        cid = int(data.split(":")[1])
+        async with db.get_session() as session:
+            ch = await session.get(Channel, cid)
+            if ch and ch.is_asset:
+                ch.is_asset = False
+                logging.info("asset channel unset %s", cid)
+                await session.commit()
+        await send_channels_list(callback.message, db, bot, edit=True)
+        await callback.answer("Removed")
     elif data.startswith("set:"):
         cid = int(data.split(":")[1])
         async with db.get_session() as session:
@@ -1042,6 +1217,21 @@ async def process_request(callback: types.CallbackQuery, db: Database, bot: Bot)
                 ch.is_registered = True
                 logging.info("channel %s registered", cid)
                 await session.commit()
+        await send_setchannel_list(callback.message, db, bot, edit=True)
+        await callback.answer("Registered")
+    elif data.startswith("assetset:"):
+        cid = int(data.split(":")[1])
+        async with db.get_session() as session:
+            current = await session.execute(
+                select(Channel).where(Channel.is_asset.is_(True))
+            )
+            cur = current.scalars().first()
+            if cur and cur.channel_id != cid:
+                cur.is_asset = False
+            ch = await session.get(Channel, cid)
+            if ch and ch.is_admin:
+                ch.is_asset = True
+            await session.commit()
         await send_setchannel_list(callback.message, db, bot, edit=True)
         await callback.answer("Registered")
     elif data.startswith("dailyset:"):
@@ -1154,17 +1344,25 @@ async def send_channels_list(
     keyboard = []
     for ch in channels:
         name = ch.title or ch.username or str(ch.channel_id)
+        status = []
+        row: list[types.InlineKeyboardButton] = []
         if ch.is_registered:
-            lines.append(f"{name} ✅")
-            keyboard.append(
-                [
-                    types.InlineKeyboardButton(
-                        text="Cancel", callback_data=f"unset:{ch.channel_id}"
-                    )
-                ]
+            status.append("✅")
+            row.append(
+                types.InlineKeyboardButton(
+                    text="Cancel", callback_data=f"unset:{ch.channel_id}"
+                )
             )
-        else:
-            lines.append(name)
+        if ch.is_asset:
+            status.append("📅")
+            row.append(
+                types.InlineKeyboardButton(
+                    text="Asset off", callback_data=f"assetunset:{ch.channel_id}"
+                )
+            )
+        lines.append(f"{name} {' '.join(status)}".strip())
+        if row:
+            keyboard.append(row)
     if not lines:
         lines.append("No channels")
     markup = types.InlineKeyboardMarkup(inline_keyboard=keyboard) if keyboard else None
@@ -1184,9 +1382,7 @@ async def send_setchannel_list(
                 await bot.send_message(message.chat.id, "Not authorized")
             return
         result = await session.execute(
-            select(Channel).where(
-                Channel.is_admin.is_(True), Channel.is_registered.is_(False)
-            )
+            select(Channel).where(Channel.is_admin.is_(True))
         )
         channels = result.scalars().all()
     logging.info("setchannel list: %s", [c.channel_id for c in channels])
@@ -1195,13 +1391,20 @@ async def send_setchannel_list(
     for ch in channels:
         name = ch.title or ch.username or str(ch.channel_id)
         lines.append(name)
-        keyboard.append(
-            [
+        row = []
+        if not ch.is_registered:
+            row.append(
                 types.InlineKeyboardButton(
-                    text=name, callback_data=f"set:{ch.channel_id}"
+                    text="Announce", callback_data=f"set:{ch.channel_id}"
                 )
-            ]
-        )
+            )
+        if not ch.is_asset:
+            row.append(
+                types.InlineKeyboardButton(
+                    text="Asset", callback_data=f"assetset:{ch.channel_id}"
+                )
+            )
+        keyboard.append(row)
     if not lines:
         lines.append("No channels")
     markup = types.InlineKeyboardMarkup(inline_keyboard=keyboard) if keyboard else None
@@ -1530,6 +1733,8 @@ async def add_events_from_text(
     media: list[tuple[bytes, str]] | tuple[bytes, str] | None = None,
     *,
     raise_exc: bool = False,
+    source_chat_id: int | None = None,
+    source_message_id: int | None = None,
 ) -> list[tuple[Event, bool, list[str], str]]:
     try:
         parsed = await parse_event_via_4o(text)
@@ -1576,6 +1781,8 @@ async def add_events_from_text(
             pushkin_card=bool(data.get("pushkin_card")),
             source_text=text,
             source_post_url=source_link,
+            source_chat_id=source_chat_id,
+            source_message_id=source_message_id,
         )
 
         if base_event.event_type == "выставка" and not base_event.end_date:
@@ -1601,7 +1808,16 @@ async def add_events_from_text(
                 events_to_add = []
                 for i in range((end_dt - start_dt).days + 1):
                     day = start_dt + timedelta(days=i)
-                    copy_e = Event(**base_event.model_dump(exclude={"id", "added_at"}))
+                    copy_e = Event(
+                        **base_event.model_dump(
+                            exclude={
+                                "id",
+                                "added_at",
+                                "ics_post_url",
+                                "ics_post_id",
+                            }
+                        )
+                    )
                     copy_e.date = day.isoformat()
                     copy_e.end_date = None
                     events_to_add.append(copy_e)
@@ -1647,6 +1863,18 @@ async def add_events_from_text(
                                 obj.ics_url = ics
                                 await session.commit()
                                 saved.ics_url = ics
+                        posted = await post_ics_asset(saved, db, bot)
+                        if posted:
+                            url_p, msg_id = posted
+                            async with db.get_session() as session:
+                                obj = await session.get(Event, saved.id)
+                                if obj:
+                                    obj.ics_post_url = url_p
+                                    obj.ics_post_id = msg_id
+                                    await session.commit()
+                                    saved.ics_post_url = url_p
+                                    saved.ics_post_id = msg_id
+                            await add_calendar_button(saved, bot)
                 res = await create_source_page(
                     saved.title or "Event",
                     saved.source_text,
@@ -2113,7 +2341,10 @@ def format_event_md(e: Event) -> str:
     if e.telegraph_url:
         cam = "\U0001f4f8" * max(0, e.photo_count)
         prefix = f"{cam} " if cam else ""
-        lines.append(f"{prefix}[подробнее]({e.telegraph_url})")
+        more_line = f"{prefix}[подробнее]({e.telegraph_url})"
+        if e.ics_post_url:
+            more_line += f" \U0001f4c5 [добавить в календарь]({e.ics_post_url})"
+        lines.append(more_line)
     loc = e.location_name
     addr = e.location_address
     if addr and e.city:
@@ -2904,9 +3135,11 @@ async def build_events_message(db: Database, target_date: date, tz: timezone):
     keyboard = [
         [
             types.InlineKeyboardButton(
-                text="\u274c", callback_data=f"del:{e.id}:{target_date.isoformat()}"
+                text=f"\u274c {e.id}", callback_data=f"del:{e.id}:{target_date.isoformat()}"
             ),
-            types.InlineKeyboardButton(text="\u270e", callback_data=f"edit:{e.id}"),
+            types.InlineKeyboardButton(
+                text=f"\u270e {e.id}", callback_data=f"edit:{e.id}"
+            ),
         ]
         for e in events
     ]
@@ -2997,8 +3230,12 @@ async def build_exhibitions_message(db: Database, tz: timezone):
 
     keyboard = [
         [
-            types.InlineKeyboardButton(text="\u274c", callback_data=f"del:{e.id}:exh"),
-            types.InlineKeyboardButton(text="\u270e", callback_data=f"edit:{e.id}"),
+            types.InlineKeyboardButton(
+                text=f"\u274c {e.id}", callback_data=f"del:{e.id}:exh"
+            ),
+            types.InlineKeyboardButton(
+                text=f"\u270e {e.id}", callback_data=f"edit:{e.id}"
+            ),
         ]
         for e in events
     ]
@@ -3313,6 +3550,8 @@ async def handle_forwarded(message: types.Message, db: Database, bot: Bot):
         link,
         message.html_text or message.caption_html,
         media,
+        source_chat_id=chat.id if link else None,
+        source_message_id=msg_id if link else None,
     )
     logging.info("forward parsed %d events", len(results))
     for saved, added, lines, status in results:
@@ -3663,7 +3902,9 @@ def create_app() -> web.Application:
         or c.data.startswith("editfield:")
         or c.data.startswith("editdone:")
         or c.data.startswith("unset:")
+        or c.data.startswith("assetunset:")
         or c.data.startswith("set:")
+        or c.data.startswith("assetset:")
         or c.data.startswith("dailyset:")
         or c.data.startswith("dailyunset:")
         or c.data.startswith("dailytime:")


### PR DESCRIPTION
## Summary
- add calendar asset channel support
- show asset channel in channel listing
- let /setchannel mark a channel as asset
- publish calendar files to asset channel
- link asset files from month and weekend pages
- add calendar button to forwarded posts
- improve asset channel captions and tests
- show event id on event management buttons

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6872a6c81b7083328218fa673f3e39fc