### PR TITLE
Fix duplicate festival link

### DIFF
--- a/main.py
+++ b/main.py
@@ -3498,7 +3498,10 @@ def event_to_nodes(e: Event, festival: Festival | None = None) -> list[dict]:
     md = format_event_md(e, festival)
 
     lines = md.split("\n")
-    body_md = "\n".join(lines[1:]) if len(lines) > 1 else ""
+    body_lines = lines[1:]
+    if festival and body_lines:
+        body_lines = body_lines[1:]
+    body_md = "\n".join(body_lines) if body_lines else ""
     from telegraph.utils import html_to_nodes
 
     nodes = [{"tag": "h4", "children": event_title_nodes(e)}]

--- a/tests/test_bot.py
+++ b/tests/test_bot.py
@@ -4179,6 +4179,16 @@ def test_event_to_nodes_festival_link():
     fest = main.Festival(name="Jazz", telegraph_url="http://tg")
     nodes = main.event_to_nodes(e, fest)
     assert nodes[1]["children"][0]["attrs"]["href"] == "http://tg"
+    assert sum(
+        1
+        for n in nodes
+        if isinstance(n, dict)
+        and any(
+            isinstance(c, dict)
+            and c.get("attrs", {}).get("href") == "http://tg"
+            for c in n.get("children", [])
+        )
+    ) == 1
 
 
 


### PR DESCRIPTION
## Summary
- avoid repeating festival links in event nodes
- test that a festival link only appears once

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688ab06ba8a88332bf840a580b567c67