### PR TITLE
Support VK wall links for details

### DIFF
--- a/tests/test_bot.py
+++ b/tests/test_bot.py
@@ -3296,6 +3296,38 @@ async def test_multiple_ticket_links(tmp_path: Path, monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_add_event_lines_include_vk_link(tmp_path: Path, monkeypatch):
+    db = Database(str(tmp_path / "db.sqlite"))
+    await db.init()
+
+    async def fake_parse(text: str) -> list[dict]:
+        return [
+            {
+                "title": "T",
+                "short_description": "d",
+                "date": FUTURE_DATE,
+                "time": "18:00",
+                "location_name": "Hall",
+            }
+        ]
+
+    async def fake_create(title, text, source, html_text=None, media=None, ics_url=None, db=None):
+        return "https://t.me/page", "p"
+
+    monkeypatch.setattr("main.parse_event_via_4o", fake_parse)
+    monkeypatch.setattr("main.create_source_page", fake_create)
+
+    results = await main.add_events_from_text(
+        db, "text", "https://vk.com/wall-1_1", None, None
+    )
+    assert results
+    lines = results[0][2]
+    assert "telegraph: https://t.me/page" in lines
+    idx = lines.index("telegraph: https://t.me/page")
+    assert lines[idx + 1] == "Vk: https://vk.com/wall-1_1"
+
+
+@pytest.mark.asyncio
 async def test_add_event_strips_city_from_address(tmp_path: Path, monkeypatch):
     db = Database(str(tmp_path / "db.sqlite"))
     await db.init()
@@ -3763,6 +3795,37 @@ async def test_daily_no_more_link(tmp_path: Path, monkeypatch):
     posts = await main.build_daily_posts(db, timezone.utc)
     text = posts[0][0]
     assert "подробнее" not in text
+
+
+def test_format_event_vk_with_vk_link():
+    e = Event(
+        title="T",
+        description="d",
+        source_text="s",
+        date="2025-07-10",
+        time="18:00",
+        location_name="Hall",
+        source_post_url="https://vk.com/wall-1_1",
+        telegraph_url="https://t.me/page",
+    )
+    text = main.format_event_vk(e)
+    assert "[подробнее|https://vk.com/wall-1_1]" in text
+    assert "t.me/page" not in text
+
+
+def test_format_event_vk_fallback_link():
+    e = Event(
+        title="T",
+        description="d",
+        source_text="s",
+        date="2025-07-10",
+        time="18:00",
+        location_name="Hall",
+        source_post_url="https://vk.cc/abc",
+        telegraph_url="https://t.me/page",
+    )
+    text = main.format_event_vk(e)
+    assert "[подробнее|https://t.me/page]" in text
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- add `is_vk_wall_url` helper
- use VK wall links in `format_event_vk`
- test new VK link behaviour
- show VK link when creating events

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688896f614008332930c498759020e00