### PR TITLE
Support festival full name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -137,6 +137,13 @@
   some performances are listed, only those performances become events. The bot
   no longer adds extra dates unless every day is described.
 
+## v0.3.20 - Festival full name
+
+- Festivals now store both short and full names. Telegraph pages and VK posts
+  use the full name while events and lists keep the short version.
+- `/fest` gained edit options for these fields. Existing records are updated
+  automatically with the short name as the default full one.
+
 
 
 

--- a/docs/FOUR_O_REQUEST.md
+++ b/docs/FOUR_O_REQUEST.md
@@ -49,6 +49,8 @@ fields.
 Festival pages also rely on 4o. To craft a festival blurb the bot sends the
 previous description (if any) together with the full text of up to five recent
 announcements. The prompt instructs the model:
+The model also returns `festival_full` alongside `festival` so the bot can store
+the edition name separately.
 "Стиль профессионального журналиста в сфере мероприятий и культуры. Не
 используй типовые штампы, не выдумывай факты. Описание должно состоять из трёх
 предложений, если сведений мало — из одного". Only information from the

--- a/docs/PROMPTS.md
+++ b/docs/PROMPTS.md
@@ -12,6 +12,7 @@ If multiple events are found, return an array of objects. Each object uses these
 title             - name of the event
 short_description - one-sentence summary
 festival          - festival name or empty string
+festival_full     - full festival edition name or empty string
 date              - single date or range (YYYY-MM-DD or YYYY-MM-DD..YYYY-MM-DD)
 time              - start time or time range (HH:MM or HH:MM..HH:MM)
 location_name     - venue name, use standard directory form if known
@@ -47,6 +48,8 @@ Guidelines:
   include just those individual events with their own dates and set the
   `festival` field. Do **not** create separate events for each day of the
   festival unless every date is explicitly detailed.
+- When a festival name contains an edition number or full title, return the short
+  name in `festival` and the complete wording in `festival_full`.
 - Respond with **plain JSON only** &mdash; do not wrap the output in code
   fences.
 

--- a/tests/test_bot.py
+++ b/tests/test_bot.py
@@ -5290,6 +5290,7 @@ async def test_festival_page_contacts_and_dates(tmp_path: Path):
     async with db.get_session() as session:
         fest = main.Festival(
             name="Jazz",
+            full_name="Jazz XVIII",
             website_url="https://jazz.ru",
             vk_url="https://vk.com/jazz",
             tg_url="https://t.me/jazz",
@@ -5323,6 +5324,7 @@ async def test_festival_page_contacts_and_dates(tmp_path: Path):
         await session.commit()
 
     title, content = await main.build_festival_page_content(db, fest)
+    assert title == "Jazz XVIII"
     dump = json_dumps(content)
     assert "Контакты фестиваля" in dump
     assert "Мероприятия фестиваля" in dump
@@ -5384,7 +5386,7 @@ async def test_festival_vk_message_period_location(tmp_path: Path):
     await db.init()
 
     async with db.get_session() as session:
-        fest = main.Festival(name="Jazz")
+        fest = main.Festival(name="Jazz", full_name="Jazz XVIII")
         session.add(fest)
         session.add(
             Event(
@@ -5413,6 +5415,8 @@ async def test_festival_vk_message_period_location(tmp_path: Path):
         await session.commit()
 
     text = await main.build_festival_vk_message(db, fest)
+    lines = text.splitlines()
+    assert lines[0] == "Jazz XVIII"
     assert "\U0001f4c5" in text or "📅" in text
     assert "\U0001f4cd" in text or "📍" in text
 


### PR DESCRIPTION
## Summary
- extend `Festival` with `full_name`
- migrate database and populate `full_name`
- use full name for Telegraph page titles and VK posts
- allow editing short and full names via `/fest`
- instruct model 4o about `festival_full`
- add tests for new behaviour

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688c7b6ac3388332a31a5dada9125edd