### PR TITLE
Link VK titles in daily posts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -165,6 +165,10 @@
 - Weekend VK posts include only events with existing VK source posts and no
   longer attempt to create source posts automatically.
 
+## v0.3.25 - Daily VK title links
+
+- Event titles in VK daily announcements link to their VK posts when available.
+
 
 
 

--- a/main.py
+++ b/main.py
@@ -4079,8 +4079,16 @@ def format_event_vk(
     if e.emoji and not e.title.strip().startswith(e.emoji):
         emoji_part = f"{e.emoji} "
 
+    vk_link = e.source_vk_post_url if is_vk_wall_url(e.source_vk_post_url) else None
+    if not vk_link and is_vk_wall_url(e.source_post_url):
+        vk_link = e.source_post_url
 
-    title = f"{prefix}{emoji_part}{e.title.upper()}".strip()
+    title_text = f"{emoji_part}{e.title.upper()}".strip()
+    if vk_link:
+        title = f"{prefix}[{vk_link}|{title_text}]".strip()
+    else:
+        title = f"{prefix}{title_text}".strip()
+
     desc = re.sub(
         r",?\s*подробнее\s*\([^\n]*\)$",
         "",
@@ -4088,8 +4096,8 @@ def format_event_vk(
         flags=re.I,
     )
     details_link = None
-    if is_vk_wall_url(e.source_post_url):
-        details_link = e.source_post_url
+    if vk_link:
+        details_link = vk_link
     elif e.telegraph_url:
         details_link = e.telegraph_url
     if details_link:

--- a/tests/test_bot.py
+++ b/tests/test_bot.py
@@ -4383,8 +4383,11 @@ def test_format_event_vk_with_vk_link():
         location_name="Hall",
         source_post_url="https://vk.com/wall-1_1",
         telegraph_url="https://t.me/page",
+        added_at=datetime.utcnow() - timedelta(days=2),
     )
     text = main.format_event_vk(e)
+    lines = text.splitlines()
+    assert lines[0] == "[https://vk.com/wall-1_1|T]"
     assert "[подробнее|https://vk.com/wall-1_1]" in text
     assert "t.me/page" not in text
 
@@ -4418,6 +4421,26 @@ def test_format_event_vk_festival_link():
     text = main.format_event_vk(e, festival=fest)
     lines = text.splitlines()
     assert lines[1] == "✨ [https://vk.com/wall-1_1|Jazz]"
+
+
+def test_format_event_vk_prefers_source_vk_post_url():
+    e = Event(
+        title="T",
+        description="d",
+        source_text="s",
+        date="2025-07-10",
+        time="18:00",
+        location_name="Hall",
+        source_post_url="https://example.com/page",
+        source_vk_post_url="https://vk.com/wall-1_1",
+        telegraph_url="https://t.me/page",
+        added_at=datetime.utcnow() - timedelta(days=2),
+    )
+    text = main.format_event_vk(e)
+    lines = text.splitlines()
+    assert lines[0] == "[https://vk.com/wall-1_1|T]"
+    assert "[подробнее|https://vk.com/wall-1_1]" in text
+    assert "t.me/page" not in text
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- Link event titles in VK daily announcements to their VK posts using `[url|title]`
- Prefer `source_vk_post_url` over other links and update descriptions accordingly
- Add regression tests and changelog entry for VK daily title links

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_688e9f29e51c8332b1e477b6469fce05