### PR TITLE
Refine span logging and HTTP session limits

### DIFF
--- a/span.py
+++ b/span.py
@@ -2,10 +2,13 @@ import logging
 import time
 from contextlib import asynccontextmanager
 
+import psutil
+
 
 class _Span:
     def __init__(self) -> None:
         self._thresholds: dict[str, float] = {}
+        self._process = psutil.Process()
 
     def configure(self, thresholds: dict[str, int | float]) -> None:
         self._thresholds.update(thresholds)
@@ -13,12 +16,20 @@ class _Span:
     @asynccontextmanager
     async def __call__(self, label: str):
         start = time.perf_counter()
+        start_rss = self._process.memory_info().rss // 2**20
         try:
             yield
         finally:
             dt = (time.perf_counter() - start) * 1000
+            end_rss = self._process.memory_info().rss // 2**20
             if dt >= self._thresholds.get(label, 1000):
-                logging.debug("%s took %.0f ms", label, dt)
+                logging.debug(
+                    "%s took %.0f ms rss=%d MB Δ%+d MB",
+                    label,
+                    dt,
+                    end_rss,
+                    end_rss - start_rss,
+                )
 
 
 span = _Span()


### PR DESCRIPTION
## Summary
- Distinguish database work from network calls with dedicated spans for Telegram, VK, Telegraph and generic HTTP
- Reduce aiohttp connector limits and enable DNS caching for shared session
- Log RSS usage in span helper for lightweight memory tracking

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68971265a35c83329b155f201852ab6d