### PR TITLE
Fix daily announcement to include silent events

### DIFF
--- a/main.py
+++ b/main.py
@@ -3003,7 +3003,7 @@ async def build_daily_posts(
     async with db.get_session() as session:
         res_today = await session.execute(
             select(Event)
-            .where(Event.date == today.isoformat(), Event.silent.is_(False))
+            .where(Event.date == today.isoformat())
             .order_by(Event.time)
         )
         events_today = res_today.scalars().all()

--- a/tests/test_bot.py
+++ b/tests/test_bot.py
@@ -2949,7 +2949,7 @@ async def test_build_daily_posts(tmp_path: Path):
     text, markup = posts[0]
     assert "АНОНС" in text
     assert markup.inline_keyboard[0]
-    assert text.count("\U0001f449") == 1
+    assert text.count("\U0001f449") == 2
     first_btn = markup.inline_keyboard[0][0].text
     assert first_btn.startswith("(+1)")
 


### PR DESCRIPTION
## Summary
- show silent events in today's daily announcement
- update tests for new logic

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6874ca73a82883328683735d69b5e908