### PR TITLE
Redact access tokens in logs

### DIFF
--- a/main.py
+++ b/main.py
@@ -618,6 +618,10 @@ async def close_http_session() -> None:
     await close_shared_session()
 
 
+def redact_token(tok: str) -> str:
+    return tok[:6] + "…" + tok[-4:] if tok and len(tok) > 10 else "<redacted>"
+
+
 def _vk_user_token() -> str | None:
     """Return user token unless it was previously marked invalid."""
     token = os.getenv("VK_USER_TOKEN")
@@ -651,7 +655,9 @@ async def _vk_api(
     for kind, token in tokens:
         params["access_token"] = token
         params["v"] = "5.131"
-        logging.info("calling VK API %s using %s token %s", method, kind, token)
+        logging.info(
+            "calling VK API %s using %s token %s", method, kind, redact_token(token)
+        )
         async def _call():
             async with HTTP_SEMAPHORE:
                 async with session.post(

--- a/tests/test_redact_token.py
+++ b/tests/test_redact_token.py
@@ -1,0 +1,11 @@
+import pytest
+
+from main import redact_token
+
+
+def test_redact_token_long():
+    assert redact_token('abcdefghijklmnopqrstuvwxyz') == 'abcdef…wxyz'
+
+
+def test_redact_token_short():
+    assert redact_token('1234567890') == '<redacted>'


### PR DESCRIPTION
## Summary
- add `redact_token` helper to abbreviate sensitive tokens
- redact tokens in VK API logging
- test token redaction

## Testing
- `pytest -q`
- `PYTHONPATH=. pytest tests/test_redact_token.py -q`


------
https://chatgpt.com/codex/tasks/task_e_689877b10d84833291517846ac0405cf