### PR TITLE
Reduce scheduler load and reuse sqlite connection

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,3 +124,12 @@ many events the bot automatically splits the announcement into two pages. The
 first one ends with a prominent link "<месяц> продолжение" leading to the second
 page.
 
+## Production tips
+
+- Periodic jobs are staggered to avoid CPU and I/O spikes. Each scheduler task
+  runs every 15 minutes with an individual offset and is limited to a single
+  concurrent instance.
+- Database access reuses a single SQLite connection and disables per-request
+  ping queries for faster read operations. A read-only context manager is
+  available for pure `SELECT` statements.
+

--- a/db.py
+++ b/db.py
@@ -1,0 +1,232 @@
+import asyncio
+from contextlib import asynccontextmanager
+
+import aiosqlite
+from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
+from sqlmodel import SQLModel
+
+
+class Database:
+    def __init__(self, path: str):
+        """Initialize async engine and reusable aiosqlite connection."""
+        self.path = path
+        self.engine = create_async_engine(
+            f"sqlite+aiosqlite:///{path}",
+            pool_size=5,
+            max_overflow=0,
+            connect_args={"timeout": 30, "isolation_level": None},
+            pool_pre_ping=False,
+        )
+        self._conn: aiosqlite.Connection | None = None
+        self._lock = asyncio.Lock()
+
+    async def raw_conn(self) -> aiosqlite.Connection:
+        """Return a shared aiosqlite connection."""
+        if self._conn is None:
+            async with self._lock:
+                if self._conn is None:
+                    self._conn = await aiosqlite.connect(self.path, timeout=30)
+                    await self._conn.execute("PRAGMA journal_mode=WAL")
+                    await self._conn.execute("PRAGMA read_uncommitted = 1")
+        return self._conn
+
+    @asynccontextmanager
+    async def read_only(self):
+        """Context manager for read-only transactions."""
+        conn = await self.raw_conn()
+        await conn.execute("BEGIN")
+        try:
+            yield conn
+        finally:
+            await conn.rollback()
+
+    async def init(self):
+        async with self.engine.begin() as conn:
+            await conn.exec_driver_sql("PRAGMA journal_mode=WAL")
+            await conn.run_sync(SQLModel.metadata.create_all)
+            result = await conn.exec_driver_sql("PRAGMA table_info(event)")
+            cols = [r[1] for r in result.fetchall()]
+            if "telegraph_url" not in cols:
+                await conn.exec_driver_sql(
+                    "ALTER TABLE event ADD COLUMN telegraph_url VARCHAR"
+                )
+            if "ticket_price_min" not in cols:
+                await conn.exec_driver_sql(
+                    "ALTER TABLE event ADD COLUMN ticket_price_min INTEGER"
+                )
+            if "ticket_price_max" not in cols:
+                await conn.exec_driver_sql(
+                    "ALTER TABLE event ADD COLUMN ticket_price_max INTEGER"
+                )
+            if "ticket_link" not in cols:
+                await conn.exec_driver_sql(
+                    "ALTER TABLE event ADD COLUMN ticket_link VARCHAR"
+                )
+            if "source_post_url" not in cols:
+                await conn.exec_driver_sql(
+                    "ALTER TABLE event ADD COLUMN source_post_url VARCHAR"
+                )
+            if "source_vk_post_url" not in cols:
+                await conn.exec_driver_sql(
+                    "ALTER TABLE event ADD COLUMN source_vk_post_url VARCHAR"
+                )
+            if "is_free" not in cols:
+                await conn.exec_driver_sql(
+                    "ALTER TABLE event ADD COLUMN is_free BOOLEAN DEFAULT 0"
+                )
+            if "silent" not in cols:
+                await conn.exec_driver_sql(
+                    "ALTER TABLE event ADD COLUMN silent BOOLEAN DEFAULT 0"
+                )
+            if "telegraph_path" not in cols:
+                await conn.exec_driver_sql(
+                    "ALTER TABLE event ADD COLUMN telegraph_path VARCHAR"
+                )
+            if "event_type" not in cols:
+                await conn.exec_driver_sql(
+                    "ALTER TABLE event ADD COLUMN event_type VARCHAR"
+                )
+            if "emoji" not in cols:
+                await conn.exec_driver_sql("ALTER TABLE event ADD COLUMN emoji VARCHAR")
+            if "end_date" not in cols:
+                await conn.exec_driver_sql(
+                    "ALTER TABLE event ADD COLUMN end_date VARCHAR"
+                )
+            if "added_at" not in cols:
+                await conn.exec_driver_sql(
+                    "ALTER TABLE event ADD COLUMN added_at VARCHAR"
+                )
+            if "photo_count" not in cols:
+                await conn.exec_driver_sql(
+                    "ALTER TABLE event ADD COLUMN photo_count INTEGER DEFAULT 0"
+                )
+            if "pushkin_card" not in cols:
+                await conn.exec_driver_sql(
+                    "ALTER TABLE event ADD COLUMN pushkin_card BOOLEAN DEFAULT 0"
+                )
+            if "ics_url" not in cols:
+                await conn.exec_driver_sql(
+                    "ALTER TABLE event ADD COLUMN ics_url VARCHAR"
+                )
+            if "ics_post_url" not in cols:
+                await conn.exec_driver_sql(
+                    "ALTER TABLE event ADD COLUMN ics_post_url VARCHAR"
+                )
+            if "ics_post_id" not in cols:
+                await conn.exec_driver_sql(
+                    "ALTER TABLE event ADD COLUMN ics_post_id INTEGER"
+                )
+            if "source_chat_id" not in cols:
+                await conn.exec_driver_sql(
+                    "ALTER TABLE event ADD COLUMN source_chat_id INTEGER"
+                )
+            if "source_message_id" not in cols:
+                await conn.exec_driver_sql(
+                    "ALTER TABLE event ADD COLUMN source_message_id INTEGER"
+                )
+            if "creator_id" not in cols:
+                await conn.exec_driver_sql(
+                    "ALTER TABLE event ADD COLUMN creator_id INTEGER"
+                )
+
+            result = await conn.exec_driver_sql("PRAGMA table_info(user)")
+            cols = [r[1] for r in result.fetchall()]
+            if "is_partner" not in cols:
+                await conn.exec_driver_sql(
+                    "ALTER TABLE user ADD COLUMN is_partner BOOLEAN DEFAULT 0"
+                )
+            if "organization" not in cols:
+                await conn.exec_driver_sql(
+                    "ALTER TABLE user ADD COLUMN organization VARCHAR"
+                )
+            if "location" not in cols:
+                await conn.exec_driver_sql(
+                    "ALTER TABLE user ADD COLUMN location VARCHAR"
+                )
+            if "blocked" not in cols:
+                await conn.exec_driver_sql(
+                    "ALTER TABLE user ADD COLUMN blocked BOOLEAN DEFAULT 0"
+                )
+            if "last_partner_reminder" not in cols:
+                await conn.exec_driver_sql(
+                    "ALTER TABLE user ADD COLUMN last_partner_reminder VARCHAR"
+                )
+
+            result = await conn.exec_driver_sql("PRAGMA table_info(channel)")
+            cols = [r[1] for r in result.fetchall()]
+            if "daily_time" not in cols:
+                await conn.exec_driver_sql(
+                    "ALTER TABLE channel ADD COLUMN daily_time VARCHAR"
+                )
+            if "last_daily" not in cols:
+                await conn.exec_driver_sql(
+                    "ALTER TABLE channel ADD COLUMN last_daily VARCHAR"
+                )
+            if "is_asset" not in cols:
+                await conn.exec_driver_sql(
+                    "ALTER TABLE channel ADD COLUMN is_asset BOOLEAN DEFAULT 0"
+                )
+
+            result = await conn.exec_driver_sql("PRAGMA table_info(monthpage)")
+            cols = [r[1] for r in result.fetchall()]
+            if "url2" not in cols:
+                await conn.exec_driver_sql(
+                    "ALTER TABLE monthpage ADD COLUMN url2 VARCHAR"
+                )
+            if "path2" not in cols:
+                await conn.exec_driver_sql(
+                    "ALTER TABLE monthpage ADD COLUMN path2 VARCHAR"
+                )
+
+            result = await conn.exec_driver_sql("PRAGMA table_info(weekendpage)")
+            cols = [r[1] for r in result.fetchall()]
+            if "vk_post_url" not in cols:
+                await conn.exec_driver_sql(
+                    "ALTER TABLE weekendpage ADD COLUMN vk_post_url VARCHAR"
+                )
+
+            result = await conn.exec_driver_sql("PRAGMA table_info(festival)")
+            cols = [r[1] for r in result.fetchall()]
+            if "full_name" not in cols:
+                await conn.exec_driver_sql(
+                    "ALTER TABLE festival ADD COLUMN full_name VARCHAR"
+                )
+                await conn.exec_driver_sql(
+                    "UPDATE festival SET full_name = name"
+                )
+            if "photo_url" not in cols:
+                await conn.exec_driver_sql(
+                    "ALTER TABLE festival ADD COLUMN photo_url VARCHAR"
+                )
+            if "website_url" not in cols:
+                await conn.exec_driver_sql(
+                    "ALTER TABLE festival ADD COLUMN website_url VARCHAR"
+                )
+            if "vk_url" not in cols:
+                await conn.exec_driver_sql(
+                    "ALTER TABLE festival ADD COLUMN vk_url VARCHAR"
+                )
+            if "tg_url" not in cols:
+                await conn.exec_driver_sql(
+                    "ALTER TABLE festival ADD COLUMN tg_url VARCHAR"
+                )
+            if "start_date" not in cols:
+                await conn.exec_driver_sql(
+                    "ALTER TABLE festival ADD COLUMN start_date VARCHAR"
+                )
+            if "end_date" not in cols:
+                await conn.exec_driver_sql(
+                    "ALTER TABLE festival ADD COLUMN end_date VARCHAR"
+                )
+            if "vk_poll_url" not in cols:
+                await conn.exec_driver_sql(
+                    "ALTER TABLE festival ADD COLUMN vk_poll_url VARCHAR"
+                )
+
+        # ensure shared connection is ready
+        await self.raw_conn()
+
+    def get_session(self) -> AsyncSession:
+        """Create a new session with attributes kept after commit."""
+        return AsyncSession(self.engine, expire_on_commit=False)
+

--- a/main.py
+++ b/main.py
@@ -37,7 +37,7 @@ import asyncio
 import contextlib
 import html
 from io import BytesIO
-from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
+from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy import update
 from sqlmodel import Field, SQLModel, select
 import aiosqlite
@@ -46,6 +46,8 @@ import atexit
 from cachetools import TTLCache
 from markup import simple_md_to_html
 from apscheduler.schedulers.asyncio import AsyncIOScheduler
+from db import Database
+from scheduler import setup_scheduler
 
 DEBUG = os.getenv("EVBOT_DEBUG") == "1"
 LOG_LVL = logging.DEBUG if DEBUG else logging.INFO
@@ -421,205 +423,6 @@ class Festival(SQLModel, table=True):
     vk_url: Optional[str] = None
     tg_url: Optional[str] = None
 
-
-class Database:
-    def __init__(self, path: str):
-        """Initialize async engine with WAL and connection pooling."""
-        self.engine = create_async_engine(
-            f"sqlite+aiosqlite:///{path}",
-            pool_size=5,
-            max_overflow=0,
-            connect_args={"timeout": 30, "isolation_level": None},
-            pool_pre_ping=True,
-        )
-
-    async def init(self):
-        async with self.engine.begin() as conn:
-            await conn.exec_driver_sql("PRAGMA journal_mode=WAL")
-            await conn.run_sync(SQLModel.metadata.create_all)
-            result = await conn.exec_driver_sql("PRAGMA table_info(event)")
-            cols = [r[1] for r in result.fetchall()]
-            if "telegraph_url" not in cols:
-                await conn.exec_driver_sql(
-                    "ALTER TABLE event ADD COLUMN telegraph_url VARCHAR"
-                )
-            if "ticket_price_min" not in cols:
-                await conn.exec_driver_sql(
-                    "ALTER TABLE event ADD COLUMN ticket_price_min INTEGER"
-                )
-            if "ticket_price_max" not in cols:
-                await conn.exec_driver_sql(
-                    "ALTER TABLE event ADD COLUMN ticket_price_max INTEGER"
-                )
-            if "ticket_link" not in cols:
-                await conn.exec_driver_sql(
-                    "ALTER TABLE event ADD COLUMN ticket_link VARCHAR"
-                )
-            if "source_post_url" not in cols:
-                await conn.exec_driver_sql(
-                    "ALTER TABLE event ADD COLUMN source_post_url VARCHAR"
-                )
-            if "source_vk_post_url" not in cols:
-                await conn.exec_driver_sql(
-                    "ALTER TABLE event ADD COLUMN source_vk_post_url VARCHAR"
-                )
-            if "is_free" not in cols:
-                await conn.exec_driver_sql(
-                    "ALTER TABLE event ADD COLUMN is_free BOOLEAN DEFAULT 0"
-                )
-            if "silent" not in cols:
-                await conn.exec_driver_sql(
-                    "ALTER TABLE event ADD COLUMN silent BOOLEAN DEFAULT 0"
-                )
-            if "telegraph_path" not in cols:
-                await conn.exec_driver_sql(
-                    "ALTER TABLE event ADD COLUMN telegraph_path VARCHAR"
-                )
-            if "event_type" not in cols:
-                await conn.exec_driver_sql(
-                    "ALTER TABLE event ADD COLUMN event_type VARCHAR"
-                )
-            if "emoji" not in cols:
-                await conn.exec_driver_sql("ALTER TABLE event ADD COLUMN emoji VARCHAR")
-            if "end_date" not in cols:
-                await conn.exec_driver_sql(
-                    "ALTER TABLE event ADD COLUMN end_date VARCHAR"
-                )
-            if "added_at" not in cols:
-                await conn.exec_driver_sql(
-                    "ALTER TABLE event ADD COLUMN added_at VARCHAR"
-                )
-            if "photo_count" not in cols:
-                await conn.exec_driver_sql(
-                    "ALTER TABLE event ADD COLUMN photo_count INTEGER DEFAULT 0"
-                )
-            if "pushkin_card" not in cols:
-                await conn.exec_driver_sql(
-                    "ALTER TABLE event ADD COLUMN pushkin_card BOOLEAN DEFAULT 0"
-                )
-            if "ics_url" not in cols:
-                await conn.exec_driver_sql(
-                    "ALTER TABLE event ADD COLUMN ics_url VARCHAR"
-                )
-            if "ics_post_url" not in cols:
-                await conn.exec_driver_sql(
-                    "ALTER TABLE event ADD COLUMN ics_post_url VARCHAR"
-                )
-            if "ics_post_id" not in cols:
-                await conn.exec_driver_sql(
-                    "ALTER TABLE event ADD COLUMN ics_post_id INTEGER"
-                )
-            if "source_chat_id" not in cols:
-                await conn.exec_driver_sql(
-                    "ALTER TABLE event ADD COLUMN source_chat_id INTEGER"
-                )
-            if "source_message_id" not in cols:
-                await conn.exec_driver_sql(
-                    "ALTER TABLE event ADD COLUMN source_message_id INTEGER"
-                )
-            if "creator_id" not in cols:
-                await conn.exec_driver_sql(
-                    "ALTER TABLE event ADD COLUMN creator_id INTEGER"
-                )
-
-            result = await conn.exec_driver_sql("PRAGMA table_info(user)")
-            cols = [r[1] for r in result.fetchall()]
-            if "is_partner" not in cols:
-                await conn.exec_driver_sql(
-                    "ALTER TABLE user ADD COLUMN is_partner BOOLEAN DEFAULT 0"
-                )
-            if "organization" not in cols:
-                await conn.exec_driver_sql(
-                    "ALTER TABLE user ADD COLUMN organization VARCHAR"
-                )
-            if "location" not in cols:
-                await conn.exec_driver_sql(
-                    "ALTER TABLE user ADD COLUMN location VARCHAR"
-                )
-            if "blocked" not in cols:
-                await conn.exec_driver_sql(
-                    "ALTER TABLE user ADD COLUMN blocked BOOLEAN DEFAULT 0"
-                )
-            if "last_partner_reminder" not in cols:
-                await conn.exec_driver_sql(
-                    "ALTER TABLE user ADD COLUMN last_partner_reminder VARCHAR"
-                )
-
-            result = await conn.exec_driver_sql("PRAGMA table_info(channel)")
-            cols = [r[1] for r in result.fetchall()]
-            if "daily_time" not in cols:
-                await conn.exec_driver_sql(
-                    "ALTER TABLE channel ADD COLUMN daily_time VARCHAR"
-                )
-            if "last_daily" not in cols:
-                await conn.exec_driver_sql(
-                    "ALTER TABLE channel ADD COLUMN last_daily VARCHAR"
-                )
-            if "is_asset" not in cols:
-                await conn.exec_driver_sql(
-                    "ALTER TABLE channel ADD COLUMN is_asset BOOLEAN DEFAULT 0"
-                )
-
-            result = await conn.exec_driver_sql("PRAGMA table_info(monthpage)")
-            cols = [r[1] for r in result.fetchall()]
-            if "url2" not in cols:
-                await conn.exec_driver_sql(
-                    "ALTER TABLE monthpage ADD COLUMN url2 VARCHAR"
-                )
-            if "path2" not in cols:
-                await conn.exec_driver_sql(
-                    "ALTER TABLE monthpage ADD COLUMN path2 VARCHAR"
-                )
-
-            result = await conn.exec_driver_sql("PRAGMA table_info(weekendpage)")
-            cols = [r[1] for r in result.fetchall()]
-            if "vk_post_url" not in cols:
-                await conn.exec_driver_sql(
-                    "ALTER TABLE weekendpage ADD COLUMN vk_post_url VARCHAR"
-                )
-
-            result = await conn.exec_driver_sql("PRAGMA table_info(festival)")
-            cols = [r[1] for r in result.fetchall()]
-            if "full_name" not in cols:
-                await conn.exec_driver_sql(
-                    "ALTER TABLE festival ADD COLUMN full_name VARCHAR"
-                )
-                await conn.exec_driver_sql(
-                    "UPDATE festival SET full_name = name"
-                )
-            if "photo_url" not in cols:
-                await conn.exec_driver_sql(
-                    "ALTER TABLE festival ADD COLUMN photo_url VARCHAR"
-                )
-            if "website_url" not in cols:
-                await conn.exec_driver_sql(
-                    "ALTER TABLE festival ADD COLUMN website_url VARCHAR"
-                )
-            if "vk_url" not in cols:
-                await conn.exec_driver_sql(
-                    "ALTER TABLE festival ADD COLUMN vk_url VARCHAR"
-                )
-            if "tg_url" not in cols:
-                await conn.exec_driver_sql(
-                    "ALTER TABLE festival ADD COLUMN tg_url VARCHAR"
-                )
-            if "start_date" not in cols:
-                await conn.exec_driver_sql(
-                    "ALTER TABLE festival ADD COLUMN start_date VARCHAR"
-                )
-            if "end_date" not in cols:
-                await conn.exec_driver_sql(
-                    "ALTER TABLE festival ADD COLUMN end_date VARCHAR"
-                )
-
-            if "vk_poll_url" not in cols:
-                await conn.exec_driver_sql(
-                    "ALTER TABLE festival ADD COLUMN vk_poll_url VARCHAR"
-                )
-
-    def get_session(self) -> AsyncSession:
-        """Create a new session with attributes kept after commit."""
-        return AsyncSession(self.engine, expire_on_commit=False)
 
 
 async def get_tz_offset(db: Database) -> str:
@@ -1081,22 +884,24 @@ async def notify_inactive_partners(
     return notified
 
 
-async def dump_database(path: str = DB_PATH) -> bytes:
-    """Return a SQL dump of the specified database."""
-    async with aiosqlite.connect(path, timeout=30) as conn:
-        lines: list[str] = []
-        async for line in conn.iterdump():
-            lines.append(line)
+async def dump_database(db: Database) -> bytes:
+    """Return a SQL dump using the shared connection."""
+    conn = await db.raw_conn()
+    lines: list[str] = []
+    async for line in conn.iterdump():
+        lines.append(line)
     return "\n".join(lines).encode("utf-8")
 
 
-async def restore_database(data: bytes, db: Database, path: str = DB_PATH):
+async def restore_database(data: bytes, db: Database):
     """Replace current database with the provided dump."""
+    path = db.path
     if os.path.exists(path):
         os.remove(path)
     async with aiosqlite.connect(path, timeout=30) as conn:
         await conn.executescript(data.decode("utf-8"))
         await conn.commit()
+        await conn.close()
     await db.init()
 
 
@@ -6575,12 +6380,7 @@ async def vk_poll_scheduler(db: Database, bot: Bot):
 
 
 def start_periodic_tasks(db: Database, bot: Bot) -> AsyncIOScheduler:
-    scheduler = AsyncIOScheduler()
-    scheduler.add_job(vk_scheduler, "interval", minutes=15, args=[db, bot])
-    scheduler.add_job(vk_poll_scheduler, "interval", minutes=15, args=[db, bot])
-    scheduler.add_job(cleanup_scheduler, "interval", minutes=15, args=[db, bot])
-    scheduler.add_job(page_update_scheduler, "interval", minutes=15, args=[db])
-    scheduler.add_job(partner_notification_scheduler, "interval", minutes=15, args=[db, bot])
+    scheduler = setup_scheduler(db, bot)
     scheduler.start()
     return scheduler
 
@@ -7182,7 +6982,7 @@ async def handle_dumpdb(message: types.Message, db: Database, bot: Bot):
         tz_setting = await session.get(Setting, "tz_offset")
         catbox_setting = await session.get(Setting, "catbox_enabled")
 
-    data = await dump_database(db.engine.url.database)
+    data = await dump_database(db)
     file = types.BufferedInputFile(data, filename="dump.sql")
     await bot.send_document(message.chat.id, file)
     token_exists = os.path.exists(TELEGRAPH_TOKEN_FILE)
@@ -7240,7 +7040,7 @@ async def handle_restore(message: types.Message, db: Database, bot: Bot):
         return
     bio = BytesIO()
     await bot.download(document.file_id, destination=bio)
-    await restore_database(bio.getvalue(), db, db.engine.url.database)
+    await restore_database(bio.getvalue(), db)
     await bot.send_message(message.chat.id, "Database restored")
 async def handle_edit_message(message: types.Message, db: Database, bot: Bot):
     state = editing_sessions.get(message.from_user.id)

--- a/scheduler.py
+++ b/scheduler.py
@@ -1,0 +1,57 @@
+from apscheduler.schedulers.asyncio import AsyncIOScheduler
+
+
+def setup_scheduler(db, bot):
+    """Configure periodic jobs with staggered start times."""
+    # Import here to avoid circular dependencies during module import.
+    from main import (
+        vk_scheduler,
+        vk_poll_scheduler,
+        cleanup_scheduler,
+        page_update_scheduler,
+        partner_notification_scheduler,
+    )
+
+    scheduler = AsyncIOScheduler()
+    scheduler.add_job(
+        vk_scheduler,
+        "cron",
+        minute="1,16,31,46",
+        misfire_grace_time=60,
+        max_instances=1,
+        args=[db, bot],
+    )
+    scheduler.add_job(
+        vk_poll_scheduler,
+        "cron",
+        minute="2,17,32,47",
+        misfire_grace_time=60,
+        max_instances=1,
+        args=[db, bot],
+    )
+    scheduler.add_job(
+        cleanup_scheduler,
+        "cron",
+        minute="3,18,33,48",
+        misfire_grace_time=60,
+        max_instances=1,
+        args=[db, bot],
+    )
+    scheduler.add_job(
+        page_update_scheduler,
+        "cron",
+        minute="4,19,34,49",
+        misfire_grace_time=60,
+        max_instances=1,
+        args=[db],
+    )
+    scheduler.add_job(
+        partner_notification_scheduler,
+        "cron",
+        minute="5,20,35,50",
+        misfire_grace_time=60,
+        max_instances=1,
+        args=[db, bot],
+    )
+    return scheduler
+

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -1,0 +1,13 @@
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parent.parent))
+from scheduler import setup_scheduler
+
+
+def test_scheduler_offsets_and_limits():
+    scheduler = setup_scheduler(None, None)
+    jobs = scheduler.get_jobs()
+    assert all(job.misfire_grace_time == 60 for job in jobs)
+    assert all(job.max_instances == 1 for job in jobs)
+    assert "minute='1,16,31,46'" in str(jobs[0].trigger)


### PR DESCRIPTION
## Summary
- create `db` module with shared SQLite connection and read-only helper
- stagger periodic jobs with misfire limits
- document production tips and add scheduler test

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68911150351c83328995938d23089f20