### PR TITLE
Fix database session context manager

### DIFF
--- a/db.py
+++ b/db.py
@@ -269,6 +269,7 @@ class Database:
         conn = await self._ensure_conn()
         yield conn
 
+    @asynccontextmanager
     async def get_session(self):
         from sqlalchemy.ext.asyncio import create_async_engine, AsyncSession
         from sqlalchemy.orm import sessionmaker
@@ -281,7 +282,8 @@ class Database:
             self._sessionmaker = sessionmaker(
                 self._orm_engine, expire_on_commit=False, class_=AsyncSession
             )
-        return self._sessionmaker()
+        async with self._sessionmaker() as session:
+            yield session
 
     @property
     def engine(self):


### PR DESCRIPTION
## Summary
- ensure Database.get_session acts as an async context manager

## Testing
- `VK_USER_TOKEN=dummy pytest` *(fails: NameError: name 'select' is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_689a7d1f14548332b6783ac5ff9071dc