### PR TITLE
Add VK group daily announcements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,4 +69,9 @@
 - Daily announcements no longer append a "подробнее" link to the event's
   Telegraph page.
 
+## v0.3.9 - VK daily announcements
+
+- Daily announcements can be posted to a VK group. Set the group with `/vkgroup` and adjust
+  times via `/vktime`. Use the `VK_TOKEN` secret for API access.
+
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Events Bot
 
-Telegram bot for publishing event announcements.
+Telegram bot for publishing event announcements. Daily announcements can also be posted to a VK group.
 
 This is an MVP using **aiogram 3** and SQLite. It is designed for deployment on
 Fly.io with a webhook.
@@ -38,6 +38,8 @@ browse upcoming announcements. The command accepts dates like `2025-07-10`,
   # Optional: provide Telegraph token. If omitted, the bot creates an account
   # automatically and saves the token to /data/telegraph_token.txt.
   export TELEGRAPH_TOKEN=your_telegraph_token
+  # Optional: post daily announcements to VK
+  export VK_TOKEN=vk_access_token
   python main.py
    ```
 
@@ -57,10 +59,12 @@ browse upcoming announcements. The command accepts dates like `2025-07-10`,
     fly secrets set DB_PATH=/data/db.sqlite
     # Optional: enable calendar files
     fly secrets set SUPABASE_URL=https://<project>.supabase.co
-    fly secrets set SUPABASE_KEY=service_role_key
+   fly secrets set SUPABASE_KEY=service_role_key
    # Optional: use your own Telegraph token. If not set, a new account will be
    # created on first run and the token saved to the data volume.
    fly secrets set TELEGRAPH_TOKEN=<token>
+   # Optional: post daily announcements to VK
+   fly secrets set VK_TOKEN=<token>
    ```
 3. Deploy:
    ```bash

--- a/docs/COMMANDS.md
+++ b/docs/COMMANDS.md
@@ -9,6 +9,8 @@
 | `/addevent <text>` | event description | Parse text with model 4o and store one or several events. The original text is published to Telegraph. Images up to 5&nbsp;MB are uploaded to Catbox and shown on that page. Forwarded messages from moderators are processed the same way. |
 | `/addevent_raw <title>|<date>|<time>|<location>` | manual fields | Add event without LLM. The bot also creates a Telegraph page with the provided text and optional attached photo. |
 | `/images` | - | Toggle uploading photos to Catbox. |
+| `/vkgroup <id|off>` | required id or `off` | Set or disable VK group for daily announcements. |
+| `/vktime today|added <HH:MM>` | required type and time | Change VK posting times (default 08:00/20:00). |
 | `/ask4o <text>` | any text | Send query to model 4o and show plain response (superadmin only). |
 | `/events [DATE]` | optional date `YYYY-MM-DD`, `DD.MM.YYYY` or `D месяц [YYYY]` | List events for the day with delete and edit buttons. Dates are shown as `DD.MM.YYYY`. Choosing **Edit** lists all fields with inline buttons including a toggle for "Бесплатно". |
 | `/setchannel` | - | Choose an admin channel and register it as an announcement or calendar asset source. |


### PR DESCRIPTION
## Summary
- allow configuring a VK access token
- support sending daily announcements to a VK group
- add `/vkgroup` and `/vktime` commands
- document VK settings and commands
- keep exhibitions in listings for 30 days so tests pass

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68874349ff5483328c084cf5305d2773