### PR TITLE
Add event photo support for Telegraph pages and clean month navigation

### DIFF
--- a/db.py
+++ b/db.py
@@ -125,12 +125,14 @@ class Database:
                     source_chat_id INTEGER,
                     source_message_id INTEGER,
                     creator_id INTEGER,
+                    photo_urls JSON,
                     photo_count INTEGER DEFAULT 0,
                     added_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
                     content_hash TEXT
                 )
                 """
             )
+            await _add_column(conn, "event", "photo_urls JSON")
 
             await conn.execute(
                 """

--- a/models.py
+++ b/models.py
@@ -92,6 +92,7 @@ class Event(SQLModel, table=True):
     source_chat_id: Optional[int] = None
     source_message_id: Optional[int] = None
     creator_id: Optional[int] = None
+    photo_urls: list[str] = Field(default_factory=list, sa_column=Column(JSON))
     photo_count: int = 0
     added_at: datetime = Field(default_factory=datetime.utcnow)
     content_hash: Optional[str] = None


### PR DESCRIPTION
## Summary
- store uploaded photo URLs with events and reuse them when generating Telegraph pages
- show only current and upcoming months in page navigation
- update tests accordingly

## Testing
- `pytest tests/test_bot.py::test_create_source_page_adds_nav -q`
- `pytest tests/test_bot.py::test_month_nav_and_exhibitions tests/test_bot.py::test_month_buttons_future -q`


------
https://chatgpt.com/codex/tasks/task_e_689babb65e94833280f3016eae76bbb8