### PR TITLE
Add timeout for Telegraph API calls

### DIFF
--- a/tests/test_bot.py
+++ b/tests/test_bot.py
@@ -937,6 +937,18 @@ async def test_telegraph_test(monkeypatch, capsys):
 
 
 @pytest.mark.asyncio
+async def test_telegraph_call_timeout(monkeypatch):
+    monkeypatch.setattr(main, "TELEGRAPH_TIMEOUT", 0.05)
+
+    def slow():
+        import time as time_module
+        time_module.sleep(0.2)
+
+    with pytest.raises(TelegraphException):
+        await main.telegraph_call(slow)
+
+
+@pytest.mark.asyncio
 async def test_create_source_page_photo(monkeypatch):
     class DummyTG:
         def __init__(self, access_token=None):


### PR DESCRIPTION
## Summary
- avoid hanging when Telegraph is slow by running API calls with a timeout
- cover the new timeout helper with a unit test

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688e8689388083328a74af40fdbd2dfa