### PR TITLE
Refactor models, scheduler, and logging

### DIFF
--- a/fly.toml
+++ b/fly.toml
@@ -27,3 +27,9 @@ app = "events-bot-new"
   [[services.ports]]
     handlers = ["tls", "http"]
     port = "443"
+
+  [[services.checks]]
+    interval = "15s"
+    timeout  = "2s"
+    method   = "get"
+    path     = "/healthz"

--- a/models.py
+++ b/models.py
@@ -1,0 +1,116 @@
+from datetime import datetime
+from typing import Optional
+
+from sqlmodel import Field, SQLModel
+
+
+class User(SQLModel, table=True):
+    user_id: int = Field(primary_key=True)
+    username: Optional[str] = None
+    is_superadmin: bool = False
+    is_partner: bool = False
+    organization: Optional[str] = None
+    location: Optional[str] = None
+    blocked: bool = False
+    last_partner_reminder: Optional[datetime] = None
+
+
+class PendingUser(SQLModel, table=True):
+    user_id: int = Field(primary_key=True)
+    username: Optional[str] = None
+    requested_at: datetime = Field(default_factory=datetime.utcnow)
+
+
+class RejectedUser(SQLModel, table=True):
+    user_id: int = Field(primary_key=True)
+    username: Optional[str] = None
+    rejected_at: datetime = Field(default_factory=datetime.utcnow)
+
+
+class Channel(SQLModel, table=True):
+    channel_id: int = Field(primary_key=True)
+    title: Optional[str] = None
+    username: Optional[str] = None
+    is_admin: bool = False
+    is_registered: bool = False
+    is_asset: bool = False
+    daily_time: Optional[str] = None
+    last_daily: Optional[str] = None
+
+
+class Setting(SQLModel, table=True):
+    key: str = Field(primary_key=True)
+    value: str
+
+
+class Event(SQLModel, table=True):
+    id: Optional[int] = Field(default=None, primary_key=True)
+    title: str
+    description: str
+    festival: Optional[str] = None
+    date: str
+    time: str
+    location_name: str
+    location_address: Optional[str] = None
+    city: Optional[str] = None
+    ticket_price_min: Optional[int] = None
+    ticket_price_max: Optional[int] = None
+    ticket_link: Optional[str] = None
+    event_type: Optional[str] = None
+    emoji: Optional[str] = None
+    end_date: Optional[str] = None
+    is_free: bool = False
+    pushkin_card: bool = False
+    silent: bool = False
+    telegraph_path: Optional[str] = None
+    source_text: str
+    telegraph_url: Optional[str] = None
+    ics_url: Optional[str] = None
+    source_post_url: Optional[str] = None
+    source_vk_post_url: Optional[str] = None
+    ics_post_url: Optional[str] = None
+    ics_post_id: Optional[int] = None
+    source_chat_id: Optional[int] = None
+    source_message_id: Optional[int] = None
+    creator_id: Optional[int] = None
+    photo_count: int = 0
+    added_at: datetime = Field(default_factory=datetime.utcnow)
+
+
+class MonthPage(SQLModel, table=True):
+    __table_args__ = {"extend_existing": True}
+    month: str = Field(primary_key=True)
+    url: str
+    path: str
+    url2: Optional[str] = None
+    path2: Optional[str] = None
+
+
+class WeekendPage(SQLModel, table=True):
+    __table_args__ = {"extend_existing": True}
+    start: str = Field(primary_key=True)
+    url: str
+    path: str
+    vk_post_url: Optional[str] = None
+
+
+class Festival(SQLModel, table=True):
+    __table_args__ = {"extend_existing": True}
+    id: Optional[int] = Field(default=None, primary_key=True)
+    name: str
+    full_name: Optional[str] = None
+    description: Optional[str] = None
+    start_date: Optional[str] = None
+    end_date: Optional[str] = None
+    telegraph_url: Optional[str] = None
+    telegraph_path: Optional[str] = None
+    vk_post_url: Optional[str] = None
+    vk_poll_url: Optional[str] = None
+    photo_url: Optional[str] = None
+    website_url: Optional[str] = None
+    vk_url: Optional[str] = None
+    tg_url: Optional[str] = None
+
+
+def create_all(engine) -> None:
+    SQLModel.metadata.create_all(engine)

--- a/scheduler.py
+++ b/scheduler.py
@@ -1,62 +1,67 @@
 from apscheduler.executors.asyncio import AsyncIOExecutor
 from apscheduler.schedulers.asyncio import AsyncIOScheduler
 
-
-class LimitedAsyncIOExecutor(AsyncIOExecutor):
-    def __init__(self, max_workers: int = 2):
-        super().__init__()
-        self._max_workers = max_workers
+_scheduler: AsyncIOScheduler | None = None
 
 
-def setup_scheduler(db, bot):
-    """Configure periodic jobs with staggered start times."""
-    # Import here to avoid circular dependencies during module import.
-    from main import (
-        vk_scheduler,
-        vk_poll_scheduler,
-        cleanup_scheduler,
-        page_update_scheduler,
-        partner_notification_scheduler,
-    )
+def startup(db, bot) -> AsyncIOScheduler:
+    global _scheduler
+    if _scheduler is None:
+        from main import (
+            vk_scheduler,
+            vk_poll_scheduler,
+            cleanup_scheduler,
+            page_update_scheduler,
+            partner_notification_scheduler,
+        )
 
-    scheduler = AsyncIOScheduler(
-        executors={"default": LimitedAsyncIOExecutor(2)},
-        job_defaults={"coalesce": True, "misfire_grace_time": 30},
-    )
-    scheduler.add_job(
-        vk_scheduler,
-        "cron",
-        minute="1,16,31,46",
-        max_instances=1,
-        args=[db, bot],
-    )
-    scheduler.add_job(
-        vk_poll_scheduler,
-        "cron",
-        minute="2,17,32,47",
-        max_instances=1,
-        args=[db, bot],
-    )
-    scheduler.add_job(
-        cleanup_scheduler,
-        "cron",
-        minute="3,18,33,48",
-        max_instances=1,
-        args=[db, bot],
-    )
-    scheduler.add_job(
-        page_update_scheduler,
-        "cron",
-        minute="4,19,34,49",
-        max_instances=1,
-        args=[db],
-    )
-    scheduler.add_job(
-        partner_notification_scheduler,
-        "cron",
-        minute="5,20,35,50",
-        max_instances=1,
-        args=[db, bot],
-    )
-    return scheduler
+        executor = AsyncIOExecutor()
+        executor._max_workers = 2
+        _scheduler = AsyncIOScheduler(
+            executors={"default": executor},
+            job_defaults={"coalesce": True, "misfire_grace_time": 30},
+        )
+        _scheduler.add_job(
+            vk_scheduler,
+            "cron",
+            minute="1,16,31,46",
+            max_instances=1,
+            args=[db, bot],
+        )
+        _scheduler.add_job(
+            vk_poll_scheduler,
+            "cron",
+            minute="2,17,32,47",
+            max_instances=1,
+            args=[db, bot],
+        )
+        _scheduler.add_job(
+            cleanup_scheduler,
+            "cron",
+            minute="3,18,33,48",
+            max_instances=1,
+            args=[db, bot],
+        )
+        _scheduler.add_job(
+            page_update_scheduler,
+            "cron",
+            minute="4,19,34,49",
+            max_instances=1,
+            args=[db],
+        )
+        _scheduler.add_job(
+            partner_notification_scheduler,
+            "cron",
+            minute="5,20,35,50",
+            max_instances=1,
+            args=[db, bot],
+        )
+        _scheduler.start()
+    return _scheduler
 
+
+def cleanup() -> None:
+    global _scheduler
+    if _scheduler:
+        _scheduler.shutdown(wait=False)
+        _scheduler = None

--- a/tests/test_scheduler_limits.py
+++ b/tests/test_scheduler_limits.py
@@ -4,16 +4,15 @@ from pathlib import Path
 import pytest
 
 sys.path.append(str(Path(__file__).resolve().parent.parent))
-from scheduler import setup_scheduler
+from scheduler import startup, cleanup
 
 
 @pytest.mark.asyncio
 async def test_scheduler_offsets_and_limits():
-    scheduler = setup_scheduler(None, None)
-    scheduler.start()
+    scheduler = startup(None, None)
     jobs = scheduler.get_jobs()
     assert all(job.misfire_grace_time == 30 for job in jobs)
     assert all(job.max_instances == 1 for job in jobs)
     assert any("minute='1,16,31,46'" in str(job.trigger) for job in jobs)
     assert scheduler._executors["default"]._max_workers == 2
-    scheduler.shutdown(wait=False)
+    cleanup()


### PR DESCRIPTION
## Summary
- centralize SQLModel models in `models.py` and reuse a shared `AsyncSession`
- add `configure_logging` and limit SQL debug noise
- set up APScheduler with a single AsyncIOExecutor and Fly health checks

## Testing
- `python -m py_compile db.py main.py scheduler.py models.py tests/test_scheduler_limits.py`
- `pytest tests/test_scheduler_limits.py -q`
- `pytest --maxfail=1` *(fails: MissingGreenlet: greenlet_spawn has not been called)*

------
https://chatgpt.com/codex/tasks/task_e_689131423dd883329adae363b6f2b999