### PR TITLE
Handle span kwargs and run event pipeline with logging

### DIFF
--- a/span.py
+++ b/span.py
@@ -14,7 +14,7 @@ class _Span:
         self._thresholds.update(thresholds)
 
     @asynccontextmanager
-    async def __call__(self, label: str):
+    async def __call__(self, label: str, **fields):
         start = time.perf_counter()
         start_rss = self._process.memory_info().rss // 2**20
         try:
@@ -23,12 +23,16 @@ class _Span:
             dt = (time.perf_counter() - start) * 1000
             end_rss = self._process.memory_info().rss // 2**20
             if dt >= self._thresholds.get(label, 1000):
+                extra = " ".join(f"{k}={v}" for k, v in fields.items())
+                if extra:
+                    extra = " " + extra
                 logging.debug(
-                    "%s took %.0f ms rss=%d MB Δ%+d MB",
+                    "%s took %.0f ms rss=%d MB Δ%+d MB%s",
                     label,
                     dt,
                     end_rss,
                     end_rss - start_rss,
+                    extra,
                 )
 
 


### PR DESCRIPTION
## Summary
- allow span context manager to accept **kwargs and include them in debug log
- schedule full event update pipeline after upserting events, wrapping each step with span and resilient logging
- log final pipeline completion status

## Testing
- `pytest` *(fails: 17 failed, 168 passed, 1 skipped)*

------
https://chatgpt.com/codex/tasks/task_e_6899f432a9588332a2c97fdb1e5b34fa