### PR TITLE
Handle festival period from description

### DIFF
--- a/docs/FOUR_O_REQUEST.md
+++ b/docs/FOUR_O_REQUEST.md
@@ -53,3 +53,6 @@ announcements. The prompt instructs the model:
 используй типовые штампы, не выдумывай факты. Описание должно состоять из трёх
 предложений, если сведений мало — из одного". Only information from the
 provided texts may appear in the summary.
+If the description contains a date range like "с 27 августа по 6 сентября 2025",
+these dates define the festival period. When no range is present the period is
+calculated from the events added to the festival.


### PR DESCRIPTION
## Summary
- compute festival period from description text if available
- list all festival locations
- document how festival date range is derived
- cover festival date/location logic in tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688b92ac0c3483328f4df5e198904fb5