### PR TITLE
Refactor telegraph page layout and fix month nav

### DIFF
--- a/tests/test_bot.py
+++ b/tests/test_bot.py
@@ -2632,7 +2632,7 @@ async def test_weekend_nav_and_exhibitions(tmp_path: Path):
             for c in n.get("children", [])
         )
     ]
-    assert len(nav_blocks) == 2
+    assert len(nav_blocks) == 1
     first_block_children = nav_blocks[0]["children"]
     assert not isinstance(first_block_children[0], dict)
 
@@ -2652,7 +2652,6 @@ async def test_weekend_nav_and_exhibitions(tmp_path: Path):
         if n.get("tag") == "h3" and "Постоянные" in "".join(n.get("children", []))
     )
     assert content[idx_exh - 1].get("tag") == "p"
-    assert content[idx_exh - 2].get("tag") == "br"
 
 
 @pytest.mark.asyncio
@@ -2687,7 +2686,7 @@ async def test_month_nav_and_exhibitions(tmp_path: Path):
             for c in n.get("children", [])
         )
     ]
-    assert len(nav_blocks) == 2
+    assert len(nav_blocks) == 1
     first_block_children = nav_blocks[0]["children"]
     assert not isinstance(first_block_children[0], dict)
 
@@ -2697,7 +2696,6 @@ async def test_month_nav_and_exhibitions(tmp_path: Path):
         if n.get("tag") == "h3" and "Постоянные" in "".join(n.get("children", []))
     )
     assert content[idx_exh - 1].get("tag") == "p"
-    assert content[idx_exh - 2].get("tag") == "br"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- factor out shared helper for daily sections
- move month/weekend navigation blocks below exhibitions
- wrap source images in `<figure>` for Telegraph
- update tests for new markup

## Testing
- `pytest tests/test_bot.py::test_weekend_nav_and_exhibitions tests/test_bot.py::test_month_nav_and_exhibitions`


------
https://chatgpt.com/codex/tasks/task_e_689bb83e2b1083328161dd7a6d220312