### PR TITLE
Add added events count to daily VK and TG posts

### DIFF
--- a/main.py
+++ b/main.py
@@ -3800,7 +3800,7 @@ async def build_daily_posts(
     )
     section1 = "\n".join(lines1)
 
-    lines2 = ["<b><i>ДОБАВИЛИ В АНОНС</i></b>"]
+    lines2 = [f"<b><i>+{len(events_new)} ДОБАВИЛИ В АНОНС</i></b>"]
     for e in events_new:
         w_url = None
         d = parse_iso_date(e.date)
@@ -3981,7 +3981,7 @@ async def build_daily_sections_vk(
     )
     section1 = "\n".join(lines1)
 
-    lines2 = ["ДОБАВИЛИ В АНОНС", VK_BLANK_LINE]
+    lines2 = [f"+{len(events_new)} ДОБАВИЛИ В АНОНС", VK_BLANK_LINE]
     for e in events_new:
         w_url = None
         d = parse_iso_date(e.date)


### PR DESCRIPTION
## Summary
- include added events count in Telegram daily post header
- include added events count in VK daily post header

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6888d589ff6883328eebf203b804cd8f