### PR TITLE
Add festival logging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -112,6 +112,14 @@
 - `parse_event_via_4o` also accepts the legacy `channel_title` argument for
   compatibility.
 
+## v0.3.16 - Festival pages
+
+- Added a `Festival` model and `/fest` command for listing festivals.
+- Daily announcements now show festival links.
+- Logged festival-related actions including page creation and edits.
+- Festival pages automatically include an LLM-generated description and can be
+  edited or deleted via `/fest`.
+
 
 
 

--- a/docs/COMMANDS.md
+++ b/docs/COMMANDS.md
@@ -19,6 +19,7 @@
 | `/daily` | - | Manage daily announcement channels and VK posting times; send test posts. |
 | `/exhibitions` | - | List active exhibitions similar to `/events`; each entry shows the period `c <start>` / `по <end>` and includes edit/delete buttons. |
 | `/pages` | - | Show links to Telegraph month and weekend pages. |
+| `/fest` | - | List festivals with edit/delete options; send a new description after tapping **Edit**. |
 
 | `/stats [events]` | optional `events` | Superadmin only. Show Telegraph view counts starting from the past month and weekend pages up to all current and future ones. Use `events` to list event page stats. |
 | `/dumpdb` | - | Superadmin only. Download a SQL dump of the database and see restore instructions. |

--- a/main.py
+++ b/main.py
@@ -29,6 +29,7 @@ import html
 from io import BytesIO
 import markdown
 from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
+from sqlalchemy import update
 from sqlmodel import Field, SQLModel, select
 import aiosqlite
 
@@ -83,6 +84,8 @@ vk_time_sessions: dict[int, str] = {}
 
 # superadmin user_id -> pending partner user_id
 partner_info_sessions: dict[int, int] = {}
+# user_id -> festival_id for description editing
+festival_edit_sessions: dict[int, int] = {}
 
 # toggle for uploading images to catbox
 CATBOX_ENABLED: bool = False
@@ -208,6 +211,16 @@ class WeekendPage(SQLModel, table=True):
     start: str = Field(primary_key=True)
     url: str
     path: str
+
+
+class Festival(SQLModel, table=True):
+    __table_args__ = {"extend_existing": True}
+    id: Optional[int] = Field(default=None, primary_key=True)
+    name: str
+    description: Optional[str] = None
+    telegraph_url: Optional[str] = None
+    telegraph_path: Optional[str] = None
+    vk_post_url: Optional[str] = None
 
 
 class Database:
@@ -462,6 +475,20 @@ async def get_asset_channel(db: Database) -> Channel | None:
             select(Channel).where(Channel.is_asset.is_(True))
         )
         return result.scalars().first()
+
+
+async def ensure_festival(db: Database, name: str) -> Festival:
+    """Return existing festival by name or create a new record."""
+    async with db.get_session() as session:
+        res = await session.execute(select(Festival).where(Festival.name == name))
+        fest = res.scalar_one_or_none()
+        if fest:
+            return fest
+        fest = Festival(name=name)
+        session.add(fest)
+        await session.commit()
+        logging.info("created festival %s", name)
+        return fest
 
 
 async def get_superadmin_id(db: Database) -> int | None:
@@ -1000,6 +1027,8 @@ async def remove_calendar_button(event: Event, bot: Bot):
 async def parse_event_via_4o(
     text: str,
     source_channel: str | None = None,
+    *,
+    festival_names: list[str] | None = None,
     **extra: str | None,
 ) -> list[dict]:
     token = os.getenv("FOUR_O_TOKEN")
@@ -1017,6 +1046,8 @@ async def parse_event_via_4o(
             ]
         if locations:
             prompt += "\nKnown venues:\n" + "\n".join(locations)
+    if festival_names:
+        prompt += "\nKnown festivals:\n" + "\n".join(festival_names)
     headers = {
         "Authorization": f"Bearer {token}",
         "Content-Type": "application/json",
@@ -1311,6 +1342,22 @@ async def process_request(callback: types.CallbackQuery, db: Database, bot: Bot)
             ):
                 await callback.answer("Not authorized", show_alert=True)
                 return
+        if field == "festival":
+            async with db.get_session() as session:
+                fests = (await session.execute(select(Festival))).scalars().all()
+            keyboard = [
+                [
+                    types.InlineKeyboardButton(text=f.name, callback_data=f"setfest:{eid}:{f.id}")
+                ]
+                for f in fests
+            ]
+            keyboard.append([
+                types.InlineKeyboardButton(text="None", callback_data=f"setfest:{eid}:0")
+            ])
+            markup = types.InlineKeyboardMarkup(inline_keyboard=keyboard)
+            await callback.message.answer("Choose festival", reply_markup=markup)
+            await callback.answer()
+            return
         editing_sessions[callback.from_user.id] = (int(eid), field)
         await callback.message.answer(f"Send new value for {field}")
         await callback.answer()
@@ -1345,6 +1392,65 @@ async def process_request(callback: types.CallbackQuery, db: Database, bot: Bot)
         if event:
             await show_edit_menu(callback.from_user.id, event, bot)
         await callback.answer()
+    elif data.startswith("setfest:"):
+        _, eid, fid = data.split(":")
+        async with db.get_session() as session:
+            user = await session.get(User, callback.from_user.id)
+            event = await session.get(Event, int(eid))
+            if not event or (user and user.blocked) or (
+                user and user.is_partner and event.creator_id != user.user_id
+            ):
+                await callback.answer("Not authorized", show_alert=True)
+                return
+            if fid == "0":
+                event.festival = None
+            else:
+                fest = await session.get(Festival, int(fid))
+                if fest:
+                    event.festival = fest.name
+            await session.commit()
+            fest_name = event.festival
+            logging.info(
+                "event %s festival set to %s",
+                eid,
+                fest_name or "None",
+            )
+        if fest_name:
+            await sync_festival_page(db, fest_name)
+            await sync_festival_vk_post(db, fest_name)
+        await show_edit_menu(callback.from_user.id, event, bot)
+        await callback.answer("Updated")
+    elif data.startswith("festedit:"):
+        fid = int(data.split(":")[1])
+        async with db.get_session() as session:
+            if not await session.get(User, callback.from_user.id):
+                await callback.answer("Not authorized", show_alert=True)
+                return
+            fest = await session.get(Festival, fid)
+            if not fest:
+                await callback.answer("Festival not found", show_alert=True)
+                return
+        festival_edit_sessions[callback.from_user.id] = fid
+        await callback.message.answer("Send festival description")
+        await callback.answer()
+    elif data.startswith("festdel:"):
+        fid = int(data.split(":")[1])
+        async with db.get_session() as session:
+            if not await session.get(User, callback.from_user.id):
+                await callback.answer("Not authorized", show_alert=True)
+                return
+            fest = await session.get(Festival, fid)
+            if not fest:
+                await callback.answer("Festival not found", show_alert=True)
+                return
+            await session.execute(
+                update(Event).where(Event.festival == fest.name).values(festival=None)
+            )
+            await session.delete(fest)
+            await session.commit()
+            logging.info("festival %s deleted", fest.name)
+        await send_festivals_list(callback.message, db, bot, edit=True)
+        await callback.answer("Deleted")
     elif data.startswith("togglesilent:"):
         eid = int(data.split(":")[1])
         async with db.get_session() as session:
@@ -1792,6 +1898,31 @@ async def send_users_list(message: types.Message, db: Database, bot: Bot, edit: 
         await bot.send_message(message.chat.id, "\n".join(lines), reply_markup=markup)
 
 
+async def send_festivals_list(message: types.Message, db: Database, bot: Bot, edit: bool = False):
+    async with db.get_session() as session:
+        if not await session.get(User, message.from_user.id):
+            if not edit:
+                await bot.send_message(message.chat.id, "Not authorized")
+            return
+        result = await session.execute(select(Festival))
+        fests = result.scalars().all()
+    lines = [f"{f.id} {f.name}" for f in fests]
+    keyboard = [
+        [
+            types.InlineKeyboardButton(text="Edit", callback_data=f"festedit:{f.id}"),
+            types.InlineKeyboardButton(text="Delete", callback_data=f"festdel:{f.id}"),
+        ]
+        for f in fests
+    ]
+    if not lines:
+        lines.append("No festivals")
+    markup = types.InlineKeyboardMarkup(inline_keyboard=keyboard) if keyboard else None
+    if edit:
+        await message.edit_text("\n".join(lines), reply_markup=markup)
+    else:
+        await bot.send_message(message.chat.id, "\n".join(lines), reply_markup=markup)
+
+
 async def send_setchannel_list(
     message: types.Message, db: Database, bot: Bot, edit: bool = False
 ):
@@ -2206,10 +2337,21 @@ async def add_events_from_text(
         llm_text = text
         if channel_title:
             llm_text = f"{channel_title}\n{llm_text}"
-        if source_channel:
-            parsed = await parse_event_via_4o(llm_text, source_channel)
-        else:
-            parsed = await parse_event_via_4o(llm_text)
+        async with db.get_session() as session:
+            res_f = await session.execute(select(Festival.name))
+            fest_names = [r[0] for r in res_f.fetchall()]
+        try:
+            if source_channel:
+                parsed = await parse_event_via_4o(
+                    llm_text, source_channel, festival_names=fest_names
+                )
+            else:
+                parsed = await parse_event_via_4o(llm_text, festival_names=fest_names)
+        except TypeError:
+            if source_channel:
+                parsed = await parse_event_via_4o(llm_text, source_channel)
+            else:
+                parsed = await parse_event_via_4o(llm_text)
 
         logging.info("LLM returned %d events", len(parsed))
     except Exception as e:
@@ -2228,6 +2370,12 @@ async def add_events_from_text(
             data.get("date"),
             data.get("time"),
         )
+        if data.get("festival"):
+            logging.info(
+                "4o recognized festival %s for event %s",
+                data.get("festival"),
+                data.get("title"),
+            )
 
         date_raw = data.get("date", "") or ""
         end_date_raw = data.get("end_date") or None
@@ -2269,6 +2417,9 @@ async def add_events_from_text(
             source_message_id=source_message_id,
             creator_id=creator_id,
         )
+
+        if base_event.festival:
+            await ensure_festival(db, base_event.festival)
 
         if base_event.event_type == "выставка" and not base_event.end_date:
             start_dt = parse_iso_date(base_event.date) or datetime.now(LOCAL_TZ).date()
@@ -2410,6 +2561,16 @@ async def add_events_from_text(
             if w_start:
                 logging.info("syncing weekend page %s", w_start.isoformat())
                 await sync_weekend_page(db, w_start.isoformat())
+            fest_obj = None
+            if saved.festival:
+                logging.info("syncing festival %s", saved.festival)
+                await sync_festival_page(db, saved.festival)
+                await sync_festival_vk_post(db, saved.festival)
+                async with db.get_session() as session:
+                    res = await session.execute(
+                        select(Festival).where(Festival.name == saved.festival)
+                    )
+                    fest_obj = res.scalar_one_or_none()
 
             lines = [
                 f"title: {saved.title}",
@@ -2423,6 +2584,8 @@ async def add_events_from_text(
                 lines.append(f"city: {saved.city}")
             if saved.festival:
                 lines.append(f"festival: {saved.festival}")
+                if fest_obj and fest_obj.telegraph_url:
+                    lines.append(f"festival_page: {fest_obj.telegraph_url}")
             if saved.description:
                 lines.append(f"description: {saved.description}")
             if saved.event_type:
@@ -2876,14 +3039,21 @@ def is_recent(e: Event, tz: timezone | None = None, now: datetime | None = None)
     return e.added_at >= start
 
 
-def format_event_md(e: Event) -> str:
+def format_event_md(e: Event, festival: Festival | None = None) -> str:
     prefix = ""
     if is_recent(e):
         prefix += "\U0001f6a9 "
     emoji_part = ""
     if e.emoji and not e.title.strip().startswith(e.emoji):
         emoji_part = f"{e.emoji} "
-    lines = [f"{prefix}{emoji_part}{e.title}".strip(), e.description.strip()]
+    lines = [f"{prefix}{emoji_part}{e.title}".strip()]
+    if festival:
+        link = festival.telegraph_url
+        if link:
+            lines.append(f"[{festival.name}]({link})")
+        else:
+            lines.append(festival.name)
+    lines.append(e.description.strip())
     if e.pushkin_card:
         lines.append("\u2705 Пушкинская карта")
     if e.is_free:
@@ -2944,7 +3114,10 @@ def format_event_md(e: Event) -> str:
 
 
 def format_event_vk(
-    e: Event, highlight: bool = False, weekend_url: str | None = None
+    e: Event,
+    highlight: bool = False,
+    weekend_url: str | None = None,
+    festival: Festival | None = None,
 ) -> str:
 
     prefix = ""
@@ -2971,7 +3144,14 @@ def format_event_vk(
         details_link = e.telegraph_url
     if details_link:
         desc = f"{desc}, [подробнее|{details_link}]"
-    lines = [title, desc]
+    lines = [title]
+    if festival:
+        link = festival.vk_post_url
+        if link:
+            lines.append(f"[{festival.name}|{link}]")
+        else:
+            lines.append(festival.name)
+    lines.append(desc)
 
     if e.pushkin_card:
         lines.append("\u2705 Пушкинская карта")
@@ -3037,7 +3217,10 @@ def format_event_vk(
 
 
 def format_event_daily(
-    e: Event, highlight: bool = False, weekend_url: str | None = None
+    e: Event,
+    highlight: bool = False,
+    weekend_url: str | None = None,
+    festival: Festival | None = None,
 ) -> str:
     """Return HTML-formatted text for a daily announcement item."""
     prefix = ""
@@ -3056,7 +3239,14 @@ def format_event_daily(
 
     desc = e.description.strip()
     desc = re.sub(r",?\s*подробнее\s*\([^\n]*\)$", "", desc, flags=re.I)
-    lines = [title, html.escape(desc)]
+    lines = [title]
+    if festival:
+        link = festival.telegraph_url
+        if link:
+            lines.append(f'<a href="{html.escape(link)}">{html.escape(festival.name)}</a>')
+        else:
+            lines.append(html.escape(festival.name))
+    lines.append(html.escape(desc))
 
     if e.pushkin_card:
         lines.append("\u2705 Пушкинская карта")
@@ -3184,8 +3374,8 @@ def event_title_nodes(e: Event) -> list:
     return nodes
 
 
-def event_to_nodes(e: Event) -> list[dict]:
-    md = format_event_md(e)
+def event_to_nodes(e: Event, festival: Festival | None = None) -> list[dict]:
+    md = format_event_md(e, festival)
     lines = md.split("\n")
     body_md = "\n".join(lines[1:]) if len(lines) > 1 else ""
     from telegraph.utils import html_to_nodes
@@ -3305,6 +3495,10 @@ async def build_month_page_content(
         e for e in exhibitions if e.end_date and e.date <= today_str
     ]
 
+    async with db.get_session() as session:
+        res_f = await session.execute(select(Festival))
+        fest_map = {f.name: f for f in res_f.scalars().all()}
+
     by_day: dict[date, list[Event]] = {}
     for e in events:
         date_part = e.date.split("..", 1)[0]
@@ -3337,7 +3531,8 @@ async def build_month_page_content(
         content.append({"tag": "br"})
         content.append({"tag": "p", "children": ["\u00a0"]})
         for ev in by_day[day]:
-            content.extend(event_to_nodes(ev))
+            fest = fest_map.get(ev.festival or "")
+            content.extend(event_to_nodes(ev, fest))
 
     today_month = datetime.now(LOCAL_TZ).strftime("%Y-%m")
     future_pages = [p for p in nav_pages if p.month >= today_month]
@@ -3560,6 +3755,10 @@ async def build_weekend_page_content(db: Database, start: str) -> tuple[str, lis
         )
     ]
 
+    async with db.get_session() as session:
+        res_f = await session.execute(select(Festival))
+        fest_map = {f.name: f for f in res_f.scalars().all()}
+
     by_day: dict[date, list[Event]] = {}
     for e in events:
         d = parse_iso_date(e.date)
@@ -3596,7 +3795,8 @@ async def build_weekend_page_content(db: Database, start: str) -> tuple[str, lis
         content.append({"tag": "br"})
         content.append({"tag": "p", "children": ["\u00a0"]})
         for ev in by_day[d]:
-            content.extend(event_to_nodes(ev))
+            fest = fest_map.get(ev.festival or "")
+            content.extend(event_to_nodes(ev, fest))
 
     weekend_nav: list[dict] = []
     future_weekends = [w for w in weekend_pages if w.start >= start]
@@ -3696,6 +3896,120 @@ async def sync_weekend_page(db: Database, start: str, update_links: bool = False
                 await sync_weekend_page(db, w.start, update_links=False)
 
 
+async def generate_festival_description(fest: Festival, events: list[Event]) -> str:
+    """Use LLM to craft a short festival blurb."""
+    lines = [f"{e.title}: {e.description}" for e in events[:5]]
+    prompt = (
+        f"Напиши дружелюбное описание фестиваля {fest.name} в 2-3 предложения. "
+        "Используй только факты из списка событий:\n" + "\n".join(lines)
+    )
+    try:
+        text = await ask_4o(prompt)
+        logging.info("generated description for festival %s", fest.name)
+        return text
+    except Exception as e:
+        logging.error("failed to generate festival description %s: %s", fest.name, e)
+        return ""
+
+
+async def build_festival_page_content(db: Database, fest: Festival) -> tuple[str, list]:
+    logging.info("building festival page content for %s", fest.name)
+    async with db.get_session() as session:
+        res = await session.execute(
+            select(Event).where(Event.festival == fest.name).order_by(Event.date, Event.time)
+        )
+        events = res.scalars().all()
+        logging.info("festival %s has %d events", fest.name, len(events))
+        if not fest.description:
+            desc = await generate_festival_description(fest, events)
+            if desc:
+                fest.description = desc
+                await session.commit()
+    nodes: list[dict] = []
+    if fest.description:
+        nodes.append({"tag": "p", "children": [fest.description]})
+    for e in events:
+        nodes.extend(event_to_nodes(e))
+    return fest.name, nodes
+
+
+async def sync_festival_page(db: Database, name: str):
+    token = get_telegraph_token()
+    if not token:
+        logging.error("Telegraph token unavailable")
+        return
+    tg = Telegraph(access_token=token)
+    async with db.get_session() as session:
+        result = await session.execute(
+            select(Festival).where(Festival.name == name)
+        )
+        fest = result.scalar_one_or_none()
+        if not fest:
+            return
+        try:
+            title, content = await build_festival_page_content(db, fest)
+            created = False
+            if fest.telegraph_path:
+                await asyncio.to_thread(
+                    tg.edit_page, fest.telegraph_path, title=title, content=content
+                )
+                logging.info("updated festival page %s in Telegraph", name)
+            else:
+                data = await asyncio.to_thread(tg.create_page, title, content=content)
+                fest.telegraph_url = data.get("url")
+                fest.telegraph_path = data.get("path")
+                created = True
+                logging.info("created festival page %s: %s", name, fest.telegraph_url)
+            await session.commit()
+            logging.info("synced festival page %s", name)
+        except Exception as e:
+            logging.error("Failed to sync festival %s: %s", name, e)
+
+
+async def build_festival_vk_message(db: Database, fest: Festival) -> str:
+    async with db.get_session() as session:
+        res = await session.execute(
+            select(Event).where(Event.festival == fest.name).order_by(Event.date, Event.time)
+        )
+        events = res.scalars().all()
+    lines = [fest.name]
+    if fest.description:
+        lines.append(fest.description)
+    for ev in events:
+        lines.append(VK_BLANK_LINE)
+        lines.append(format_event_vk(ev))
+    return "\n".join(lines)
+
+
+async def sync_festival_vk_post(db: Database, name: str):
+    token = VK_TOKEN
+    if not token:
+        return
+    group_id = await get_vk_group_id(db)
+    if not group_id:
+        return
+    async with db.get_session() as session:
+        res = await session.execute(select(Festival).where(Festival.name == name))
+        fest = res.scalar_one_or_none()
+        if not fest:
+            return
+    message = await build_festival_vk_message(db, fest)
+    try:
+        if fest.vk_post_url:
+            await edit_vk_post(token, fest.vk_post_url, message)
+            logging.info("updated festival post %s on VK", name)
+        else:
+            url = await post_to_vk(token, group_id, message)
+            if url:
+                async with db.get_session() as session:
+                    fest = (await session.execute(select(Festival).where(Festival.name == name))).scalar_one()
+                    fest.vk_post_url = url
+                    await session.commit()
+            logging.info("created festival post %s: %s", name, url)
+    except Exception as e:
+        logging.error("VK post error for festival %s: %s", name, e)
+
+
 async def build_daily_posts(
     db: Database,
     tz: timezone,
@@ -3705,6 +4019,7 @@ async def build_daily_posts(
         now = datetime.now(tz)
     today = now.date()
     yesterday_utc = recent_cutoff(tz, now)
+    fest_map: dict[str, Festival] = {}
     async with db.get_session() as session:
         res_today = await session.execute(
             select(Event)
@@ -3740,6 +4055,9 @@ async def build_daily_posts(
                 )
             )
         ).scalars().all()
+
+        res_fests = await session.execute(select(Festival))
+        fest_map = {f.name: f for f in res_fests.scalars().all()}
 
         weekend_count = 0
         if wpage:
@@ -3793,7 +4111,14 @@ async def build_daily_posts(
             if w:
                 w_url = w.url
         lines1.append("")
-        lines1.append(format_event_daily(e, highlight=True, weekend_url=w_url))
+        lines1.append(
+            format_event_daily(
+                e,
+                highlight=True,
+                weekend_url=w_url,
+                festival=fest_map.get(e.festival or ""),
+            )
+        )
     lines1.append("")
     lines1.append(
         f"#Афиша_Калининград #Калининград #концерт #{tag} #{today.day}_{MONTHS[today.month - 1]}"
@@ -3809,7 +4134,13 @@ async def build_daily_posts(
             if w:
                 w_url = w.url
         lines2.append("")
-        lines2.append(format_event_daily(e, weekend_url=w_url))
+        lines2.append(
+            format_event_daily(
+                e,
+                weekend_url=w_url,
+                festival=fest_map.get(e.festival or ""),
+            )
+        )
     section2 = "\n".join(lines2)
 
     buttons = []
@@ -3863,6 +4194,7 @@ async def build_daily_sections_vk(
         now = datetime.now(tz)
     today = now.date()
     yesterday_utc = recent_cutoff(tz, now)
+    fest_map: dict[str, Festival] = {}
     async with db.get_session() as session:
         res_today = await session.execute(
             select(Event)
@@ -3949,7 +4281,14 @@ async def build_daily_sections_vk(
             w = weekend_map.get(d.isoformat())
             if w:
                 w_url = w.url
-        lines1.append(format_event_vk(e, highlight=True, weekend_url=w_url))
+        lines1.append(
+            format_event_vk(
+                e,
+                highlight=True,
+                weekend_url=w_url,
+                festival=fest_map.get(e.festival or ""),
+            )
+        )
         lines1.append(VK_EVENT_SEPARATOR)
     if events_today:
         lines1.pop()
@@ -3989,7 +4328,13 @@ async def build_daily_sections_vk(
             w = weekend_map.get(d.isoformat())
             if w:
                 w_url = w.url
-        lines2.append(format_event_vk(e, weekend_url=w_url))
+        lines2.append(
+            format_event_vk(
+                e,
+                weekend_url=w_url,
+                festival=fest_map.get(e.festival or ""),
+            )
+        )
         lines2.append(VK_EVENT_SEPARATOR)
     if events_new:
         lines2.pop()
@@ -4005,14 +4350,47 @@ async def build_daily_sections_vk(
     return section1, section2
 
 
-async def post_to_vk(token: str, group_id: str, message: str):
+async def post_to_vk(token: str, group_id: str, message: str) -> str | None:
     if not token or not group_id:
-        return
+        return None
     url = "https://api.vk.com/method/wall.post"
     params = {
         "owner_id": f"-{group_id.lstrip('-')}",
         "from_group": 1,
         "message": message,
+        "access_token": token,
+        "v": "5.131",
+    }
+    async with create_ipv4_session(ClientSession) as session:
+        async with session.post(url, data=params) as resp:
+            data = await resp.json()
+            if "error" in data:
+                raise RuntimeError(f"VK error: {data['error']}")
+            post_id = data.get("response", {}).get("post_id")
+            if post_id:
+                return f"https://vk.com/wall-{group_id.lstrip('-')}_{post_id}"
+    return None
+
+
+def _vk_owner_and_post_id(url: str) -> tuple[str, str] | None:
+    m = re.search(r"wall(-?\d+)_(\d+)", url)
+    if not m:
+        return None
+    return m.group(1), m.group(2)
+
+
+async def edit_vk_post(token: str, post_url: str, message: str) -> None:
+    ids = _vk_owner_and_post_id(post_url)
+    if not ids:
+        logging.error("invalid VK post url %s", post_url)
+        return
+    owner_id, post_id = ids
+    url = "https://api.vk.com/method/wall.edit"
+    params = {
+        "owner_id": owner_id,
+        "post_id": post_id,
+        "message": message,
+        "from_group": 1,
         "access_token": token,
         "v": "5.131",
     }
@@ -4517,6 +4895,10 @@ async def handle_pages(message: types.Message, db: Database, bot: Bot):
     await bot.send_message(message.chat.id, "\n".join(lines))
 
 
+async def handle_fest(message: types.Message, db: Database, bot: Bot):
+    await send_festivals_list(message, db, bot, edit=False)
+
+
 
 
 
@@ -4724,6 +5106,7 @@ async def handle_edit_message(message: types.Message, db: Database, bot: Bot):
             return
         old_date = event.date.split("..", 1)[0]
         old_month = old_date[:7]
+        old_fest = event.festival
         if field in {"ticket_price_min", "ticket_price_max"}:
             try:
                 setattr(event, field, int(value))
@@ -4744,6 +5127,7 @@ async def handle_edit_message(message: types.Message, db: Database, bot: Bot):
         await session.commit()
         new_date = event.date.split("..", 1)[0]
         new_month = new_date[:7]
+        new_fest = event.festival
     await sync_month_page(db, old_month)
     old_dt = parse_iso_date(old_date)
     old_w = weekend_start_for_date(old_dt) if old_dt else None
@@ -4755,6 +5139,12 @@ async def handle_edit_message(message: types.Message, db: Database, bot: Bot):
     new_w = weekend_start_for_date(new_dt) if new_dt else None
     if new_w and new_w != old_w:
         await sync_weekend_page(db, new_w.isoformat())
+    if old_fest:
+        await sync_festival_page(db, old_fest)
+        await sync_festival_vk_post(db, old_fest)
+    if new_fest and new_fest != old_fest:
+        await sync_festival_page(db, new_fest)
+        await sync_festival_vk_post(db, new_fest)
     editing_sessions[message.from_user.id] = (eid, None)
     await show_edit_menu(message.from_user.id, event, bot)
 
@@ -4844,6 +5234,26 @@ async def handle_partner_info_message(message: types.Message, db: Database, bot:
     logging.info("approved user %s as partner %s, %s", uid, org, loc)
 
 
+async def handle_festival_edit_message(message: types.Message, db: Database, bot: Bot):
+    fid = festival_edit_sessions.get(message.from_user.id)
+    if not fid:
+        return
+    text = (message.text or "").strip()
+    async with db.get_session() as session:
+        fest = await session.get(Festival, fid)
+        if not fest:
+            await bot.send_message(message.chat.id, "Festival not found")
+            festival_edit_sessions.pop(message.from_user.id, None)
+            return
+        fest.description = text
+        await session.commit()
+        logging.info("festival %s description updated", fest.name)
+    festival_edit_sessions.pop(message.from_user.id, None)
+    await bot.send_message(message.chat.id, "Festival updated")
+    await sync_festival_page(db, fest.name)
+    await sync_festival_vk_post(db, fest.name)
+
+
 processed_media_groups: set[str] = set()
 
 # store up to three images for albums until the caption arrives
@@ -4920,19 +5330,29 @@ async def handle_forwarded(message: types.Message, db: Database, bot: Bot):
                     cid = cid.lstrip("-")
                 link = f"https://t.me/c/{cid}/{msg_id}"
     else:
-        fo = message.model_extra.get("forward_origin") if hasattr(message, "model_extra") else None
-        if isinstance(fo, dict) and fo.get("type") == "messageOriginChannel":
-            chat_data = fo.get("chat") or {}
-            chat_id = chat_data.get("id")
-            msg_id = fo.get("message_id")
-            channel_name = chat_data.get("title") or chat_data.get("username")
+        fo = getattr(message, "forward_origin", None)
+        if isinstance(fo, dict):
+            fo_type = fo.get("type")
+        else:
+            fo_type = getattr(fo, "type", None)
+        if fo_type in {"messageOriginChannel", "channel"}:
+            chat_data = fo.get("chat") if isinstance(fo, dict) else getattr(fo, "chat", {})
+            chat_id = chat_data.get("id") if isinstance(chat_data, dict) else getattr(chat_data, "id", None)
+            msg_id = fo.get("message_id") if isinstance(fo, dict) else getattr(fo, "message_id", None)
+            channel_name = (
+                chat_data.get("title") if isinstance(chat_data, dict) else getattr(chat_data, "title", None)
+            )
+            if not channel_name:
+                channel_name = (
+                    chat_data.get("username") if isinstance(chat_data, dict) else getattr(chat_data, "username", None)
+                )
 
             async with db.get_session() as session:
                 ch = await session.get(Channel, chat_id)
                 allowed = ch.is_registered if ch else False
             logging.info("forward from origin chat %s allowed=%s", chat_id, allowed)
             if allowed:
-                username = chat_data.get("username")
+                username = chat_data.get("username") if isinstance(chat_data, dict) else getattr(chat_data, "username", None)
                 if username:
                     link = f"https://t.me/{username}/{msg_id}"
                 else:
@@ -5341,6 +5761,12 @@ def create_app() -> web.Application:
     async def stats_wrapper(message: types.Message):
         await handle_stats(message, db, bot)
 
+    async def fest_wrapper(message: types.Message):
+        await handle_fest(message, db, bot)
+
+    async def festival_edit_wrapper(message: types.Message):
+        await handle_festival_edit_message(message, db, bot)
+
     async def users_wrapper(message: types.Message):
         await handle_users(message, db, bot)
 
@@ -5415,7 +5841,11 @@ def create_app() -> web.Application:
         or c.data.startswith("delics:")
         or c.data.startswith("partner:")
         or c.data.startswith("block:")
-        or c.data.startswith("unblock:"),
+        or c.data.startswith("unblock:")
+        or c.data.startswith("festedit:")
+        or c.data.startswith("festdel:")
+        or c.data.startswith("setfest:")
+    ,
     )
     dp.message.register(tz_wrapper, Command("tz"))
     dp.message.register(add_event_wrapper, Command("addevent"))
@@ -5431,6 +5861,7 @@ def create_app() -> web.Application:
     dp.message.register(reg_daily_wrapper, Command("regdailychannels"))
     dp.message.register(daily_wrapper, Command("daily"))
     dp.message.register(exhibitions_wrapper, Command("exhibitions"))
+    dp.message.register(fest_wrapper, Command("fest"))
     dp.message.register(pages_wrapper, Command("pages"))
     dp.message.register(stats_wrapper, Command("stats"))
     dp.message.register(users_wrapper, Command("users"))
@@ -5447,6 +5878,9 @@ def create_app() -> web.Application:
     )
     dp.message.register(
         vk_time_msg_wrapper, lambda m: m.from_user.id in vk_time_sessions
+    )
+    dp.message.register(
+        festival_edit_wrapper, lambda m: m.from_user.id in festival_edit_sessions
     )
     dp.message.register(
         forward_wrapper,

--- a/tests/test_bot.py
+++ b/tests/test_bot.py
@@ -1384,7 +1384,7 @@ async def test_forward_add_event_origin(tmp_path: Path, monkeypatch):
             "message_id": 3,
             "date": 0,
             "forward_origin": {
-                "type": "messageOriginChannel",
+                "type": "channel",
                 "chat": {"id": -100123, "type": "channel", "username": "chan"},
                 "message_id": 10,
                 "date": 0,
@@ -4081,6 +4081,132 @@ def test_format_event_vk_fallback_link():
     )
     text = main.format_event_vk(e)
     assert "[подробнее|https://t.me/page]" in text
+
+
+@pytest.mark.asyncio
+async def test_daily_posts_festival_link(tmp_path: Path):
+    db = Database(str(tmp_path / "db.sqlite"))
+    await db.init()
+
+    today = date.today()
+    async with db.get_session() as session:
+        session.add(
+            main.Festival(name="Jazz", telegraph_url="http://tg", vk_post_url="http://vk")
+        )
+        session.add(
+            Event(
+                title="T",
+                description="d",
+                source_text="s",
+                date=today.isoformat(),
+                time="18:00",
+                location_name="Hall",
+                festival="Jazz",
+            )
+        )
+        await session.commit()
+
+    posts = await main.build_daily_posts(db, timezone.utc)
+    assert "http://tg" in posts[0][0]
+    sec1, _ = await main.build_daily_sections_vk(db, timezone.utc)
+    assert sec1
+
+
+@pytest.mark.asyncio
+async def test_festival_auto_page_creation(tmp_path: Path, monkeypatch):
+    db = Database(str(tmp_path / "db.sqlite"))
+    await db.init()
+
+    async def fake_parse(*args, **kwargs):
+        return [
+            {
+                "title": "Jazz Day",
+                "short_description": "desc",
+                "date": FUTURE_DATE,
+                "time": "18:00",
+                "location_name": "Hall",
+                "festival": "Jazz",
+            }
+        ]
+
+    class DummyTG:
+        def __init__(self, access_token=None):
+            pass
+
+        def create_page(self, title, content=None):
+            return {"url": "http://tg", "path": "p"}
+
+        def edit_page(self, path, title=None, content=None):
+            pass
+
+    monkeypatch.setenv("TELEGRAPH_TOKEN", "t")
+    monkeypatch.setattr("main.Telegraph", lambda access_token=None: DummyTG())
+    monkeypatch.setattr("main.parse_event_via_4o", fake_parse)
+
+    async def fake_ask(text):
+        return "Desc"
+
+    monkeypatch.setattr("main.ask_4o", fake_ask)
+    async def fake_create(*args, **kwargs):
+        return "u", "p"
+
+    monkeypatch.setattr("main.create_source_page", fake_create)
+
+    await main.add_events_from_text(db, "t", None, None, None)
+
+    async with db.get_session() as session:
+        fest = (await session.execute(select(main.Festival))).scalars().first()
+    assert fest and fest.telegraph_url == "http://tg"
+    assert fest.description == "Desc"
+
+
+@pytest.mark.asyncio
+async def test_handle_fest_list(tmp_path: Path):
+    db = Database(str(tmp_path / "db.sqlite"))
+    await db.init()
+    bot = DummyBot("123:abc")
+
+    async with db.get_session() as session:
+        session.add(User(user_id=1))
+        session.add(main.Festival(name="Jazz"))
+        await session.commit()
+
+    msg = types.Message.model_validate(
+        {
+            "message_id": 1,
+            "date": 0,
+            "chat": {"id": 1, "type": "private"},
+            "from": {"id": 1, "is_bot": False, "first_name": "A"},
+            "text": "/fest",
+        }
+    )
+    await main.handle_fest(msg, db, bot)
+    assert "Jazz" in bot.messages[-1][1]
+
+
+@pytest.mark.asyncio
+async def test_month_page_festival_link(tmp_path: Path):
+    db = Database(str(tmp_path / "db.sqlite"))
+    await db.init()
+
+    m = FUTURE_DATE[:7]
+    async with db.get_session() as session:
+        session.add(main.Festival(name="Jazz", telegraph_url="http://tg"))
+        session.add(
+            Event(
+                title="T",
+                description="d",
+                source_text="s",
+                date=FUTURE_DATE,
+                time="18:00",
+                location_name="Hall",
+                festival="Jazz",
+            )
+        )
+        await session.commit()
+
+    title, content = await main.build_month_page_content(db, m)
+    assert "http://tg" in json_dumps(content)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- log when building festival pages
- sync festival posts to VK with logging
- fix forwarded message source extraction with structured origin

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6888dff4c2b08332bec56465955b8ecc