### PR TITLE
Preserve registration links in VK source posts

### DIFF
--- a/tests/test_vk_source.py
+++ b/tests/test_vk_source.py
@@ -1,4 +1,5 @@
 import pytest
+from pathlib import Path
 import main
 
 
@@ -52,4 +53,33 @@ def test_build_vk_source_message_converts_links():
     msg = main.build_vk_source_message(text, None, display_link=False)
     assert "здесь (http://reg)" in msg
     assert "билеты (http://pay)" in msg
+
+
+@pytest.mark.asyncio
+async def test_add_events_from_text_preserves_links(tmp_path: Path, monkeypatch):
+    main.VK_AFISHA_GROUP_ID = ""
+    db = main.Database(str(tmp_path / "db.sqlite"))
+    await db.init()
+
+    async def fake_parse(text: str, source_channel: str | None = None, festival_names=None):
+        return [
+            {
+                "title": "T",
+                "short_description": "d",
+                "date": "2099-01-01",
+                "time": "18:00",
+                "location_name": "Hall",
+            }
+        ]
+
+    async def fake_create(title, text, source, html_text=None, media=None, ics_url=None, db=None, **kwargs):
+        return "url", "p"
+
+    monkeypatch.setattr(main, "parse_event_via_4o", fake_parse)
+    monkeypatch.setattr(main, "create_source_page", fake_create)
+
+    html = "<a href='http://reg'>Регистрация</a>"
+    res = await main.add_events_from_text(db, "Регистрация", None, html, None)
+    ev = res[0][0]
+    assert "Регистрация (http://reg)" in ev.source_text
 


### PR DESCRIPTION
## Summary
- convert HTML links in event text to `label (url)` when saving source text so VK source posts keep registration links
- apply same link exposure to raw event creation
- add test verifying that links are preserved

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688e53a51e288332bcb0f1ed994de9e3