### PR TITLE
feat: add deep debug instrumentation

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,3 +10,4 @@ ics==0.7.2
 supabase==2.16.0
 icalendar==6.0.1
 cachetools>=5.3.1
+psutil>=5.9.0


### PR DESCRIPTION
## Summary
- add EVBOT_DEBUG switch with detailed perf logging helpers
- instrument heavy operations, queue stats, and ICS uploads for debugging
- record queue metrics and data sizes when EVBOT_DEBUG=1

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6890cc03abd08332ac2ddc4a2fcd84b4