### PR TITLE
feat: expand vk source pages with event details

### DIFF
--- a/tests/test_bot.py
+++ b/tests/test_bot.py
@@ -3818,7 +3818,7 @@ async def test_add_event_lines_include_vk_link(tmp_path: Path, monkeypatch):
 
     called = False
 
-    async def fake_sync(event, source, text, db=None, bot=None, **kwargs):
+    async def fake_sync(event, text, db=None, bot=None, **kwargs):
         nonlocal called
         called = True
         return "https://vk.com/source"

--- a/tests/test_vk_source.py
+++ b/tests/test_vk_source.py
@@ -35,7 +35,6 @@ async def test_sync_vk_source_post_includes_calendar_link(monkeypatch):
 
     url = await main.sync_vk_source_post(
         event,
-        "https://source",
         "Title\nDescription",
         None,
         None,
@@ -44,13 +43,23 @@ async def test_sync_vk_source_post_includes_calendar_link(monkeypatch):
 
     assert url == "https://vk.com/wall-1_2"
     assert not any(method == "wall.createComment" for method, _ in calls)
+    lines = captured_message["text"].splitlines()
+    assert lines[0] == "Title"
+    assert lines[1] == main.VK_BLANK_LINE
     assert "Добавить в календарь http://ics" in captured_message["text"]
-    assert captured_message["text"].startswith("[https://source|Title]\nDescription")
+    assert captured_message["text"].endswith(main.VK_SOURCE_FOOTER)
 
 
 def test_build_vk_source_message_converts_links():
     text = "Регистрация [здесь](http://reg) и <a href=\"http://pay\">билеты</a>"
-    msg = main.build_vk_source_message(text, None, display_link=False)
+    event = main.Event(
+        title="T",
+        description="",
+        date="2024-01-01",
+        time="00:00",
+        location_name="Place",
+    )
+    msg = main.build_vk_source_message(event, text)
     assert "здесь (http://reg)" in msg
     assert "билеты (http://pay)" in msg
 


### PR DESCRIPTION
## Summary
- enrich VK source posts with title, festival link, pricing, schedule and location
- include original event text and optional calendar link
- update VK sync logic and tests for the new layout

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688f2156a7388332b91ff3d06ab6b394