### PR TITLE
Update LLM instructions on festival ranges

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -131,6 +131,12 @@
 - `/fest` shows these links and accepts `site:`, `vk:` and `tg:` edits.
 - **Edit** now opens a menu to update description or contact links individually.
 
+## v0.3.19 - Festival range fix
+
+- LLM instructions clarified: when festival dates span multiple days but only
+  some performances are listed, only those performances become events. The bot
+  no longer adds extra dates unless every day is described.
+
 
 
 

--- a/docs/PROMPTS.md
+++ b/docs/PROMPTS.md
@@ -43,6 +43,10 @@ Guidelines:
 - If the event text does not specify a year, assume it happens in the current
   year.
 - Omit any events dated before today.
+- When a festival period is mentioned but only some performances are described,
+  include just those individual events with their own dates and set the
+  `festival` field. Do **not** create separate events for each day of the
+  festival unless every date is explicitly detailed.
 - Respond with **plain JSON only** &mdash; do not wrap the output in code
   fences.
 


### PR DESCRIPTION
## Summary
- clarify in the prompt that multi-day festival dates should not create daily events unless each day is detailed
- note the behaviour in the changelog

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688ba0ff1b3483328c1ea6c7932b8ee6