### PR TITLE
Refactor event updates into async queue

### DIFF
--- a/tests/test_bot.py
+++ b/tests/test_bot.py
@@ -64,6 +64,23 @@ def _mock_sync_vk_source_post(monkeypatch):
 def _reset_http_session(monkeypatch):
     monkeypatch.setattr(main, "_http_session", None)
 
+
+@pytest.fixture(autouse=True)
+def _sync_event_updates(monkeypatch):
+    monkeypatch.setenv("EVENT_UPDATE_SYNC", "1")
+
+
+@pytest.fixture(autouse=True)
+def _mock_page_sync(monkeypatch):
+    async def fake_month(db_obj, month):
+        return None
+
+    async def fake_weekend(db_obj, start):
+        return None
+
+    monkeypatch.setattr(main, "sync_month_page", fake_month)
+    monkeypatch.setattr(main, "sync_weekend_page", fake_weekend)
+
 FUTURE_DATE = (date.today() + timedelta(days=10)).isoformat()
 
 

--- a/tests/test_vk_source.py
+++ b/tests/test_vk_source.py
@@ -3,6 +3,17 @@ from pathlib import Path
 import main
 
 
+@pytest.fixture(autouse=True)
+def _sync_event_updates(monkeypatch):
+    monkeypatch.setenv("EVENT_UPDATE_SYNC", "1")
+    async def fake_month(db_obj, month):
+        return None
+    async def fake_weekend(db_obj, start):
+        return None
+    monkeypatch.setattr(main, "sync_month_page", fake_month)
+    monkeypatch.setattr(main, "sync_weekend_page", fake_weekend)
+
+
 @pytest.mark.asyncio
 async def test_sync_vk_source_post_includes_calendar_link(monkeypatch):
     main.VK_AFISHA_GROUP_ID = "1"


### PR DESCRIPTION
## Summary
- introduce asynchronous event update queue with worker and retry logic
- defer heavy telegraph/VK/month/weekend sync into idempotent jobs
- wire queue workers into app startup and shutdown

## Testing
- `pytest -q` *(fails: VK_USER_TOKEN missing and month page expectations)*

------
https://chatgpt.com/codex/tasks/task_e_68998f777af083329a86cb9e025df185