### PR TITLE
Simplify worker and scheduling

### DIFF
--- a/scheduler.py
+++ b/scheduler.py
@@ -105,7 +105,6 @@ def startup(db, bot) -> AsyncIOScheduler:
         vk_scheduler,
         vk_poll_scheduler,
         cleanup_scheduler,
-        page_update_scheduler,
         partner_notification_scheduler,
     )
 
@@ -135,19 +134,9 @@ def startup(db, bot) -> AsyncIOScheduler:
         _job_wrapper("cleanup_scheduler", cleanup_scheduler),
         "cron",
         id="cleanup_scheduler",
-        minute="3,18,33,48",
+        hour="2",
+        minute="7",
         args=[db, bot],
-        replace_existing=True,
-        max_instances=1,
-        coalesce=True,
-        misfire_grace_time=30,
-    )
-    _scheduler.add_job(
-        _job_wrapper("page_update_scheduler", page_update_scheduler),
-        "cron",
-        id="page_update_scheduler",
-        minute="4,19,34,49",
-        args=[db],
         replace_existing=True,
         max_instances=1,
         coalesce=True,

--- a/span.py
+++ b/span.py
@@ -12,7 +12,7 @@ class _Span:
     def configure(self, thresholds: dict[str, int | float]) -> None:
         self._thresholds.update(thresholds)
 
-    def __call__(self, label: str, **_):
+    def __call__(self, label: str, **kwargs):
         span = self
 
         class _Ctx:


### PR DESCRIPTION
## Summary
- import select/update from SQLAlchemy directly and simplify startup
- use shared aiohttp session for HTTP calls
- make queue worker resilient and remove periodic page rebuild

## Testing
- `pytest tests/test_bot.py::test_start_superadmin -q`
- `pytest tests/test_bot.py::test_page_update_scheduler -q`


------
https://chatgpt.com/codex/tasks/task_e_689af88e80548332bf3468a726cd8c11