### PR TITLE
Support channel names in LLM requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -105,5 +105,12 @@
 
 - Removed the "Мероприятия на" prefix from month and weekend links in VK daily posts.
 
+## v0.3.15 - Channel name context
+
+- Forwarded messages include the Telegram channel title in 4o requests so the
+  model can infer the venue.
+- `parse_event_via_4o` also accepts the legacy `channel_title` argument for
+  compatibility.
+
 
 

--- a/docs/FOUR_O_REQUEST.md
+++ b/docs/FOUR_O_REQUEST.md
@@ -26,6 +26,9 @@ The response must be JSON with the fields listed in `docs/PROMPTS.md`. When the
 text describes multiple events, return an array of such objects.
 The prefix "Today is YYYY-MM-DD." helps the model infer the correct year for
 dates that omit it and lets the model ignore any events scheduled before today.
+When a post is forwarded from a Telegram channel, the channel title is added
+before the announcement text as `Channel: <name>.` so the model can guess the
+venue.
 Edit this file or `docs/PROMPTS.md` to fine‑tune the request details.
 
 The command `/ask4o <text>` sends an arbitrary user message to the same

--- a/main.py
+++ b/main.py
@@ -984,7 +984,11 @@ async def remove_calendar_button(event: Event, bot: Bot):
         logging.error("failed to remove calendar button: %s", e)
 
 
-async def parse_event_via_4o(text: str) -> list[dict]:
+async def parse_event_via_4o(
+    text: str,
+    source_channel: str | None = None,
+    **extra: str | None,
+) -> list[dict]:
     token = os.getenv("FOUR_O_TOKEN")
     if not token:
         raise RuntimeError("FOUR_O_TOKEN is missing")
@@ -1004,12 +1008,18 @@ async def parse_event_via_4o(text: str) -> list[dict]:
         "Authorization": f"Bearer {token}",
         "Content-Type": "application/json",
     }
+    if not source_channel:
+        source_channel = extra.get("channel_title")
     today = datetime.now(LOCAL_TZ).date().isoformat()
+    user_msg = f"Today is {today}. "
+    if source_channel:
+        user_msg += f"Channel: {source_channel}. "
+    user_msg += text
     payload = {
         "model": "gpt-4o",
         "messages": [
             {"role": "system", "content": prompt},
-            {"role": "user", "content": f"Today is {today}. {text}"},
+            {"role": "user", "content": user_msg},
         ],
         "temperature": 0,
     }
@@ -2167,6 +2177,7 @@ async def add_events_from_text(
     source_chat_id: int | None = None,
     source_message_id: int | None = None,
     creator_id: int | None = None,
+    source_channel: str | None = None,
 
     bot: Bot | None = None,
 
@@ -2176,7 +2187,7 @@ async def add_events_from_text(
     )
     try:
         logging.info("LLM parse start (%d chars)", len(text))
-        parsed = await parse_event_via_4o(text)
+        parsed = await parse_event_via_4o(text, source_channel)
         logging.info("LLM returned %d events", len(parsed))
     except Exception as e:
         logging.error("LLM error: %s", e)
@@ -2433,6 +2444,7 @@ async def handle_add_event(message: types.Message, db: Database, bot: Bot):
             media,
             raise_exc=True,
             creator_id=creator_id,
+            source_channel=None,
             bot=bot,
         )
     except Exception as e:
@@ -4814,10 +4826,12 @@ async def handle_forwarded(message: types.Message, db: Database, bot: Bot):
     link = None
     msg_id = None
     chat_id: int | None = None
+    channel_name: str | None = None
     if message.forward_from_chat and message.forward_from_message_id:
         chat = message.forward_from_chat
         msg_id = message.forward_from_message_id
         chat_id = chat.id
+        channel_name = chat.title or getattr(chat, "username", None)
         async with db.get_session() as session:
             ch = await session.get(Channel, chat_id)
             allowed = ch.is_registered if ch else False
@@ -4838,6 +4852,7 @@ async def handle_forwarded(message: types.Message, db: Database, bot: Bot):
             chat_data = fo.get("chat") or {}
             chat_id = chat_data.get("id")
             msg_id = fo.get("message_id")
+            channel_name = chat_data.get("title") or chat_data.get("username")
             async with db.get_session() as session:
                 ch = await session.get(Channel, chat_id)
                 allowed = ch.is_registered if ch else False
@@ -4865,6 +4880,7 @@ async def handle_forwarded(message: types.Message, db: Database, bot: Bot):
         source_chat_id=chat_id if link else None,
         source_message_id=msg_id if link else None,
         creator_id=user.user_id,
+        source_channel=channel_name,
 
         bot=bot,
 


### PR DESCRIPTION
## Summary
- add source_channel arg for LLM parsing
- pass channel title from forwarded messages
- document updated 4o request format
- handle legacy `channel_title` param in `parse_event_via_4o`
- record update in changelog
- adjust tests

## Testing
- `pytest tests/test_bot.py::test_parse_event_alias_channel_title tests/test_bot.py::test_forward_passes_channel_name -q`


------
https://chatgpt.com/codex/tasks/task_e_688899f40678833298c4545195397572