### PR TITLE
Add VK settings to daily menus

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,4 +69,23 @@
 - Daily announcements no longer append a "подробнее" link to the event's
   Telegraph page.
 
+## v0.3.9 - VK daily announcements
+
+- Daily announcements can be posted to a VK group. Set the group with `/vkgroup` and adjust
+  times via `/vktime`. Use the `VK_TOKEN` secret for API access.
+
+## v0.3.10 - Unified daily management
+
+- `/regdailychannels` and `/daily` now show the VK group alongside Telegram channels.
+  VK posting times can be changed there and test posts sent.
+- Daily announcements include new hashtag lines for Telegram and VK posts.
+
+## v0.3.11 - VK formatting tweaks
+
+- VK daily posts show a calendar icon before "АНОНС" and include more spacing between events.
+- Date, time and location are italicized if supported.
+- Prices include `руб.` and ticket links move to the next line.
+- The "подробнее" line now ends with a colon and calendar links appear on their own line as
+  "📆 Добавить в календарь: <link>".
+
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Events Bot
 
-Telegram bot for publishing event announcements.
+Telegram bot for publishing event announcements. Daily announcements can also be posted to a VK group.
+Use `/regdailychannels` and `/daily` to manage both Telegram channels and the VK group including posting times.
 
 This is an MVP using **aiogram 3** and SQLite. It is designed for deployment on
 Fly.io with a webhook.
@@ -38,6 +39,8 @@ browse upcoming announcements. The command accepts dates like `2025-07-10`,
   # Optional: provide Telegraph token. If omitted, the bot creates an account
   # automatically and saves the token to /data/telegraph_token.txt.
   export TELEGRAPH_TOKEN=your_telegraph_token
+  # Optional: post daily announcements to VK
+  export VK_TOKEN=vk_access_token
   python main.py
    ```
 
@@ -57,10 +60,12 @@ browse upcoming announcements. The command accepts dates like `2025-07-10`,
     fly secrets set DB_PATH=/data/db.sqlite
     # Optional: enable calendar files
     fly secrets set SUPABASE_URL=https://<project>.supabase.co
-    fly secrets set SUPABASE_KEY=service_role_key
+   fly secrets set SUPABASE_KEY=service_role_key
    # Optional: use your own Telegraph token. If not set, a new account will be
    # created on first run and the token saved to the data volume.
    fly secrets set TELEGRAPH_TOKEN=<token>
+   # Optional: post daily announcements to VK
+   fly secrets set VK_TOKEN=<token>
    ```
 3. Deploy:
    ```bash

--- a/docs/COMMANDS.md
+++ b/docs/COMMANDS.md
@@ -9,12 +9,14 @@
 | `/addevent <text>` | event description | Parse text with model 4o and store one or several events. The original text is published to Telegraph. Images up to 5&nbsp;MB are uploaded to Catbox and shown on that page. Forwarded messages from moderators are processed the same way. |
 | `/addevent_raw <title>|<date>|<time>|<location>` | manual fields | Add event without LLM. The bot also creates a Telegraph page with the provided text and optional attached photo. |
 | `/images` | - | Toggle uploading photos to Catbox. |
+| `/vkgroup <id|off>` | required id or `off` | Set or disable VK group for daily announcements. |
+| `/vktime today|added <HH:MM>` | required type and time | Change VK posting times (default 08:00/20:00). |
 | `/ask4o <text>` | any text | Send query to model 4o and show plain response (superadmin only). |
 | `/events [DATE]` | optional date `YYYY-MM-DD`, `DD.MM.YYYY` or `D месяц [YYYY]` | List events for the day with delete and edit buttons. Dates are shown as `DD.MM.YYYY`. Choosing **Edit** lists all fields with inline buttons including a toggle for "Бесплатно". |
 | `/setchannel` | - | Choose an admin channel and register it as an announcement or calendar asset source. |
 | `/channels` | - | List admin channels showing registered and asset ones with disable buttons. |
-| `/regdailychannels` | - | Choose admin channels for daily announcements (default 08:00). |
-| `/daily` | - | Manage daily announcement channels: cancel, change time, test send. |
+| `/regdailychannels` | - | Choose admin channels for daily announcements and set the VK group. |
+| `/daily` | - | Manage daily announcement channels and VK posting times; send test posts. |
 | `/exhibitions` | - | List active exhibitions similar to `/events`; each entry shows the period `c <start>` / `по <end>` and includes edit/delete buttons. |
 | `/pages` | - | Show links to Telegraph month and weekend pages. |
 

--- a/main.py
+++ b/main.py
@@ -38,6 +38,7 @@ TELEGRAPH_TOKEN_FILE = os.getenv("TELEGRAPH_TOKEN_FILE", "/data/telegraph_token.
 SUPABASE_URL = os.getenv("SUPABASE_URL")
 SUPABASE_KEY = os.getenv("SUPABASE_KEY")
 SUPABASE_BUCKET = os.getenv("SUPABASE_BUCKET", "events-ics")
+VK_TOKEN = os.getenv("VK_TOKEN")
 ICS_CONTENT_TYPE = "text/calendar; charset=utf-8"
 ICS_CONTENT_DISP_TEMPLATE = 'inline; filename="{name}"'
 ICS_CALNAME = "kenigevents"
@@ -68,6 +69,10 @@ CONTENT_SEPARATOR = "🟧" * 10
 editing_sessions: dict[int, tuple[int, str | None]] = {}
 # user_id -> channel_id for daily time editing
 daily_time_sessions: dict[int, int] = {}
+# waiting for VK group ID input
+vk_group_sessions: set[int] = set()
+# user_id -> section (today/added) for VK time update
+vk_time_sessions: dict[int, str] = {}
 
 # toggle for uploading images to catbox
 CATBOX_ENABLED: bool = False
@@ -344,6 +349,66 @@ async def set_catbox_enabled(db: Database, value: bool):
         await session.commit()
     global CATBOX_ENABLED
     CATBOX_ENABLED = value
+
+
+async def get_setting_value(db: Database, key: str) -> str | None:
+    async with db.get_session() as session:
+        setting = await session.get(Setting, key)
+        return setting.value if setting else None
+
+
+async def set_setting_value(db: Database, key: str, value: str | None):
+    async with db.get_session() as session:
+        setting = await session.get(Setting, key)
+        if value is None:
+            if setting:
+                await session.delete(setting)
+        elif setting:
+            setting.value = value
+        else:
+            setting = Setting(key=key, value=value)
+            session.add(setting)
+        await session.commit()
+
+
+async def get_vk_group_id(db: Database) -> str | None:
+    return await get_setting_value(db, "vk_group_id")
+
+
+async def set_vk_group_id(db: Database, group_id: str | None):
+    await set_setting_value(db, "vk_group_id", group_id)
+
+
+async def get_vk_time_today(db: Database) -> str:
+    return await get_setting_value(db, "vk_time_today") or "08:00"
+
+
+async def set_vk_time_today(db: Database, value: str):
+    await set_setting_value(db, "vk_time_today", value)
+
+
+async def get_vk_time_added(db: Database) -> str:
+    return await get_setting_value(db, "vk_time_added") or "20:00"
+
+
+async def set_vk_time_added(db: Database, value: str):
+    await set_setting_value(db, "vk_time_added", value)
+
+
+async def get_vk_last_today(db: Database) -> str | None:
+    return await get_setting_value(db, "vk_last_today")
+
+
+async def set_vk_last_today(db: Database, value: str):
+    await set_setting_value(db, "vk_last_today", value)
+
+
+async def get_vk_last_added(db: Database) -> str | None:
+    return await get_setting_value(db, "vk_last_added")
+
+
+async def set_vk_last_added(db: Database, value: str):
+    await set_setting_value(db, "vk_last_added", value)
 
 
 def get_supabase_client() -> Client | None:
@@ -1392,6 +1457,29 @@ async def process_request(callback: types.CallbackQuery, db: Database, bot: Bot)
         now = datetime.now(tz) + timedelta(days=1)
         await send_daily_announcement(db, bot, cid, tz, record=False, now=now)
         await callback.answer("Sent")
+    elif data == "vkset":
+        vk_group_sessions.add(callback.from_user.id)
+        await callback.message.answer("Send VK group id or 'off'")
+        await callback.answer()
+    elif data == "vkunset":
+        await set_vk_group_id(db, None)
+        await send_daily_list(callback.message, db, bot, edit=True)
+        await callback.answer("Disabled")
+    elif data.startswith("vktime:"):
+        typ = data.split(":", 1)[1]
+        vk_time_sessions[callback.from_user.id] = typ
+        await callback.message.answer("Send new time HH:MM")
+        await callback.answer()
+    elif data.startswith("vkdailysend:"):
+        section = data.split(":", 1)[1]
+        group_id = await get_vk_group_id(db)
+        if group_id:
+            offset = await get_tz_offset(db)
+            tz = offset_to_timezone(offset)
+            await send_daily_announcement_vk(
+                db, VK_TOKEN, group_id, tz, section=section
+            )
+        await callback.answer("Sent")
 
 
 async def handle_tz(message: types.Message, db: Database, bot: Bot):
@@ -1418,6 +1506,44 @@ async def handle_images(message: types.Message, db: Database, bot: Bot):
     await set_catbox_enabled(db, new_value)
     status = "enabled" if new_value else "disabled"
     await bot.send_message(message.chat.id, f"Image uploads {status}")
+
+
+async def handle_vkgroup(message: types.Message, db: Database, bot: Bot):
+    parts = message.text.split(maxsplit=1)
+    if len(parts) != 2:
+        await bot.send_message(message.chat.id, "Usage: /vkgroup <id|off>")
+        return
+    async with db.get_session() as session:
+        user = await session.get(User, message.from_user.id)
+        if not user or not user.is_superadmin:
+            await bot.send_message(message.chat.id, "Not authorized")
+            return
+    if parts[1].lower() == "off":
+        await set_vk_group_id(db, None)
+        await bot.send_message(message.chat.id, "VK posting disabled")
+    else:
+        await set_vk_group_id(db, parts[1])
+        await bot.send_message(message.chat.id, f"VK group set to {parts[1]}")
+
+
+async def handle_vktime(message: types.Message, db: Database, bot: Bot):
+    parts = message.text.split()
+    if len(parts) != 3 or parts[1] not in {"today", "added"}:
+        await bot.send_message(message.chat.id, "Usage: /vktime today|added HH:MM")
+        return
+    async with db.get_session() as session:
+        user = await session.get(User, message.from_user.id)
+        if not user or not user.is_superadmin:
+            await bot.send_message(message.chat.id, "Not authorized")
+            return
+    if not re.match(r"^\d{2}:\d{2}$", parts[2]):
+        await bot.send_message(message.chat.id, "Invalid time format")
+        return
+    if parts[1] == "today":
+        await set_vk_time_today(db, parts[2])
+    else:
+        await set_vk_time_added(db, parts[2])
+    await bot.send_message(message.chat.id, "VK time updated")
 
 
 async def handle_my_chat_member(update: types.ChatMemberUpdated, db: Database):
@@ -1554,6 +1680,18 @@ async def send_regdaily_list(
         channels = result.scalars().all()
     lines = []
     keyboard = []
+    group_id = await get_vk_group_id(db)
+    if group_id:
+        lines.append(f"VK group {group_id}")
+        keyboard.append([
+            types.InlineKeyboardButton(text="Change", callback_data="vkset"),
+            types.InlineKeyboardButton(text="Disable", callback_data="vkunset"),
+        ])
+    else:
+        lines.append("VK group disabled")
+        keyboard.append([
+            types.InlineKeyboardButton(text="Set VK group", callback_data="vkset")
+        ])
     for ch in channels:
         name = ch.title or ch.username or str(ch.channel_id)
         lines.append(name)
@@ -1588,6 +1726,23 @@ async def send_daily_list(
         channels = result.scalars().all()
     lines = []
     keyboard = []
+    group_id = await get_vk_group_id(db)
+    if group_id:
+        t_today = await get_vk_time_today(db)
+        t_added = await get_vk_time_added(db)
+        lines.append(f"VK group {group_id} {t_today}/{t_added}")
+        keyboard.append([
+            types.InlineKeyboardButton(text="Disable", callback_data="vkunset"),
+            types.InlineKeyboardButton(text="Today", callback_data="vktime:today"),
+            types.InlineKeyboardButton(text="Added", callback_data="vktime:added"),
+            types.InlineKeyboardButton(text="Test today", callback_data="vkdailysend:today"),
+            types.InlineKeyboardButton(text="Test added", callback_data="vkdailysend:added"),
+        ])
+    else:
+        lines.append("VK group disabled")
+        keyboard.append([
+            types.InlineKeyboardButton(text="Set VK group", callback_data="vkset")
+        ])
     for ch in channels:
         name = ch.title or ch.username or str(ch.channel_id)
         t = ch.daily_time or "?"
@@ -2555,6 +2710,83 @@ def format_event_md(e: Event) -> str:
     return "\n".join(lines)
 
 
+def format_event_vk(e: Event, highlight: bool = False, weekend_url: str | None = None) -> str:
+    prefix = ""
+    if highlight:
+        prefix += "\U0001f449 "
+    if is_recent(e):
+        prefix += "\U0001f6a9 "
+    emoji_part = ""
+    if e.emoji and not e.title.strip().startswith(e.emoji):
+        emoji_part = f"{e.emoji} "
+
+    title = f"{prefix}{emoji_part}{e.title}".strip()
+    desc = re.sub(r",?\s*подробнее\s*\([^\n]*\)$", "", e.description.strip(), flags=re.I)
+    lines = [title, desc]
+
+    if e.pushkin_card:
+        lines.append("\u2705 Пушкинская карта")
+
+    if e.is_free:
+        lines.append("🟡 Бесплатно")
+        if e.ticket_link:
+            lines.append(f"по регистрации {e.ticket_link}")
+    elif e.ticket_link and (
+        e.ticket_price_min is not None or e.ticket_price_max is not None
+    ):
+        if e.ticket_price_max is not None and e.ticket_price_max != e.ticket_price_min:
+            price = f"от {e.ticket_price_min} до {e.ticket_price_max} руб."
+        else:
+            val = e.ticket_price_min if e.ticket_price_min is not None else e.ticket_price_max
+            price = f"{val} руб." if val is not None else ""
+        lines.append(f"Билеты в источнике {price}".strip())
+        lines.append(e.ticket_link)
+    elif e.ticket_link:
+        lines.append("по регистрации")
+        lines.append(e.ticket_link)
+    else:
+        price = ""
+        if (
+            e.ticket_price_min is not None
+            and e.ticket_price_max is not None
+            and e.ticket_price_min != e.ticket_price_max
+        ):
+            price = f"от {e.ticket_price_min} до {e.ticket_price_max} руб."
+        elif e.ticket_price_min is not None:
+            price = f"{e.ticket_price_min} руб."
+        elif e.ticket_price_max is not None:
+            price = f"{e.ticket_price_max} руб."
+        if price:
+            lines.append(f"Билеты {price}")
+
+    if e.telegraph_url:
+        lines.append(f"подробнее: {e.telegraph_url}")
+    if e.ics_post_url:
+        lines.append(f"\U0001f4c6 Добавить в календарь: {e.ics_post_url}")
+
+    loc = e.location_name
+    addr = e.location_address
+    if addr and e.city:
+        addr = strip_city_from_address(addr, e.city)
+    if addr:
+        loc += f", {addr}"
+    if e.city:
+        loc += f", #{e.city}"
+    date_part = e.date.split("..", 1)[0]
+    d = parse_iso_date(date_part)
+    if d:
+        day = format_day_pretty(d)
+    else:
+        logging.error("Invalid event date: %s", e.date)
+        day = e.date
+    if weekend_url and d and d.weekday() == 5:
+        day_fmt = f"{day}"
+    else:
+        day_fmt = day
+    lines.append(f"[i]{day_fmt} {e.time} {loc}[/i]")
+    return "\n".join(lines)
+
+
 def format_event_daily(
     e: Event, highlight: bool = False, weekend_url: str | None = None
 ) -> str:
@@ -2778,7 +3010,7 @@ async def get_month_data(db: Database, month: str, *, fallback: bool = True):
 
     if month == today.strftime("%Y-%m"):
         today_str = today.isoformat()
-        cutoff = (today - timedelta(days=7)).isoformat()
+        cutoff = (today - timedelta(days=30)).isoformat()
         events = [e for e in events if e.date.split("..", 1)[0] >= today_str]
         exhibitions = [
             e for e in exhibitions if e.end_date and e.end_date >= cutoff
@@ -2808,7 +3040,7 @@ async def build_month_page_content(
 
 
     today = datetime.now(LOCAL_TZ).date()
-    cutoff = (today - timedelta(days=7)).isoformat()
+    cutoff = (today - timedelta(days=30)).isoformat()
 
     if month == today.strftime("%Y-%m"):
         events = [e for e in events if e.date.split("..", 1)[0] >= cutoff]
@@ -3297,6 +3529,7 @@ async def build_daily_posts(
             elif m == next_month(cur_month):
                 next_count += 1
 
+    tag = f"{today.day}{MONTHS[today.month - 1]}"
     lines1 = [
         f"<b>АНОНС на {format_day_pretty(today)} {today.year} #ежедневныйанонс</b>",
         DAYS_OF_WEEK[today.weekday()],
@@ -3312,6 +3545,10 @@ async def build_daily_posts(
                 w_url = w.url
         lines1.append("")
         lines1.append(format_event_daily(e, highlight=True, weekend_url=w_url))
+    lines1.append("")
+    lines1.append(
+        f"#Афиша_Калининград #Калининград #концерт #{tag} #{today.day}_{MONTHS[today.month - 1]}"
+    )
     section1 = "\n".join(lines1)
 
     lines2 = ["<b><i>ДОБАВИЛИ В АНОНС</i></b>"]
@@ -3366,6 +3603,117 @@ async def build_daily_posts(
         posts.append((part, None))
     posts.append((section2_parts[-1], markup))
     return posts
+
+
+async def build_daily_sections_vk(
+    db: Database,
+    tz: timezone,
+    now: datetime | None = None,
+) -> tuple[str, str]:
+    if now is None:
+        now = datetime.now(tz)
+    today = now.date()
+    yesterday_utc = recent_cutoff(tz, now)
+    async with db.get_session() as session:
+        res_today = await session.execute(
+            select(Event)
+            .where(Event.date == today.isoformat())
+            .order_by(Event.time)
+        )
+        events_today = res_today.scalars().all()
+        res_new = await session.execute(
+            select(Event)
+            .where(
+                Event.date > today.isoformat(),
+                Event.added_at.is_not(None),
+                Event.added_at >= yesterday_utc,
+                Event.silent.is_(False),
+            )
+            .order_by(Event.date, Event.time)
+        )
+        events_new = res_new.scalars().all()
+
+        w_start = next_weekend_start(today)
+        res_w_all = await session.execute(select(WeekendPage))
+        weekend_map = {w.start: w for w in res_w_all.scalars().all()}
+
+    lines1 = [
+        f"\U0001f4c5 АНОНС на {format_day_pretty(today)} {today.year}",
+        DAYS_OF_WEEK[today.weekday()],
+        "",
+        "НЕ ПРОПУСТИТЕ СЕГОДНЯ",
+    ]
+    for e in events_today:
+        w_url = None
+        d = parse_iso_date(e.date)
+        if d and d.weekday() == 5:
+            w = weekend_map.get(d.isoformat())
+            if w:
+                w_url = w.url
+        lines1.append("")
+        lines1.append(format_event_vk(e, highlight=True, weekend_url=w_url))
+        lines1.append("")
+    lines1.append("")
+    lines1.append(
+        f"#Афиша_Калининград #кудапойти_Калининград #Калининград #39region #концерт #{today.day}{MONTHS[today.month - 1]}"
+    )
+    section1 = "\n".join(lines1)
+
+    lines2 = ["ДОБАВИЛИ В АНОНС"]
+    for e in events_new:
+        w_url = None
+        d = parse_iso_date(e.date)
+        if d and d.weekday() == 5:
+            w = weekend_map.get(d.isoformat())
+            if w:
+                w_url = w.url
+        lines2.append("")
+        lines2.append(format_event_vk(e, weekend_url=w_url))
+        lines2.append("")
+    lines2.append("")
+    lines2.append(
+        f"#события_Калининград #Калининград #39region #новое #фестиваль #{today.day}{MONTHS[today.month - 1]}"
+    )
+    section2 = "\n".join(lines2)
+
+    return section1, section2
+
+
+async def post_to_vk(token: str, group_id: str, message: str):
+    if not token or not group_id:
+        return
+    url = "https://api.vk.com/method/wall.post"
+    params = {
+        "owner_id": f"-{group_id.lstrip('-')}",
+        "from_group": 1,
+        "message": message,
+        "access_token": token,
+        "v": "5.131",
+    }
+    async with create_ipv4_session(ClientSession) as session:
+        async with session.post(url, data=params) as resp:
+            data = await resp.json()
+            if "error" in data:
+                raise RuntimeError(f"VK error: {data['error']}")
+
+
+async def send_daily_announcement_vk(
+    db: Database,
+    token: str,
+    group_id: str,
+    tz: timezone,
+    *,
+    section: str,
+    now: datetime | None = None,
+):
+    section1, section2 = await build_daily_sections_vk(db, tz, now)
+    if section == "today":
+        await post_to_vk(token, group_id, section1)
+    elif section == "added":
+        await post_to_vk(token, group_id, section2)
+    else:
+        await post_to_vk(token, group_id, section1)
+        await post_to_vk(token, group_id, section2)
 
 
 async def send_daily_announcement(
@@ -3425,6 +3773,40 @@ async def daily_scheduler(db: Database, bot: Bot):
                     await send_daily_announcement(db, bot, ch.channel_id, tz)
                 except Exception as e:
                     logging.error("daily send failed for %s: %s", ch.channel_id, e)
+        await asyncio.sleep(60)
+
+
+async def vk_scheduler(db: Database):
+    if not VK_TOKEN:
+        return
+    while True:
+        group_id = await get_vk_group_id(db)
+        if not group_id:
+            await asyncio.sleep(60)
+            continue
+        offset = await get_tz_offset(db)
+        tz = offset_to_timezone(offset)
+        now = datetime.now(tz)
+        now_time = now.time().replace(second=0, microsecond=0)
+        today_time = datetime.strptime(await get_vk_time_today(db), "%H:%M").time()
+        added_time = datetime.strptime(await get_vk_time_added(db), "%H:%M").time()
+
+        last_today = await get_vk_last_today(db)
+        if (last_today or "") != now.date().isoformat() and now_time >= today_time:
+            try:
+                await send_daily_announcement_vk(db, VK_TOKEN, group_id, tz, section="today")
+                await set_vk_last_today(db, now.date().isoformat())
+            except Exception as e:
+                logging.error("vk daily today failed: %s", e)
+
+        last_added = await get_vk_last_added(db)
+        if (last_added or "") != now.date().isoformat() and now_time >= added_time:
+            try:
+                await send_daily_announcement_vk(db, VK_TOKEN, group_id, tz, section="added")
+                await set_vk_last_added(db, now.date().isoformat())
+            except Exception as e:
+                logging.error("vk daily added failed: %s", e)
+
         await asyncio.sleep(60)
 
 
@@ -3566,7 +3948,7 @@ async def build_events_message(db: Database, target_date: date, tz: timezone):
 
 async def build_exhibitions_message(db: Database, tz: timezone):
     today = datetime.now(tz).date()
-    cutoff = (today - timedelta(days=7)).isoformat()
+    cutoff = (today - timedelta(days=30)).isoformat()
     async with db.get_session() as session:
         result = await session.execute(
             select(Event)
@@ -4063,6 +4445,37 @@ async def handle_daily_time_message(message: types.Message, db: Database, bot: B
             ch.daily_time = value
             await session.commit()
     del daily_time_sessions[message.from_user.id]
+    await bot.send_message(message.chat.id, f"Time set to {value}")
+
+
+async def handle_vk_group_message(message: types.Message, db: Database, bot: Bot):
+    if message.from_user.id not in vk_group_sessions:
+        return
+    value = (message.text or "").strip()
+    if value.lower() == "off":
+        await set_vk_group_id(db, None)
+        await bot.send_message(message.chat.id, "VK posting disabled")
+    else:
+        await set_vk_group_id(db, value)
+        await bot.send_message(message.chat.id, f"VK group set to {value}")
+    vk_group_sessions.discard(message.from_user.id)
+
+
+async def handle_vk_time_message(message: types.Message, db: Database, bot: Bot):
+    typ = vk_time_sessions.get(message.from_user.id)
+    if not typ:
+        return
+    value = (message.text or "").strip()
+    if not re.match(r"^\d{1,2}:\d{2}$", value):
+        await bot.send_message(message.chat.id, "Invalid time")
+        return
+    if len(value.split(":")[0]) == 1:
+        value = f"0{value}"
+    if typ == "today":
+        await set_vk_time_today(db, value)
+    else:
+        await set_vk_time_added(db, value)
+    vk_time_sessions.pop(message.from_user.id, None)
     await bot.send_message(message.chat.id, f"Time set to {value}")
 
 
@@ -4563,6 +4976,12 @@ def create_app() -> web.Application:
     async def daily_time_wrapper(message: types.Message):
         await handle_daily_time_message(message, db, bot)
 
+    async def vk_group_msg_wrapper(message: types.Message):
+        await handle_vk_group_message(message, db, bot)
+
+    async def vk_time_msg_wrapper(message: types.Message):
+        await handle_vk_time_message(message, db, bot)
+
     async def forward_wrapper(message: types.Message):
         await handle_forwarded(message, db, bot)
 
@@ -4574,6 +4993,12 @@ def create_app() -> web.Application:
 
     async def images_wrapper(message: types.Message):
         await handle_images(message, db, bot)
+
+    async def vkgroup_wrapper(message: types.Message):
+        await handle_vkgroup(message, db, bot)
+
+    async def vktime_wrapper(message: types.Message):
+        await handle_vktime(message, db, bot)
 
     dp.message.register(start_wrapper, Command("start"))
     dp.message.register(register_wrapper, Command("register"))
@@ -4596,6 +5021,10 @@ def create_app() -> web.Application:
         or c.data.startswith("dailytime:")
         or c.data.startswith("dailysend:")
         or c.data.startswith("dailysendtom:")
+        or c.data == "vkset"
+        or c.data == "vkunset"
+        or c.data.startswith("vktime:")
+        or c.data.startswith("vkdailysend:")
         or c.data.startswith("togglefree:")
         or c.data.startswith("markfree:")
         or c.data.startswith("togglesilent:")
@@ -4609,6 +5038,8 @@ def create_app() -> web.Application:
     dp.message.register(list_events_wrapper, Command("events"))
     dp.message.register(set_channel_wrapper, Command("setchannel"))
     dp.message.register(images_wrapper, Command("images"))
+    dp.message.register(vkgroup_wrapper, Command("vkgroup"))
+    dp.message.register(vktime_wrapper, Command("vktime"))
     dp.message.register(channels_wrapper, Command("channels"))
     dp.message.register(reg_daily_wrapper, Command("regdailychannels"))
     dp.message.register(daily_wrapper, Command("daily"))
@@ -4622,6 +5053,12 @@ def create_app() -> web.Application:
     )
     dp.message.register(
         daily_time_wrapper, lambda m: m.from_user.id in daily_time_sessions
+    )
+    dp.message.register(
+        vk_group_msg_wrapper, lambda m: m.from_user.id in vk_group_sessions
+    )
+    dp.message.register(
+        vk_time_msg_wrapper, lambda m: m.from_user.id in vk_time_sessions
     )
     dp.message.register(
         forward_wrapper,
@@ -4650,6 +5087,7 @@ def create_app() -> web.Application:
         except Exception as e:
             logging.error("Failed to set webhook: %s", e)
         app["daily_task"] = asyncio.create_task(daily_scheduler(db, bot))
+        app["vk_task"] = asyncio.create_task(vk_scheduler(db))
         app["cleanup_task"] = asyncio.create_task(cleanup_scheduler(db, bot))
 
     async def on_shutdown(app: web.Application):
@@ -4658,6 +5096,10 @@ def create_app() -> web.Application:
             app["daily_task"].cancel()
             with contextlib.suppress(Exception):
                 await app["daily_task"]
+        if "vk_task" in app:
+            app["vk_task"].cancel()
+            with contextlib.suppress(Exception):
+                await app["vk_task"]
         if "cleanup_task" in app:
             app["cleanup_task"].cancel()
             with contextlib.suppress(Exception):


### PR DESCRIPTION
## Summary
- integrate VK group management into `/daily` and `/regdailychannels`
- support editing VK times and sending test posts via callback buttons
- append hashtag lines to Telegram and VK daily announcements
- document VK options in daily menus
- refine VK daily post formatting

## Testing
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68874349ff5483328c084cf5305d2773