### PR TITLE
Fix AsyncIOExecutor configuration in scheduler

### DIFF
--- a/scheduler.py
+++ b/scheduler.py
@@ -13,8 +13,8 @@ _scheduler: AsyncIOScheduler | None = None
 def startup(db, bot) -> AsyncIOScheduler:
     global _scheduler
     if _scheduler is None:
-        # Use a tiny async pool to limit memory overhead
-        executor = AsyncIOExecutor(max_workers=2)
+        # AsyncIOExecutor has no configuration options; use default settings
+        executor = AsyncIOExecutor()
         _scheduler = AsyncIOScheduler(
             executors={"default": executor},
             job_defaults={


### PR DESCRIPTION
## Summary
- fix scheduler startup by removing unsupported AsyncIOExecutor parameter

## Testing
- `pytest` *(fails: KeyboardInterrupt after ~55 tests)*

------
https://chatgpt.com/codex/tasks/task_e_68988e41befc8332a0428e82b5b9dae7