### PR TITLE
Handle festivals in forwarded messages

### DIFF
--- a/main.py
+++ b/main.py
@@ -7962,6 +7962,23 @@ async def handle_forwarded(message: types.Message, db: Database, bot: Bot):
         logging.info("no events parsed from forwarded text")
         return
     for saved, added, lines, status in results:
+        if isinstance(saved, Festival):
+            markup = types.InlineKeyboardMarkup(
+                inline_keyboard=[
+                    [
+                        types.InlineKeyboardButton(
+                            text="Создать события по дням",
+                            callback_data=f"festdays:{saved.id}",
+                        )
+                    ]
+                ]
+            )
+            await bot.send_message(
+                message.chat.id,
+                "Festival added\n" + "\n".join(lines),
+                reply_markup=markup,
+            )
+            continue
         buttons = []
         if (
             not saved.is_free


### PR DESCRIPTION
## Summary
- Treat Festival objects separately in `handle_forwarded` so bot asks to create daily events
- Add regression test for forwarding a festival post

## Testing
- `pytest tests/test_bot.py::test_forward_add_festival -q`
- `pytest tests/test_bot.py::test_forward_add_event -q`


------
https://chatgpt.com/codex/tasks/task_e_6896622118cc83328639dd7061178d26