### PR TITLE
Optimize runtime and lazy-load Supabase

### DIFF
--- a/fly.toml
+++ b/fly.toml
@@ -7,6 +7,8 @@ app = "events-bot-new"
 
 [env]
   PORT = "8080"
+  PYTHONOPTIMIZE = "2"
+  DISABLE_SUPABASE = "1"
 
 
 [[mounts]]

--- a/tests/test_startup_rss.py
+++ b/tests/test_startup_rss.py
@@ -1,6 +1,5 @@
 import asyncio
 import gc
-import os
 
 import psutil
 import pytest
@@ -12,7 +11,6 @@ from main import print_current_rss
 @pytest.mark.skip("RSS check is intended for manual runs")
 @pytest.mark.asyncio
 async def test_startup_rss(tmp_path, caplog):
-    os.environ["PROFILE"] = "1"
     db = Database(str(tmp_path / "db.sqlite"))
     await db.init()
     with caplog.at_level("INFO"):


### PR DESCRIPTION
## Summary
- remove runtime profiling scaffolding to reduce memory usage
- defer Supabase imports and allow disabling via `DISABLE_SUPABASE`
- configure Fly to optimize Python and disable Supabase by default

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68912885facc8332ad7848e836378931