### PR TITLE
Improve backup instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,9 +104,11 @@ The command prints the created page URL and confirms that editing works.
 
 ## Backup and restore
 
-Use `/dumpdb` to download a SQL dump of the current database. The bot replies
-with a list of connected channels and the steps required to restore the dump on
-another server. Send `/restore` with the dump file attached to load it back.
+Use `/dumpdb` to download a SQL dump of the current database. When a Telegraph
+token file exists the bot also sends `telegraph_token.txt`. The reply lists all
+connected channels and detailed steps to set up the bot elsewhere. Copy the
+token file to `/data/telegraph_token.txt` on the new host and send `/restore`
+with the dump file attached to load the database.
 
 ## Telegraph caching
 

--- a/docs/COMMANDS.md
+++ b/docs/COMMANDS.md
@@ -25,7 +25,7 @@
 
 
 | `/stats [events]` | optional `events` | Superadmin only. Show Telegraph view counts starting from the past month and weekend pages up to all current and future ones. Use `events` to list event page stats. |
-| `/dumpdb` | - | Superadmin only. Download a SQL dump of the database and see restore instructions. |
+| `/dumpdb` | - | Superadmin only. Download a SQL dump and `telegraph_token.txt` plus restore instructions. |
 | `/restore` | attach file | Superadmin only. Replace current database with the uploaded dump. |
 
 | `python main.py test_telegraph` | - | Verify Telegraph API access. Automatically creates a token if needed and prints the page URL. |

--- a/main.py
+++ b/main.py
@@ -5822,6 +5822,13 @@ async def handle_dumpdb(message: types.Message, db: Database, bot: Bot):
     data = await dump_database(db.engine.url.database)
     file = types.BufferedInputFile(data, filename="dump.sql")
     await bot.send_document(message.chat.id, file)
+    token_exists = os.path.exists(TELEGRAPH_TOKEN_FILE)
+    if token_exists:
+        with open(TELEGRAPH_TOKEN_FILE, "rb") as f:
+            token_file = types.BufferedInputFile(
+                f.read(), filename="telegraph_token.txt"
+            )
+        await bot.send_document(message.chat.id, token_file)
 
     lines = ["Channels:"]
     for ch in channels:
@@ -5837,12 +5844,21 @@ async def handle_dumpdb(message: types.Message, db: Database, bot: Bot):
 
     lines.append("")
     lines.append("To restore on another server:")
-    lines.append("1. Start the bot and send /restore with the dump file.")
+    step = 1
+    lines.append(f"{step}. Start the bot and send /restore with the dump file.")
+    step += 1
     if tz_setting:
-        lines.append(f"2. Current timezone: {tz_setting.value}")
-    lines.append("3. Add the bot as admin to the channels listed above.")
+        lines.append(f"{step}. Current timezone: {tz_setting.value}")
+        step += 1
+    lines.append(f"{step}. Add the bot as admin to the channels listed above.")
+    step += 1
+    if token_exists:
+        lines.append(
+            f"{step}. Copy telegraph_token.txt to {TELEGRAPH_TOKEN_FILE} before first run."
+        )
+        step += 1
     if catbox_setting and catbox_setting.value == "1":
-        lines.append("4. Run /images to enable photo uploads.")
+        lines.append(f"{step}. Run /images to enable photo uploads.")
 
     await bot.send_message(message.chat.id, "\n".join(lines))
 


### PR DESCRIPTION
## Summary
- include telegraph token when using `/dumpdb`
- mention token in restore instructions
- update docs for the new behaviour

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688c8795197883328c760d689476acc5