### PR TITLE
Reduce memory usage on Fly

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,8 +77,15 @@ export VK_USER_TOKEN=vk_user_token
    ```bash
    fly deploy
    ```
-   > **Note:** If the app's average memory (RSS) approaches ~140&nbsp;MB, consider
-   > upgrading the Fly machine's memory tier to avoid out-of-memory kills.
+   > **Note:** If the app's average memory (RSS) approaches ~140&nbsp;MB, choose a
+   > larger memory tier to avoid out-of-memory kills. On Apps V2 use `fly scale
+   > memory 512`; on Machines:
+   > `fly machines update -m 512 -c shared-cpu-1x <machine-id>`.
+
+4. Optional tuning:
+   - Enable swap if needed (for example `--swap 256`).
+   - The app exposes a `/healthz` endpoint used by Fly health checks.
+   - Avoid heavy requests at startup; warm caches lazily in background workers.
 
 ## Files
 - `docs/COMMANDS.md` – full list of bot commands.

--- a/tests/test_bot.py
+++ b/tests/test_bot.py
@@ -1103,7 +1103,7 @@ async def test_create_source_page_photo_catbox(monkeypatch):
     )
     monkeypatch.setattr(main, "ClientSession", DummySession)
     monkeypatch.setattr(main, "CATBOX_ENABLED", True)
-    monkeypatch.setattr(main, "imghdr", type("X", (), {"what": lambda *a, **k: "jpeg"}))
+    monkeypatch.setattr(main, "detect_image_type", lambda *a, **k: "jpeg")
 
     res = await main.create_source_page(
         "Title", "text", None, media=(b"img", "photo.jpg")


### PR DESCRIPTION
## Summary
- reuse a single aiohttp session with lower connection limits
- restrict large downloads and detect image types without imghdr
- bound queue worker concurrency and document Fly scaling tips

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689a5e9bf6bc8332a4c80d488401c935