### PR TITLE
Implement nightly Telegraph page cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -120,6 +120,10 @@
 - Festival pages automatically include an LLM-generated description and can be
   edited or deleted via `/fest`.
 
+## v0.3.17 - Telegraph cleanup
+
+- Month and weekend pages refresh at 01:00 local time to drop past events.
+
 
 
 

--- a/tests/test_bot.py
+++ b/tests/test_bot.py
@@ -4774,6 +4774,47 @@ async def test_cleanup_scheduler_notifies_superadmin(tmp_path: Path, monkeypatch
 
 
 @pytest.mark.asyncio
+async def test_page_update_scheduler(tmp_path: Path, monkeypatch):
+    db = Database(str(tmp_path / "db.sqlite"))
+    await db.init()
+
+    called = {}
+
+    async def fake_month(db_obj, month):
+        called["month"] = month
+
+    async def fake_weekend(db_obj, start, update_links=True):
+        called["weekend"] = start
+
+    monkeypatch.setattr(main, "sync_month_page", fake_month)
+    monkeypatch.setattr(main, "sync_weekend_page", fake_weekend)
+
+    class FakeDate(date):
+        @classmethod
+        def today(cls):
+            return date(2025, 7, 6)  # Sunday
+
+    class FakeDatetime(datetime):
+        @classmethod
+        def now(cls, tz=None):
+            return datetime(2025, 7, 6, 1, 5, tzinfo=tz)
+
+    monkeypatch.setattr(main, "date", FakeDate)
+    monkeypatch.setattr(main, "datetime", FakeDatetime)
+
+    async def fake_sleep(*args, **kwargs):
+        raise asyncio.CancelledError
+
+    monkeypatch.setattr(asyncio, "sleep", fake_sleep)
+
+    with pytest.raises(asyncio.CancelledError):
+        await main.page_update_scheduler(db)
+
+    assert called.get("month") == "2025-07"
+    assert called.get("weekend") == "2025-07-05"
+
+
+@pytest.mark.asyncio
 async def test_dumpdb(tmp_path: Path, monkeypatch):
     db = Database(str(tmp_path / "db.sqlite"))
     await db.init()


### PR DESCRIPTION
## Summary
- refresh current month and weekend Telegraph pages at 01:00
- run the new scheduler on startup/shutdown
- link to the new feature in `CHANGELOG.md`
- test that the scheduler calls page update functions

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688a9d584b848332b3fc276f899cb47c