### PR TITLE
Refactor cleanup job to use SQLAlchemy async sessions

### DIFF
--- a/scheduler.py
+++ b/scheduler.py
@@ -56,7 +56,6 @@ def startup(db, bot) -> AsyncIOScheduler:
         "cron",
         id="cleanup_scheduler",
         minute="3,18,33,48",
-        args=[db, bot],
         replace_existing=True,
     )
     _scheduler.add_job(


### PR DESCRIPTION
## Summary
- create global async session and engine for DB access
- replace old manual cleanup with atomic async transaction
- wrap cleanup scheduler with error logging and no manual connection handling

## Testing
- `pytest tests/test_bot.py::test_cleanup_old_events tests/test_bot.py::test_cleanup_scheduler_logs`

------
https://chatgpt.com/codex/tasks/task_e_68984a4083e88332b8c2bddc441b850e