### PR TITLE
Add VK photo toggle

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,8 +42,9 @@ browse upcoming announcements. The command accepts dates like `2025-07-10`,
   # Optional: post daily announcements to VK
   export VK_TOKEN=vk_group_token
   # Optional: user access token for VK posts with images
-  export VK_USER_TOKEN=vk_user_token
-  python main.py
+export VK_USER_TOKEN=vk_user_token
+# Sending images to VK is disabled by default. Use /vkphotos to enable it.
+ python main.py
    ```
 
 ## Deployment on Fly.io
@@ -70,6 +71,7 @@ browse upcoming announcements. The command accepts dates like `2025-07-10`,
    fly secrets set VK_TOKEN=<token>
    # Optional: user access token for VK posts with images
    fly secrets set VK_USER_TOKEN=<token>
+   # Sending images to VK is disabled by default. Toggle with /vkphotos.
    ```
 3. Deploy:
    ```bash

--- a/docs/COMMANDS.md
+++ b/docs/COMMANDS.md
@@ -11,6 +11,7 @@
 | `/images` | - | Toggle uploading photos to Catbox. |
 | `/vkgroup <id|off>` | required id or `off` | Set or disable VK group for daily announcements. |
 | `/vktime today|added <HH:MM>` | required type and time | Change VK posting times (default 08:00/20:00). |
+| `/vkphotos` | - | Toggle sending images to VK posts. |
 | `/ask4o <text>` | any text | Send query to model 4o and show plain response (superadmin only). |
 | `/events [DATE]` | optional date `YYYY-MM-DD`, `DD.MM.YYYY` or `D месяц [YYYY]` | List events for the day with delete and edit buttons. Dates are shown as `DD.MM.YYYY`. Choosing **Edit** lists all fields with inline buttons including a toggle for "Бесплатно". |
 | `/setchannel` | - | Choose an admin channel and register it as an announcement or calendar asset source. |


### PR DESCRIPTION
## Summary
- toggle VK image posting via `/vkphotos`
- load `vk_photos_enabled` on startup
- skip VK photo upload when disabled
- document VK photo toggle option in README and command list

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688bcb5fe7d083328560a35ceddef63f