### PR TITLE
feat: pool sqlite connections and cache settings

### DIFF
--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -1,0 +1,22 @@
+import os
+import sys
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+
+import pytest
+from sqlalchemy import text
+
+from main import Database
+
+
+@pytest.mark.asyncio
+async def test_journal_mode_wal(tmp_path):
+    db_path = tmp_path / "test.sqlite"
+    db = Database(str(db_path))
+    await db.init()
+    async with db.engine.connect() as conn:
+        result = await conn.execute(text("PRAGMA journal_mode"))
+        mode = result.scalar()
+    await db.engine.dispose()
+    assert mode.lower() == "wal"
+


### PR DESCRIPTION
## Summary
- pool aiosqlite connections with WAL journal
- cache settings in memory to reduce database hits
- test that SQLite runs in WAL mode

## Testing
- `pytest tests/test_db.py -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6891077723748332b4fe0433c08c53f5