### PR TITLE
Remove markdown dependency and streamline Telegraph page updates

### DIFF
--- a/markup.py
+++ b/markup.py
@@ -1,0 +1,16 @@
+import html, re
+from typing import List
+
+MD_BOLD   = re.compile(r'(\*\*|__)(.+?)\1', re.S)
+MD_ITALIC = re.compile(r'(\*|_)([^*_].*?)\1', re.S)
+MD_LINK   = re.compile(r'\[([^\]]+?)\]\((https?://[^)]+?)\)')
+MD_HEADER = re.compile(r'^(#{1,6})\s+(.+)$', re.M)
+
+def simple_md_to_html(text: str) -> str:
+    """Конвертирует небольшой подмножество markdown → HTML для Telegraph."""
+    text = html.escape(text)
+    text = MD_HEADER.sub(lambda m: f'<h{len(m[1])}>{m[2]}</h{len(m[1])}>', text)
+    text = MD_BOLD.sub(r'<b>\2</b>', text)
+    text = MD_ITALIC.sub(r'<i>\2</i>', text)
+    text = MD_LINK.sub(r'<a href="\2">\1</a>', text)
+    return text.replace('\n', '<br>')

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,6 @@ sqlmodel==0.0.24
 pytest==8.1.1
 pytest-asyncio==0.23.6
 telegraph==2.2.0
-markdown>=3.5
 ics==0.7.2
 supabase==2.16.0
 icalendar==6.0.1

--- a/tests/test_markup.py
+++ b/tests/test_markup.py
@@ -1,0 +1,23 @@
+import pytest
+
+from markup import simple_md_to_html
+
+
+def test_bold():
+    assert simple_md_to_html('**bold** __bold__') == '<b>bold</b> <b>bold</b>'
+
+
+def test_italic():
+    assert simple_md_to_html('*it* _it_') == '<i>it</i> <i>it</i>'
+
+
+def test_link():
+    assert simple_md_to_html('see [site](https://example.com)') == 'see <a href="https://example.com">site</a>'
+
+
+def test_header_and_newline():
+    assert simple_md_to_html('# Title\ntext') == '<h1>Title</h1><br>text'
+
+
+def test_emoji_preserved():
+    assert simple_md_to_html('smile 😀') == 'smile 😀'


### PR DESCRIPTION
## Summary
- replace python-markdown with lightweight `simple_md_to_html` converter
- simplify `sync_month_page` to build HTML once and split heuristically
- trim noisy logging and rename `TELEGRAPH_LIMIT`

## Testing
- `python -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6890edc3c5c083328d00cbf90af7fe6c