### PR TITLE
Support channel names in LLM requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -105,5 +105,10 @@
 
 - Removed the "Мероприятия на" prefix from month and weekend links in VK daily posts.
 
+## v0.3.15 - Channel name context
+
+- Forwarded messages include the Telegram channel title in 4o requests so the
+  model can infer the venue.
+
 
 

--- a/docs/FOUR_O_REQUEST.md
+++ b/docs/FOUR_O_REQUEST.md
@@ -26,6 +26,9 @@ The response must be JSON with the fields listed in `docs/PROMPTS.md`. When the
 text describes multiple events, return an array of such objects.
 The prefix "Today is YYYY-MM-DD." helps the model infer the correct year for
 dates that omit it and lets the model ignore any events scheduled before today.
+When a post is forwarded from a Telegram channel, the channel title is added
+before the announcement text as `Channel: <name>.` so the model can guess the
+venue.
 Edit this file or `docs/PROMPTS.md` to fine‑tune the request details.
 
 The command `/ask4o <text>` sends an arbitrary user message to the same

--- a/tests/test_bot.py
+++ b/tests/test_bot.py
@@ -933,7 +933,7 @@ async def test_addevent_caption_photo(tmp_path: Path, monkeypatch):
     await db.init()
     bot = DummyBot("123:abc")
 
-    async def fake_parse(text: str) -> list[dict]:
+    async def fake_parse(text: str, source_channel: str | None = None) -> list[dict]:
         return [
             {
                 "title": "T",
@@ -982,7 +982,7 @@ async def test_addevent_strips_command(tmp_path: Path, monkeypatch):
     await db.init()
     bot = DummyBot("123:abc")
 
-    async def fake_parse(text: str) -> list[dict]:
+    async def fake_parse(text: str, source_channel: str | None = None) -> list[dict]:
         return [
             {
                 "title": "T",
@@ -1025,7 +1025,7 @@ async def test_forward_add_event(tmp_path: Path, monkeypatch):
     await db.init()
     bot = DummyBot("123:abc")
 
-    async def fake_parse(text: str) -> list[dict]:
+    async def fake_parse(text: str, source_channel: str | None = None) -> list[dict]:
         return [
             {
                 "title": "Forwarded",
@@ -1083,12 +1083,76 @@ async def test_forward_add_event(tmp_path: Path, monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_forward_passes_channel_name(tmp_path: Path, monkeypatch):
+    db = Database(str(tmp_path / "db.sqlite"))
+    await db.init()
+    bot = DummyBot("123:abc")
+
+    captured = {}
+
+    async def fake_parse(text: str, source_channel: str | None = None) -> list[dict]:
+        captured["chan"] = source_channel
+        return [
+            {
+                "title": "Forwarded",
+                "short_description": "desc",
+                "date": FUTURE_DATE,
+                "time": "18:00",
+                "location_name": "Club",
+            }
+        ]
+
+    monkeypatch.setattr("main.parse_event_via_4o", fake_parse)
+
+    async def fake_create(*args, **kwargs):
+        return "u", "p"
+
+    monkeypatch.setattr("main.create_source_page", fake_create)
+
+    start_msg = types.Message.model_validate(
+        {
+            "message_id": 1,
+            "date": 0,
+            "chat": {"id": 1, "type": "private"},
+            "from": {"id": 1, "is_bot": False, "first_name": "A"},
+            "text": "/start",
+        }
+    )
+    await handle_start(start_msg, db, bot)
+
+    upd = DummyUpdate(-100123, "Chan")
+    await main.handle_my_chat_member(upd, db)
+
+    async with db.get_session() as session:
+        ch = await session.get(main.Channel, -100123)
+        ch.is_registered = True
+        await session.commit()
+
+    fwd_msg = types.Message.model_validate(
+        {
+            "message_id": 3,
+            "date": 0,
+            "forward_date": 0,
+            "forward_from_chat": {"id": -100123, "type": "channel", "title": "Chan"},
+            "forward_from_message_id": 10,
+            "chat": {"id": 1, "type": "private"},
+            "from": {"id": 1, "is_bot": False, "first_name": "A"},
+            "text": "Some text",
+        }
+    )
+
+    await main.handle_forwarded(fwd_msg, db, bot)
+
+    assert captured["chan"] == "Chan"
+
+
+@pytest.mark.asyncio
 async def test_forward_add_event_origin(tmp_path: Path, monkeypatch):
     db = Database(str(tmp_path / "db.sqlite"))
     await db.init()
     bot = DummyBot("123:abc")
 
-    async def fake_parse(text: str) -> list[dict]:
+    async def fake_parse(text: str, source_channel: str | None = None) -> list[dict]:
         return [
             {
                 "title": "Forwarded",
@@ -1154,7 +1218,7 @@ async def test_forward_add_event_photo(tmp_path: Path, monkeypatch):
     await db.init()
     bot = DummyBot("123:abc")
 
-    async def fake_parse(text: str) -> list[dict]:
+    async def fake_parse(text: str, source_channel: str | None = None) -> list[dict]:
         return [
             {
                 "title": "Forwarded",
@@ -1225,7 +1289,7 @@ async def test_forward_unregistered(tmp_path: Path, monkeypatch):
     await db.init()
     bot = DummyBot("123:abc")
 
-    async def fake_parse(text: str) -> list[dict]:
+    async def fake_parse(text: str, source_channel: str | None = None) -> list[dict]:
         return [
             {
                 "title": "Fwd",
@@ -1283,7 +1347,7 @@ async def test_media_group_caption_first(tmp_path: Path, monkeypatch):
     await db.init()
     bot = DummyBot("123:abc")
 
-    async def fake_parse(text: str) -> list[dict]:
+    async def fake_parse(text: str, source_channel: str | None = None) -> list[dict]:
         return [
             {
                 "title": "MG",
@@ -1361,7 +1425,7 @@ async def test_media_group_caption_last(tmp_path: Path, monkeypatch):
     await db.init()
     bot = DummyBot("123:abc")
 
-    async def fake_parse(text: str) -> list[dict]:
+    async def fake_parse(text: str, source_channel: str | None = None) -> list[dict]:
         return [
             {
                 "title": "MG",
@@ -1556,7 +1620,7 @@ async def test_exhibition_listing(tmp_path: Path, monkeypatch):
     )
     await handle_start(start_msg, db, bot)
 
-    async def fake_parse(text: str) -> list[dict]:
+    async def fake_parse(text: str, source_channel: str | None = None) -> list[dict]:
         return [
             {
                 "title": "Expo",
@@ -1649,7 +1713,7 @@ async def test_multiple_events(tmp_path: Path, monkeypatch):
     )
     await handle_start(start_msg, db, bot)
 
-    async def fake_parse(text: str) -> list[dict]:
+    async def fake_parse(text: str, source_channel: str | None = None) -> list[dict]:
         return [
             {
                 "title": "One",
@@ -2422,7 +2486,7 @@ async def test_date_range_parsing(tmp_path: Path, monkeypatch):
     await db.init()
     bot = DummyBot("123:abc")
 
-    async def fake_parse(text: str) -> list[dict]:
+    async def fake_parse(text: str, source_channel: str | None = None) -> list[dict]:
         return [
             {
                 "title": "Expo",
@@ -2899,7 +2963,7 @@ async def test_update_event_description_from_telegraph(tmp_path: Path, monkeypat
         session.add(event)
         await session.commit()
 
-    async def fake_parse(text: str) -> list[dict]:
+    async def fake_parse(text: str, source_channel: str | None = None) -> list[dict]:
         assert "first" in text and "second" in text
         return [
             {
@@ -3154,7 +3218,7 @@ async def test_extract_ticket_link(tmp_path: Path, monkeypatch):
     await db.init()
     bot = DummyBot("123:abc")
 
-    async def fake_parse(text: str) -> list[dict]:
+    async def fake_parse(text: str, source_channel: str | None = None) -> list[dict]:
         return [
             {
                 "title": "T",
@@ -3187,7 +3251,7 @@ async def test_extract_ticket_link_near_word(tmp_path: Path, monkeypatch):
     await db.init()
     bot = DummyBot("123:abc")
 
-    async def fake_parse(text: str) -> list[dict]:
+    async def fake_parse(text: str, source_channel: str | None = None) -> list[dict]:
         return [
             {
                 "title": "T",
@@ -3220,7 +3284,7 @@ async def test_ticket_link_overrides_invalid(tmp_path: Path, monkeypatch):
     await db.init()
     bot = DummyBot("123:abc")
 
-    async def fake_parse(text: str) -> list[dict]:
+    async def fake_parse(text: str, source_channel: str | None = None) -> list[dict]:
         return [
             {
                 "title": "T",
@@ -3253,7 +3317,7 @@ async def test_multiple_ticket_links(tmp_path: Path, monkeypatch):
     await db.init()
     bot = DummyBot("123:abc")
 
-    async def fake_parse(text: str) -> list[dict]:
+    async def fake_parse(text: str, source_channel: str | None = None) -> list[dict]:
         return [
             {
                 "title": "A",
@@ -3300,7 +3364,7 @@ async def test_add_event_strips_city_from_address(tmp_path: Path, monkeypatch):
     db = Database(str(tmp_path / "db.sqlite"))
     await db.init()
 
-    async def fake_parse(text: str) -> list[dict]:
+    async def fake_parse(text: str, source_channel: str | None = None) -> list[dict]:
         return [
             {
                 "title": "Show",
@@ -3331,7 +3395,7 @@ async def test_festival_expands_dates(tmp_path: Path, monkeypatch):
     db = Database(str(tmp_path / "db.sqlite"))
     await db.init()
 
-    async def fake_parse(text: str) -> list[dict]:
+    async def fake_parse(text: str, source_channel: str | None = None) -> list[dict]:
         return [
             {
                 "title": "Jazz",
@@ -3432,7 +3496,7 @@ async def test_exhibition_auto_year_end(tmp_path: Path, monkeypatch):
     db = Database(str(tmp_path / "db.sqlite"))
     await db.init()
 
-    async def fake_parse(text: str) -> list[dict]:
+    async def fake_parse(text: str, source_channel: str | None = None) -> list[dict]:
         return [
             {
                 "title": "AutoExpo",
@@ -3989,7 +4053,7 @@ async def test_forward_adds_calendar_button(tmp_path: Path, monkeypatch):
 
     monkeypatch.setattr(DummyBot, "send_document", fake_send_document, raising=False)
 
-    async def fake_parse(text):
+    async def fake_parse(text, source_channel=None):
         return [
             {
                 "title": "T",


### PR DESCRIPTION
## Summary
- add `source_channel` argument for LLM parsing
- pass channel title from forwarded messages
- document updated 4o request format
- record update in changelog
- adjust tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688899f40678833298c4545195397572