### PR TITLE
Use VK user token for VK posting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -180,6 +180,11 @@
 - Festival descriptions are generated from the full original post text.
 - Festival records store the original announcement in a new `source_text` field.
 
+## v0.3.28 - VK user token
+
+- VK posting now uses a user token. Set `VK_USER_TOKEN` with `wall,groups,offline` scopes.
+- The group token `VK_TOKEN` is optional and used only as a fallback.
+
 
 
 

--- a/README.md
+++ b/README.md
@@ -39,11 +39,11 @@ browse upcoming announcements. The command accepts dates like `2025-07-10`,
   # Optional: provide Telegraph token. If omitted, the bot creates an account
   # automatically and saves the token to /data/telegraph_token.txt.
   export TELEGRAPH_TOKEN=your_telegraph_token
-  # Optional: post daily announcements to VK
+  # User access token for VK posts (scopes: wall,groups,offline)
+  export VK_USER_TOKEN=vk_user_token
+  # Optional: group token used as a fallback
   export VK_TOKEN=vk_group_token
-  # Optional: user access token for VK posts with images
-export VK_USER_TOKEN=vk_user_token
-# Sending images to VK is disabled by default. Use /vkphotos to enable it.
+  # Sending images to VK is disabled by default. Use /vkphotos to enable it.
  python main.py
    ```
 
@@ -67,10 +67,10 @@ export VK_USER_TOKEN=vk_user_token
    # Optional: use your own Telegraph token. If not set, a new account will be
    # created on first run and the token saved to the data volume.
    fly secrets set TELEGRAPH_TOKEN=<token>
-   # Optional: post daily announcements to VK
-   fly secrets set VK_TOKEN=<token>
-   # Optional: user access token for VK posts with images
+   # User access token for VK posts (scopes: wall,groups,offline)
    fly secrets set VK_USER_TOKEN=<token>
+   # Optional: group token used as a fallback
+   fly secrets set VK_TOKEN=<token>
    # Sending images to VK is disabled by default. Toggle with /vkphotos.
    ```
 3. Deploy:

--- a/README_cron.md
+++ b/README_cron.md
@@ -11,7 +11,8 @@ The bot uses APScheduler to run periodic maintenance tasks every 15 minutes. Eac
 
 ## Environment variables
 
-- `VK_TOKEN` or `VK_USER_TOKEN` – enable posting to VK.
+- `VK_USER_TOKEN` – user token for VK posts (scopes: wall,groups,offline).
+- `VK_TOKEN` – optional group token used as a fallback.
 - `EVBOT_DEBUG` – enables extra logging and queue statistics.
 
 All jobs are lightweight and finish in under a few seconds so that the bot remains responsive.

--- a/main.py
+++ b/main.py
@@ -7199,6 +7199,8 @@ async def post_to_vk(
     db: Database | None = None,
     bot: Bot | None = None,
     attachments: list[str] | None = None,
+    token: str | None = None,
+    token_kind: str = "group",
 ) -> str | None:
     if not group_id:
         return None
@@ -7217,9 +7219,7 @@ async def post_to_vk(
         params["attachments"] = ",".join(attachments)
     if DEBUG:
         mem_info("VK post before")
-    data = await _vk_api(
-        "wall.post", params, db, bot, token=VK_TOKEN, token_kind="group"
-    )
+    data = await _vk_api("wall.post", params, db, bot, token=token, token_kind=token_kind)
     if DEBUG:
         mem_info("VK post after")
     post_id = data.get("response", {}).get("post_id")


### PR DESCRIPTION
## Summary
- allow `post_to_vk` to use `_vk_api` token fallback instead of forcing group token
- document `VK_USER_TOKEN` with required scopes and mark `VK_TOKEN` as optional
- note user token requirement in scheduler docs and changelog

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689ba0cd89508332b1ab3d11ab859dd2