### PR TITLE
Log queue size only when pending add_event tasks

### DIFF
--- a/main.py
+++ b/main.py
@@ -3750,8 +3750,8 @@ async def add_event_queue_worker(db: Database, bot: Bot):
     """Background worker to process queued events sequentially."""
     while True:
         size = add_event_queue.qsize()
-        logging.info("add_event_queue_worker tick: size=%d", size)
         if size > 0:
+            logging.info("add_event_queue_worker tick: size=%d", size)
             kind, msg, using_session = await add_event_queue.get()
             try:
                 if kind == "regular":


### PR DESCRIPTION
## Summary
- log add_event worker queue size only when tasks are pending

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688f8af5121483328dc092a3f57a683f