### PR TITLE
Fix partner reminder frequency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -150,6 +150,11 @@
   the past seven days.
 - The superadmin gets a list of partners who were reminded.
 
+## v0.3.22 - Partner reminder frequency fix
+
+- Partners who haven't added events no longer receive daily reminders; each
+  partner is notified at most once a week.
+
 
 
 


### PR DESCRIPTION
## Summary
- track last reminder time for partners so inactive partners are notified at most weekly
- add regression test for weekly partner reminders
- document partner reminder frequency fix

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688db95ca85083329ae0e84f4037e2ac