### PR TITLE
Refine event update routing

### DIFF
--- a/models.py
+++ b/models.py
@@ -151,6 +151,7 @@ class JobTask(str, Enum):
     vk_sync = "vk_sync"
     month_pages = "month_pages"
     weekend_pages = "weekend_pages"
+    festival_pages = "festival_pages"
 
 
 class JobStatus(str, Enum):


### PR DESCRIPTION
## Summary
- queue only relevant update tasks after inserting events
- skip Telegraph/VK updates when content hash unchanged
- streamline weekend page sync and expose granular job handlers

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689b0338af3883328c30e44cd306cd36