### PR TITLE
Prefer partner VK posts for daily links

### DIFF
--- a/main.py
+++ b/main.py
@@ -4079,9 +4079,9 @@ def format_event_vk(
     if e.emoji and not e.title.strip().startswith(e.emoji):
         emoji_part = f"{e.emoji} "
 
-    vk_link = e.source_vk_post_url if is_vk_wall_url(e.source_vk_post_url) else None
-    if not vk_link and is_vk_wall_url(e.source_post_url):
-        vk_link = e.source_post_url
+    vk_link = e.source_post_url if is_vk_wall_url(e.source_post_url) else None
+    if not vk_link and is_vk_wall_url(e.source_vk_post_url):
+        vk_link = e.source_vk_post_url
 
     title_text = f"{emoji_part}{e.title.upper()}".strip()
     if vk_link:

--- a/tests/test_bot.py
+++ b/tests/test_bot.py
@@ -4423,7 +4423,7 @@ def test_format_event_vk_festival_link():
     assert lines[1] == "✨ [https://vk.com/wall-1_1|Jazz]"
 
 
-def test_format_event_vk_prefers_source_vk_post_url():
+def test_format_event_vk_falls_back_to_source_vk_post_url():
     e = Event(
         title="T",
         description="d",
@@ -4440,6 +4440,26 @@ def test_format_event_vk_prefers_source_vk_post_url():
     lines = text.splitlines()
     assert lines[0] == "[https://vk.com/wall-1_1|T]"
     assert "[подробнее|https://vk.com/wall-1_1]" in text
+    assert "t.me/page" not in text
+
+
+def test_format_event_vk_prefers_source_post_url():
+    e = Event(
+        title="T",
+        description="d",
+        source_text="s",
+        date="2025-07-10",
+        time="18:00",
+        location_name="Hall",
+        source_post_url="https://vk.com/wall-1_2",
+        source_vk_post_url="https://vk.com/wall-1_1",
+        telegraph_url="https://t.me/page",
+        added_at=datetime.utcnow() - timedelta(days=2),
+    )
+    text = main.format_event_vk(e)
+    lines = text.splitlines()
+    assert lines[0] == "[https://vk.com/wall-1_2|T]"
+    assert "[подробнее|https://vk.com/wall-1_2]" in text
     assert "t.me/page" not in text
 
 


### PR DESCRIPTION
## Summary
- Prefer partner-provided `source_post_url` over `source_vk_post_url` when building VK daily announcements
- Test coverage for link precedence and fallback logic

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688f08529c488332ae546db5e620bc76