### PR TITLE
Optimize SQLite performance and page rebuild locking

### DIFF
--- a/alembic/versions/20250806_perf_idx.py
+++ b/alembic/versions/20250806_perf_idx.py
@@ -1,0 +1,26 @@
+"""performance indexes for event table"""
+
+from alembic import op
+from sqlalchemy import text
+
+revision = "20250806_perf_idx"
+down_revision = None
+branch_labels = None
+depends_on = None
+
+def upgrade() -> None:
+    op.create_index("idx_event_date", "event", ["date"])
+    op.create_index("idx_event_added_at", "event", ["added_at"])
+    op.create_index("idx_event_date_city", "event", ["date", "city"])
+    op.create_index(
+        "idx_event_festival_date",
+        "event",
+        ["festival", "date"],
+        postgresql_where=text("festival IS NOT NULL"),
+    )
+
+def downgrade() -> None:
+    op.drop_index("idx_event_date", table_name="event")
+    op.drop_index("idx_event_added_at", table_name="event")
+    op.drop_index("idx_event_date_city", table_name="event")
+    op.drop_index("idx_event_festival_date", table_name="event")

--- a/scheduler.py
+++ b/scheduler.py
@@ -56,6 +56,17 @@ def startup(db, bot) -> AsyncIOScheduler:
             max_instances=1,
             args=[db, bot],
         )
+        _scheduler.add_job(
+            lambda: db.exec_driver_sql("PRAGMA optimize;"),
+            "cron",
+            hour="3",
+        )
+        _scheduler.add_job(
+            lambda: db.exec_driver_sql("VACUUM;"),
+            "cron",
+            day_of_week="sun",
+            hour="4",
+        )
         _scheduler.start()
     return _scheduler
 

--- a/span.py
+++ b/span.py
@@ -1,0 +1,24 @@
+import logging
+import time
+from contextlib import asynccontextmanager
+
+
+class _Span:
+    def __init__(self) -> None:
+        self._thresholds: dict[str, float] = {}
+
+    def configure(self, thresholds: dict[str, int | float]) -> None:
+        self._thresholds.update(thresholds)
+
+    @asynccontextmanager
+    async def __call__(self, label: str):
+        start = time.perf_counter()
+        try:
+            yield
+        finally:
+            dt = (time.perf_counter() - start) * 1000
+            if dt >= self._thresholds.get(label, 1000):
+                logging.debug("%s took %.0f ms", label, dt)
+
+
+span = _Span()


### PR DESCRIPTION
## Summary
- add Alembic migration for event table indexes
- apply SQLite PRAGMAs and expose `exec_driver_sql`
- schedule periodic `PRAGMA optimize` and `VACUUM`
- guard month and weekend page rebuilds with per-key locks
- introduce configurable span thresholds

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68927904900083329b8b32bf889ebd1e