### PR TITLE
Add Telegraph stats command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,3 +52,7 @@
 - Calendar files are posted to this channel and linked from month and weekend pages.
 - Forwarded posts from the asset channel show a calendar button.
 
+## v0.3.6 - Telegraph stats
+- `/stats` shows view counts for the previous month and recent weekend pages.
+- `/stats events` lists stats for event source pages sorted by views.
+

--- a/docs/COMMANDS.md
+++ b/docs/COMMANDS.md
@@ -17,6 +17,7 @@
 | `/daily` | - | Manage daily announcement channels: cancel, change time, test send. |
 | `/exhibitions` | - | List active exhibitions similar to `/events`; each entry shows the period `c <start>` / `по <end>` and includes edit/delete buttons. |
 | `/pages` | - | Show links to Telegraph month and weekend pages. |
+| `/stats [events]` | optional `events` | Superadmin only. Show Telegraph view counts for the previous month and weekend pages. Use `events` to list event page stats. |
 | `python main.py test_telegraph` | - | Verify Telegraph API access. Automatically creates a token if needed and prints the page URL. |
 
 Use `/addevent` to let model 4o extract fields. `/addevent_raw` lets you


### PR DESCRIPTION
## Summary
- implement `/stats` and `/stats events` for superadmin
- document stats command in docs
- note stats feature in changelog
- test stats command logic

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6874e14ca8c48332bc06d04c5bfe5cda