### PR TITLE
Add film screening event type detection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -185,6 +185,10 @@
 - VK posting now uses a user token. Set `VK_USER_TOKEN` with `wall,groups,offline` scopes.
 - The group token `VK_TOKEN` is optional and used only as a fallback.
 
+## v0.3.29 - Film screenings
+
+- Added support for `кинопоказ` event type and automatic detection of film screenings.
+
 
 
 

--- a/docs/PROMPTS.md
+++ b/docs/PROMPTS.md
@@ -23,7 +23,7 @@ ticket_price_max  - maximum ticket price as integer or null
 ticket_link       - URL for purchasing tickets **or** registration form if present
 is_free           - true if explicitly stated the event is free
 pushkin_card     - true if the event accepts the Пушкинская карта
-event_type       - one of: спектакль, выставка, концерт, ярмарка, лекция, встреча
+event_type       - one of: спектакль, выставка, концерт, ярмарка, лекция, встреча, кинопоказ
 emoji            - an optional emoji representing the event
 end_date         - end date for multi-day events or null
 When a range is provided, put the start date in `date` and the end date in `end_date`.

--- a/main.py
+++ b/main.py
@@ -1331,6 +1331,17 @@ def strip_city_from_address(address: str | None, city: str | None) -> str | None
     return addr
 
 
+def normalize_event_type(
+    title: str, description: str, event_type: str | None
+) -> str | None:
+    """Return corrected event type, marking film screenings as ``кинопоказ``."""
+    text = f"{title} {description}".lower()
+    if event_type in (None, "", "спектакль"):
+        if any(word in text for word in ("кино", "фильм", "кинопоказ", "киносеанс")):
+            return "кинопоказ"
+    return event_type
+
+
 def canonicalize_date(value: str) -> str | None:
     """Return ISO date string if value parses as date or ``None``."""
     value = value.split("..", 1)[0].strip()
@@ -3878,6 +3889,10 @@ async def add_events_from_text(
             source_chat_id=source_chat_id,
             source_message_id=source_message_id,
             creator_id=creator_id,
+        )
+
+        base_event.event_type = normalize_event_type(
+            base_event.title, base_event.description, base_event.event_type
         )
 
         if base_event.festival:

--- a/tests/test_event_type_normalization.py
+++ b/tests/test_event_type_normalization.py
@@ -1,0 +1,13 @@
+from main import normalize_event_type
+
+
+def test_normalize_event_type_film():
+    title = "\ud83c\udfa5 Очень страшное кино"
+    desc = "Показ культового фильма 'Очень страшное кино' в Заре."
+    assert normalize_event_type(title, desc, "спектакль") == "кинопоказ"
+
+
+def test_normalize_event_type_no_change():
+    title = "\ud83c\udfb5 Concert"
+    desc = "Музыкальный концерт"
+    assert normalize_event_type(title, desc, "концерт") == "концерт"


### PR DESCRIPTION
## Summary
- add `кинопоказ` to LLM prompt and changelog
- normalize event type for film screenings
- test film screening event type normalization

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689ba6d84d6c8332b6944c44c7077e60