### PR TITLE
Improve month page readability

### DIFF
--- a/main.py
+++ b/main.py
@@ -4771,9 +4771,11 @@ def _build_month_page_content_sync(
             add_many(telegraph_br())
         add({"tag": "h3", "children": [f"🟥🟥🟥 {format_day_pretty(day)} 🟥🟥🟥"]})
         add_many(telegraph_br())
-        for ev in by_day[day]:
+        for idx, ev in enumerate(by_day[day]):
             if exceeded:
                 break
+            if idx > 0:
+                add_many(telegraph_br())
             fest = fest_map.get(ev.festival or "")
             add_many(event_to_nodes(ev, fest, fest_icon=True))
 


### PR DESCRIPTION
## Summary
- Add blank lines between events on month pages for better readability

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689677919a2c83328a95fcdd98e6175e