### PR TITLE
Add festival source_text migration

### DIFF
--- a/db.py
+++ b/db.py
@@ -273,6 +273,10 @@ class Database:
                 await conn.exec_driver_sql(
                     "ALTER TABLE festival ADD COLUMN city VARCHAR"
                 )
+            if "source_text" not in cols:
+                await conn.exec_driver_sql(
+                    "ALTER TABLE festival ADD COLUMN source_text TEXT"
+                )
 
             await conn.exec_driver_sql(
                 "CREATE INDEX IF NOT EXISTS idx_event_date_time ON event(date, time)"

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -20,3 +20,15 @@ async def test_journal_mode_wal(tmp_path):
     await db.engine.dispose()
     assert mode.lower() == "wal"
 
+
+@pytest.mark.asyncio
+async def test_festival_has_source_text(tmp_path):
+    db_path = tmp_path / "test.sqlite"
+    db = Database(str(db_path))
+    await db.init()
+    async with db.engine.connect() as conn:
+        result = await conn.execute(text("PRAGMA table_info(festival)"))
+        cols = [r[1] for r in result.fetchall()]
+    await db.engine.dispose()
+    assert "source_text" in cols
+


### PR DESCRIPTION
## Summary
- ensure `source_text` column exists on the `festival` table during DB init
- cover the column creation with a database test

## Testing
- `pytest >/tmp/pytest.log && tail -n 5 /tmp/pytest.log`


------
https://chatgpt.com/codex/tasks/task_e_68960f9ca3688332a5ca0a1a46b4ccca