### PR TITLE
Fix VK festival link formatting

### DIFF
--- a/main.py
+++ b/main.py
@@ -3659,7 +3659,7 @@ def format_event_vk(
     if festival:
         link = festival.vk_post_url
         if link:
-            lines.append(f"[{festival.name}|{link}]")
+            lines.append(f"[{link}|{festival.name}]")
         else:
             lines.append(festival.name)
     lines.append(desc)

--- a/tests/test_bot.py
+++ b/tests/test_bot.py
@@ -4114,6 +4114,22 @@ def test_format_event_vk_fallback_link():
     assert "[подробнее|https://t.me/page]" in text
 
 
+def test_format_event_vk_festival_link():
+    e = Event(
+        title="T",
+        description="d",
+        source_text="s",
+        date="2025-07-10",
+        time="18:00",
+        location_name="Hall",
+        festival="Jazz",
+    )
+    fest = main.Festival(name="Jazz", vk_post_url="https://vk.com/wall-1_1")
+    text = main.format_event_vk(e, festival=fest)
+    lines = text.splitlines()
+    assert lines[1] == "[https://vk.com/wall-1_1|Jazz]"
+
+
 @pytest.mark.asyncio
 async def test_daily_posts_festival_link(tmp_path: Path):
     db = Database(str(tmp_path / "db.sqlite"))


### PR DESCRIPTION
## Summary
- fix festival link order when posting events to VK
- add regression test for VK festival link format

## Testing
- `pytest -q` *(fails: test_weekend_nav_and_exhibitions, test_month_nav_and_exhibitions, test_create_source_page_adds_nav)*

------
https://chatgpt.com/codex/tasks/task_e_688c6351b9f88332b5c675dc53375097