### PR TITLE
Add Telegraph stats command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,3 +52,7 @@
 - Calendar files are posted to this channel and linked from month and weekend pages.
 - Forwarded posts from the asset channel show a calendar button.
 
+## v0.3.6 - Telegraph stats
+- `/stats` shows view counts for the past month and weekend pages, plus all current and upcoming ones.
+- `/stats events` lists stats for event source pages sorted by views.
+

--- a/docs/COMMANDS.md
+++ b/docs/COMMANDS.md
@@ -17,6 +17,7 @@
 | `/daily` | - | Manage daily announcement channels: cancel, change time, test send. |
 | `/exhibitions` | - | List active exhibitions similar to `/events`; each entry shows the period `c <start>` / `по <end>` and includes edit/delete buttons. |
 | `/pages` | - | Show links to Telegraph month and weekend pages. |
+| `/stats [events]` | optional `events` | Superadmin only. Show Telegraph view counts starting from the past month and weekend pages up to all current and future ones. Use `events` to list event page stats. |
 | `python main.py test_telegraph` | - | Verify Telegraph API access. Automatically creates a token if needed and prints the page URL. |
 
 Use `/addevent` to let model 4o extract fields. `/addevent_raw` lets you

--- a/main.py
+++ b/main.py
@@ -3515,6 +3515,112 @@ async def handle_pages(message: types.Message, db: Database, bot: Bot):
     await bot.send_message(message.chat.id, "\n".join(lines))
 
 
+
+
+async def fetch_views(path: str) -> int | None:
+    token = get_telegraph_token()
+    if not token:
+        return None
+    tg = Telegraph(access_token=token)
+    try:
+        data = await asyncio.to_thread(tg.get_views, path)
+        return int(data.get("views", 0))
+    except Exception as e:
+        logging.error("Failed to fetch views for %s: %s", path, e)
+        return None
+
+
+async def collect_page_stats(db: Database) -> list[str]:
+    today = date.today()
+    prev_month_start = (today.replace(day=1) - timedelta(days=1)).replace(day=1)
+    prev_month = prev_month_start.strftime("%Y-%m")
+    prev_weekend = next_weekend_start(today - timedelta(days=7))
+    cur_month = today.strftime("%Y-%m")
+    cur_weekend = next_weekend_start(today)
+
+    async with db.get_session() as session:
+        mp_prev = await session.get(MonthPage, prev_month)
+        wp_prev = await session.get(WeekendPage, prev_weekend.isoformat())
+
+        res_months = await session.execute(
+            select(MonthPage)
+            .where(MonthPage.month >= cur_month)
+            .order_by(MonthPage.month)
+        )
+        future_months = res_months.scalars().all()
+
+        res_weekends = await session.execute(
+            select(WeekendPage)
+            .where(WeekendPage.start >= cur_weekend.isoformat())
+            .order_by(WeekendPage.start)
+        )
+        future_weekends = res_weekends.scalars().all()
+
+    lines: list[str] = []
+
+    if mp_prev and mp_prev.path:
+        views = await fetch_views(mp_prev.path)
+        if views is not None:
+            month_dt = date.fromisoformat(mp_prev.month + "-01")
+            lines.append(f"{MONTHS_NOM[month_dt.month - 1]}: {views} просмотров")
+
+    if wp_prev and wp_prev.path:
+        views = await fetch_views(wp_prev.path)
+        if views is not None:
+            label = format_weekend_range(prev_weekend)
+            lines.append(f"{label}: {views} просмотров")
+
+    for wp in future_weekends:
+        if not wp.path:
+            continue
+        views = await fetch_views(wp.path)
+        if views is not None:
+            label = format_weekend_range(date.fromisoformat(wp.start))
+            lines.append(f"{label}: {views} просмотров")
+
+    for mp in future_months:
+        if not mp.path:
+            continue
+        views = await fetch_views(mp.path)
+        if views is not None:
+            month_dt = date.fromisoformat(mp.month + "-01")
+            lines.append(f"{MONTHS_NOM[month_dt.month - 1]}: {views} просмотров")
+
+    return lines
+
+
+async def collect_event_stats(db: Database) -> list[str]:
+    today = date.today()
+    prev_month_start = (today.replace(day=1) - timedelta(days=1)).replace(day=1)
+    async with db.get_session() as session:
+        result = await session.execute(
+            select(Event).where(
+                Event.telegraph_path.is_not(None),
+                Event.date >= prev_month_start.isoformat(),
+            )
+        )
+        events = result.scalars().all()
+    stats = []
+    for e in events:
+        if not e.telegraph_path:
+            continue
+        views = await fetch_views(e.telegraph_path)
+        if views is not None:
+            stats.append((e.telegraph_url or e.telegraph_path, views))
+    stats.sort(key=lambda x: x[1], reverse=True)
+    return [f"{url}: {v}" for url, v in stats]
+
+
+async def handle_stats(message: types.Message, db: Database, bot: Bot):
+    parts = message.text.split()
+    mode = parts[1] if len(parts) > 1 else ""
+    async with db.get_session() as session:
+        user = await session.get(User, message.from_user.id)
+        if not user or not user.is_superadmin:
+            await bot.send_message(message.chat.id, "Not authorized")
+            return
+    lines = await (collect_event_stats(db) if mode == "events" else collect_page_stats(db))
+    await bot.send_message(message.chat.id, "\n".join(lines) if lines else "No data")
 async def handle_edit_message(message: types.Message, db: Database, bot: Bot):
     state = editing_sessions.get(message.from_user.id)
     if not state:
@@ -3998,6 +4104,9 @@ def create_app() -> web.Application:
     async def pages_wrapper(message: types.Message):
         await handle_pages(message, db, bot)
 
+    async def stats_wrapper(message: types.Message):
+        await handle_stats(message, db, bot)
+
     async def edit_message_wrapper(message: types.Message):
         await handle_edit_message(message, db, bot)
 
@@ -4055,6 +4164,7 @@ def create_app() -> web.Application:
     dp.message.register(daily_wrapper, Command("daily"))
     dp.message.register(exhibitions_wrapper, Command("exhibitions"))
     dp.message.register(pages_wrapper, Command("pages"))
+    dp.message.register(stats_wrapper, Command("stats"))
     dp.message.register(
         edit_message_wrapper, lambda m: m.from_user.id in editing_sessions
     )

--- a/tests/test_bot.py
+++ b/tests/test_bot.py
@@ -28,6 +28,7 @@ from main import (
     handle_ask_4o,
     handle_events,
     handle_exhibitions,
+    handle_stats,
     handle_edit_message,
     process_request,
     parse_event_via_4o,
@@ -1653,6 +1654,141 @@ async def test_months_command(tmp_path: Path):
 
     await main.handle_pages(msg, db, bot)
     assert "2025-07" in bot.messages[-1][1]
+
+
+@pytest.mark.asyncio
+async def test_stats_pages(tmp_path: Path, monkeypatch):
+    db = Database(str(tmp_path / "db.sqlite"))
+    await db.init()
+    bot = DummyBot("123:abc")
+
+    prev_month = (date.today().replace(day=1) - timedelta(days=1)).strftime("%Y-%m")
+    prev_weekend = main.next_weekend_start(date.today() - timedelta(days=7))
+    cur_month = date.today().strftime("%Y-%m")
+    next_month = main.next_month(cur_month)
+    cur_weekend = main.next_weekend_start(date.today())
+    next_weekend = main.next_weekend_start(cur_weekend + timedelta(days=1))
+
+    async with db.get_session() as session:
+        session.add(main.MonthPage(month=prev_month, url="u", path="mp_prev"))
+        session.add(main.MonthPage(month=cur_month, url="u2", path="mp_cur"))
+        session.add(main.MonthPage(month=next_month, url="u3", path="mp_next"))
+        session.add(main.WeekendPage(start=prev_weekend.isoformat(), url="w1", path="wp_prev"))
+        session.add(main.WeekendPage(start=cur_weekend.isoformat(), url="w2", path="wp_cur"))
+        session.add(main.WeekendPage(start=next_weekend.isoformat(), url="w3", path="wp_next"))
+        await session.commit()
+
+    class DummyTG:
+        def __init__(self, access_token=None):
+            self.access_token = access_token
+
+        def get_views(self, path, **_):
+            views = {
+                "mp_prev": {"views": 100},
+                "mp_cur": {"views": 200},
+                "mp_next": {"views": 300},
+                "wp_prev": {"views": 10},
+                "wp_cur": {"views": 20},
+                "wp_next": {"views": 30},
+            }
+            return views[path]
+
+    monkeypatch.setenv("TELEGRAPH_TOKEN", "t")
+    monkeypatch.setattr("main.Telegraph", lambda access_token=None: DummyTG(access_token))
+
+    start_msg = types.Message.model_validate({
+        "message_id": 1,
+        "date": 0,
+        "chat": {"id": 1, "type": "private"},
+        "from": {"id": 1, "is_bot": False, "first_name": "A"},
+        "text": "/start",
+    })
+    await handle_start(start_msg, db, bot)
+
+    msg = types.Message.model_validate({
+        "message_id": 2,
+        "date": 0,
+        "chat": {"id": 1, "type": "private"},
+        "from": {"id": 1, "is_bot": False, "first_name": "A"},
+        "text": "/stats",
+    })
+    await handle_stats(msg, db, bot)
+
+    lines = bot.messages[-1][1].splitlines()
+    assert any("100" in l for l in lines)  # previous month
+    assert any("10" in l for l in lines)   # previous weekend
+    assert any("20" in l for l in lines)   # current weekend
+    assert any("300" in l for l in lines)  # future month
+
+
+@pytest.mark.asyncio
+async def test_stats_events(tmp_path: Path, monkeypatch):
+    db = Database(str(tmp_path / "db.sqlite"))
+    await db.init()
+    bot = DummyBot("123:abc")
+
+    prev_month_start = (date.today().replace(day=1) - timedelta(days=1)).replace(day=1)
+    event_date = prev_month_start + timedelta(days=1)
+
+    async with db.get_session() as session:
+        session.add(
+            Event(
+                title="A",
+                description="d",
+                source_text="s",
+                date=event_date.isoformat(),
+                time="10:00",
+                location_name="Hall",
+                telegraph_url="http://a",
+                telegraph_path="pa",
+            )
+        )
+        session.add(
+            Event(
+                title="B",
+                description="d",
+                source_text="s",
+                date=event_date.isoformat(),
+                time="11:00",
+                location_name="Hall",
+                telegraph_url="http://b",
+                telegraph_path="pb",
+            )
+        )
+        await session.commit()
+
+    class DummyTG:
+        def __init__(self, access_token=None):
+            pass
+
+        def get_views(self, path, **_):
+            return {"pa": {"views": 5}, "pb": {"views": 10}}[path]
+
+    monkeypatch.setenv("TELEGRAPH_TOKEN", "t")
+    monkeypatch.setattr("main.Telegraph", lambda access_token=None: DummyTG(access_token))
+
+    start_msg = types.Message.model_validate({
+        "message_id": 1,
+        "date": 0,
+        "chat": {"id": 1, "type": "private"},
+        "from": {"id": 1, "is_bot": False, "first_name": "A"},
+        "text": "/start",
+    })
+    await handle_start(start_msg, db, bot)
+
+    msg = types.Message.model_validate({
+        "message_id": 2,
+        "date": 0,
+        "chat": {"id": 1, "type": "private"},
+        "from": {"id": 1, "is_bot": False, "first_name": "A"},
+        "text": "/stats events",
+    })
+    await handle_stats(msg, db, bot)
+
+    lines = bot.messages[-1][1].splitlines()
+    assert lines[0].startswith("http://b")
+    assert "10" in lines[0]
+    assert "5" in lines[1]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- implement `/stats` and `/stats events` for superadmin
- document stats command in docs
- note stats feature in changelog
- test stats command logic
- expand `/stats` to include current and future pages

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6874e14ca8c48332bc06d04c5bfe5cda