### PR TITLE
Cache prompt and reuse http session

### DIFF
--- a/tests/test_bot.py
+++ b/tests/test_bot.py
@@ -56,6 +56,11 @@ def _mock_sync_vk_source_post(monkeypatch):
         return "https://vk.com/source"
     monkeypatch.setattr(main, "sync_vk_source_post", fake_sync)
 
+
+@pytest.fixture(autouse=True)
+def _reset_http_session(monkeypatch):
+    monkeypatch.setattr(main, "_http_session", None)
+
 FUTURE_DATE = (date.today() + timedelta(days=10)).isoformat()
 
 


### PR DESCRIPTION
## Summary
- cache built prompt text and drop lzma compression
- reuse a single aiohttp.ClientSession with limited concurrency
- free OpenAI response objects to reduce memory

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6890bf832e148332a3117834f6e45307