### PR TITLE
Include event time in VK weekend posts

### DIFF
--- a/main.py
+++ b/main.py
@@ -4893,7 +4893,10 @@ async def build_weekend_vk_message(db: Database, start: str) -> str:
         lines.append(VK_BLANK_LINE)
         lines.append(f"🟥🟥🟥 {format_day_pretty(d)} 🟥🟥🟥")
         for ev in evs:
-            lines.append(f"[{ev.source_vk_post_url}|{ev.title}]")
+            line = f"[{ev.source_vk_post_url}|{ev.title}]"
+            if ev.time:
+                line = f"{ev.time} | {line}"
+            lines.append(line)
             location_parts = [p for p in [ev.location_name, ev.city] if p]
             if location_parts:
                 lines.append(", ".join(location_parts))

--- a/tests/test_vk_weekend.py
+++ b/tests/test_vk_weekend.py
@@ -20,7 +20,7 @@ async def test_build_weekend_vk_message(tmp_path: Path):
         session.add(Event(title='NoVK', description='d', source_text='s', date=sat.isoformat(), time='11:00', location_name='Hall', city='Kaliningrad'))
         await session.commit()
     msg = await main.build_weekend_vk_message(db, sat.isoformat())
-    assert '[https://vk.com/wall-1_1|Party]' in msg
+    assert '10:00 | [https://vk.com/wall-1_1|Party]' in msg
     assert 'NoVK' not in msg
     assert f'[https://vk.com/wall-1_2|{format_weekend_range(next_sat)}]' in msg
     assert msg.splitlines()[0] == f'{format_weekend_range(sat)} Афиша выходных'


### PR DESCRIPTION
## Summary
- Prepend event time before the linked title in VK weekend posts, keeping the time outside the hyperlink
- Update weekend VK post test to cover the new plain-text time prefix

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688e8f3398d48332bb95210ad46e59d9