### PR TITLE
Add VK settings to daily menus

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,4 +69,36 @@
 - Daily announcements no longer append a "подробнее" link to the event's
   Telegraph page.
 
+## v0.3.9 - VK daily announcements
+
+- Daily announcements can be posted to a VK group. Set the group with `/vkgroup` and adjust
+  times via `/vktime`. Use the `VK_TOKEN` secret for API access.
+
+## v0.3.10 - Unified daily management
+
+- `/regdailychannels` and `/daily` now show the VK group alongside Telegram channels.
+  VK posting times can be changed there and test posts sent.
+- Daily announcements include new hashtag lines for Telegram and VK posts.
+
+## v0.3.11 - VK formatting tweaks
+
+- VK daily posts show a calendar icon before "АНОНС" and include more spacing between events.
+- Date, time and location are italicized if supported.
+- Prices include `руб.` and ticket links move to the next line.
+- The "подробнее" line now ends with a colon and calendar links appear on their own line as
+  "📆 Добавить в календарь: <link>".
+
+## v0.3.12 - VK announcement fixes
+
+- Remove unsupported italic tags and calendar line from VK posts.
+- Event titles appear in uppercase and the "подробнее" link follows the
+  description.
+- A visible separator line now divides events to improve readability.
+
+## v0.3.13 - VK formatting updates
+
+- VK posts use two blank separator lines built with the blank braille symbol.
+- Ticket links show a ticket emoji before the URL.
+- Date lines start with a calendar emoji and the location line with a location pin.
+
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Events Bot
 
-Telegram bot for publishing event announcements.
+Telegram bot for publishing event announcements. Daily announcements can also be posted to a VK group.
+Use `/regdailychannels` and `/daily` to manage both Telegram channels and the VK group including posting times.
 
 This is an MVP using **aiogram 3** and SQLite. It is designed for deployment on
 Fly.io with a webhook.
@@ -38,6 +39,8 @@ browse upcoming announcements. The command accepts dates like `2025-07-10`,
   # Optional: provide Telegraph token. If omitted, the bot creates an account
   # automatically and saves the token to /data/telegraph_token.txt.
   export TELEGRAPH_TOKEN=your_telegraph_token
+  # Optional: post daily announcements to VK
+  export VK_TOKEN=vk_access_token
   python main.py
    ```
 
@@ -57,10 +60,12 @@ browse upcoming announcements. The command accepts dates like `2025-07-10`,
     fly secrets set DB_PATH=/data/db.sqlite
     # Optional: enable calendar files
     fly secrets set SUPABASE_URL=https://<project>.supabase.co
-    fly secrets set SUPABASE_KEY=service_role_key
+   fly secrets set SUPABASE_KEY=service_role_key
    # Optional: use your own Telegraph token. If not set, a new account will be
    # created on first run and the token saved to the data volume.
    fly secrets set TELEGRAPH_TOKEN=<token>
+   # Optional: post daily announcements to VK
+   fly secrets set VK_TOKEN=<token>
    ```
 3. Deploy:
    ```bash

--- a/docs/COMMANDS.md
+++ b/docs/COMMANDS.md
@@ -9,12 +9,14 @@
 | `/addevent <text>` | event description | Parse text with model 4o and store one or several events. The original text is published to Telegraph. Images up to 5&nbsp;MB are uploaded to Catbox and shown on that page. Forwarded messages from moderators are processed the same way. |
 | `/addevent_raw <title>|<date>|<time>|<location>` | manual fields | Add event without LLM. The bot also creates a Telegraph page with the provided text and optional attached photo. |
 | `/images` | - | Toggle uploading photos to Catbox. |
+| `/vkgroup <id|off>` | required id or `off` | Set or disable VK group for daily announcements. |
+| `/vktime today|added <HH:MM>` | required type and time | Change VK posting times (default 08:00/20:00). |
 | `/ask4o <text>` | any text | Send query to model 4o and show plain response (superadmin only). |
 | `/events [DATE]` | optional date `YYYY-MM-DD`, `DD.MM.YYYY` or `D месяц [YYYY]` | List events for the day with delete and edit buttons. Dates are shown as `DD.MM.YYYY`. Choosing **Edit** lists all fields with inline buttons including a toggle for "Бесплатно". |
 | `/setchannel` | - | Choose an admin channel and register it as an announcement or calendar asset source. |
 | `/channels` | - | List admin channels showing registered and asset ones with disable buttons. |
-| `/regdailychannels` | - | Choose admin channels for daily announcements (default 08:00). |
-| `/daily` | - | Manage daily announcement channels: cancel, change time, test send. |
+| `/regdailychannels` | - | Choose admin channels for daily announcements and set the VK group. |
+| `/daily` | - | Manage daily announcement channels and VK posting times; send test posts. |
 | `/exhibitions` | - | List active exhibitions similar to `/events`; each entry shows the period `c <start>` / `по <end>` and includes edit/delete buttons. |
 | `/pages` | - | Show links to Telegraph month and weekend pages. |
 


### PR DESCRIPTION
## Summary
- integrate VK group management into `/daily` and `/regdailychannels`
- support editing VK times and sending test posts via callback buttons
- append hashtag lines to Telegram and VK daily announcements
- document VK options in daily menus
- refine VK daily post formatting
- remove unsupported italic formatting in VK posts, skip calendar lines
- add uppercase titles and emoji separators for VK events
- refine VK daily formatting with calendar/location icons, ticket emoji, and blank separators
- add blank separator constant and show event page links before hashtags in VK daily posts
- insert a blank line after the "Добавили в анонс" heading

## Testing
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68874349ff5483328c084cf5305d2773