### PR TITLE
Add instrumentation and shared HTTP session

### DIFF
--- a/db.py
+++ b/db.py
@@ -231,6 +231,13 @@ class Database:
                     "ALTER TABLE festival ADD COLUMN vk_poll_url VARCHAR"
                 )
 
+            await conn.exec_driver_sql(
+                "CREATE INDEX IF NOT EXISTS ix_events_date_city ON event(date, city)"
+            )
+            await conn.exec_driver_sql(
+                "CREATE INDEX IF NOT EXISTS ix_events_added_at ON event(added_at)"
+            )
+
         # ensure shared connection is ready
         await self.raw_conn()
 


### PR DESCRIPTION
## Summary
- add reusable `span` context manager with thresholds and logging deduplication filter
- instrument heavy operations and scheduler jobs with `span` blocks
- centralize HTTP requests through single aiohttp session and add DB indexes

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68921665e3ec83328ca6061eb9e49cca