### PR TITLE
Handle asset message deletion DB errors

### DIFF
--- a/main.py
+++ b/main.py
@@ -1656,10 +1656,10 @@ async def delete_ics(event: Event):
 async def delete_asset_post(event: Event, db: Database, bot: Bot):
     if not event.ics_post_id:
         return
-    channel = await get_asset_channel(db)
-    if not channel:
-        return
     try:
+        channel = await get_asset_channel(db)
+        if not channel:
+            return
         async with span("tg-send"):
             await bot.delete_message(channel.channel_id, event.ics_post_id)
     except Exception as e:


### PR DESCRIPTION
## Summary
- wrap `delete_asset_post` logic in try/except to catch DB and network errors

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68972b3f173c83329052ac7708e5a76b