### PR TITLE
Add festival contact editing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -125,6 +125,11 @@
 - Festival blurbs use the full text of event announcements and are generated in
   two or three paragraphs via 4o.
 
+## v0.3.18 - Festival contacts
+
+- Festival entries store website, VK and Telegram links.
+- `/fest` shows these links and accepts `site:`, `vk:` and `tg:` edits.
+
 
 
 

--- a/docs/COMMANDS.md
+++ b/docs/COMMANDS.md
@@ -19,7 +19,7 @@
 | `/daily` | - | Manage daily announcement channels and VK posting times; send test posts. |
 | `/exhibitions` | - | List active exhibitions similar to `/events`; each entry shows the period `c <start>` / `по <end>` and includes edit/delete buttons. |
 | `/pages` | - | Show links to Telegraph month and weekend pages. |
-| `/fest` | - | List festivals with edit/delete options; send a new description after tapping **Edit**. |
+| `/fest` | - | List festivals with edit/delete options; send a new description or `site/vk/tg: URL` after tapping **Edit**. |
 
 
 | `/stats [events]` | optional `events` | Superadmin only. Show Telegraph view counts starting from the past month and weekend pages up to all current and future ones. Use `events` to list event page stats. |


### PR DESCRIPTION
## Summary
- track festival site, VK and Telegram links
- show contact links in `/fest` output
- allow editing contact fields via `/fest` Edit
- document new contact edit flow
- test new behaviour

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688b20deeba08332b80c9c2be4e80ca1