### PR TITLE
feat: notify step completion

### DIFF
--- a/alembic/versions/20250810_job_outbox_last_result.py
+++ b/alembic/versions/20250810_job_outbox_last_result.py
@@ -1,0 +1,15 @@
+from alembic import op
+import sqlalchemy as sa
+
+revision = "20250810_job_outbox_last_result"
+down_revision = "20250809_job_outbox_idx"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column("joboutbox", sa.Column("last_result", sa.Text(), nullable=True))
+
+
+def downgrade() -> None:
+    op.drop_column("joboutbox", "last_result")

--- a/db.py
+++ b/db.py
@@ -202,11 +202,14 @@ class Database:
                     status TEXT NOT NULL DEFAULT 'pending',
                     attempts INTEGER DEFAULT 0,
                     last_error TEXT,
+                    last_result TEXT,
                     updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
                     next_run_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
                 )
                 """
             )
+
+            await _add_column(conn, "joboutbox", "last_result TEXT")
 
             await conn.execute(
                 """

--- a/models.py
+++ b/models.py
@@ -177,6 +177,7 @@ class JobOutbox(SQLModel, table=True):
     )
     attempts: int = 0
     last_error: Optional[str] = None
+    last_result: Optional[str] = None
     updated_at: datetime = Field(default_factory=datetime.utcnow)
     next_run_at: datetime = Field(default_factory=datetime.utcnow)
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,40 @@
+import os
+import sys
+
+import pytest
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+import main
+
+
+@pytest.fixture(autouse=True)
+def _mock_telegraph(monkeypatch, request):
+    if "get_telegraph_token" not in request.node.nodeid:
+        monkeypatch.setattr(main, "get_telegraph_token", lambda: "t")
+    async def fake_create_page(tg, *args, **kwargs):
+        return {"path": "test", "url": "https://t.me/test"}
+    monkeypatch.setattr(main, "telegraph_create_page", fake_create_page)
+
+    async def fake_update(event_id, db_obj, bot_obj):
+        async with db_obj.get_session() as session:
+            ev = await session.get(main.Event, event_id)
+        if not ev:
+            return None
+        res = await main.create_source_page(
+            ev.title or "Event",
+            ev.source_text,
+            ev.source_post_url,
+            db=db_obj,
+        )
+        if res:
+            url, path, *_ = res
+            async with db_obj.get_session() as session:
+                obj = await session.get(main.Event, event_id)
+                if obj:
+                    obj.telegraph_url = url
+                    obj.telegraph_path = path
+                    session.add(obj)
+                    await session.commit()
+            return url
+        return None
+    monkeypatch.setattr(main, "update_telegraph_event_page", fake_update)

--- a/tests/test_notifications.py
+++ b/tests/test_notifications.py
@@ -1,0 +1,98 @@
+import os
+import sys
+
+import pytest
+from datetime import datetime
+from sqlmodel import select
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+import main
+from main import (
+    Database,
+    Event,
+    JobOutbox,
+    JobStatus,
+    JobTask,
+    schedule_event_update_tasks,
+    run_event_update_jobs,
+)
+
+
+class DummyBot:
+    def __init__(self):
+        self.messages = []
+
+    async def send_message(self, chat_id, text, **kwargs):
+        self.messages.append(text)
+
+
+@pytest.mark.asyncio
+async def test_progress_notifications(tmp_path, monkeypatch):
+    db = Database(str(tmp_path / "db.sqlite"))
+    await db.init()
+    bot = DummyBot()
+
+    ev = Event(
+        title="t",
+        description="d",
+        date="2025-01-04",
+        time="12:00",
+        location_name="loc",
+        source_text="src",
+    )
+    async with db.get_session() as session:
+        session.add(ev)
+        await session.commit()
+        await session.refresh(ev)
+
+    await schedule_event_update_tasks(db, ev)
+
+    async def noop(eid, db_obj, bot_obj):
+        return None
+
+    monkeypatch.setattr(main, "update_telegraph_event_page", noop)
+    monkeypatch.setattr(main, "job_sync_vk_source_post", noop)
+    monkeypatch.setattr(main, "update_month_pages_for", noop)
+    monkeypatch.setattr(main, "update_weekend_pages_for", noop)
+    monkeypatch.setattr(main, "update_festival_pages_for_event", noop)
+    monkeypatch.setattr(
+        main,
+        "JOB_HANDLERS",
+        {
+            "telegraph_build": noop,
+            "vk_sync": noop,
+            "month_pages": noop,
+            "weekend_pages": noop,
+            "festival_pages": noop,
+        },
+    )
+
+    async def fake_link(task, eid, db_obj):
+        mapping = {
+            JobTask.telegraph_build: "http://t",
+            JobTask.vk_sync: "http://v",
+            JobTask.month_pages: "http://m",
+            JobTask.weekend_pages: "http://w",
+        }
+        return mapping.get(task)
+
+    monkeypatch.setattr(main, "_job_result_link", fake_link)
+
+    await run_event_update_jobs(db, bot, notify_chat_id=1, event_id=ev.id)
+
+    assert "Telegraph (событие): OK — http://t" in bot.messages
+    assert "Страница месяца: OK — http://m" in bot.messages
+    assert "Выходные: OK — http://w" in bot.messages
+    assert "VK: OK — http://v" in bot.messages
+
+    bot.messages.clear()
+    async with db.get_session() as session:
+        res = await session.execute(select(JobOutbox))
+        for job in res.scalars():
+            job.status = JobStatus.pending
+            job.next_run_at = datetime.utcnow()
+            session.add(job)
+        await session.commit()
+
+    await run_event_update_jobs(db, bot, notify_chat_id=1, event_id=ev.id)
+    assert bot.messages == []


### PR DESCRIPTION
## Summary
- add JobOutbox.last_result to remember the last successful step outcome
- send detailed OK/ERROR messages for each event processing task
- test progress notifications and deduping

## Testing
- `pytest tests/test_notifications.py -q`
- `pytest tests/test_bot.py::test_events_list tests/test_bot.py::test_addevent_caption_photo tests/test_bot.py::test_addevent_strips_command tests/test_bot.py::test_addevent_vk_wall_link tests/test_bot.py::test_addevent_vk_wall_link_query -q` *(fails: KeyError media/text/source)*


------
https://chatgpt.com/codex/tasks/task_e_689b1515f584833296de6c23ff52da58