### PR TITLE
Prevent unbounded session growth

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,4 @@ markdown>=3.5
 ics==0.7.2
 supabase==2.16.0
 icalendar==6.0.1
+cachetools>=5.3.1


### PR DESCRIPTION
## Summary
- replace weekend lock dictionaries with `lru_cache` helpers limited to 20 entries
- move user session mappings to `TTLCache` to expire idle data
- add cachetools dependency

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68907c3798308332ab6b3c577f8820b6