### PR TITLE
Fix month page sync failures due to invalid span tag

### DIFF
--- a/tests/test_month_patch.py
+++ b/tests/test_month_patch.py
@@ -171,13 +171,17 @@ async def test_patch_month_page_rebuilds_when_header_without_markers(tmp_path, m
         await session.commit()
 
     header = f"<h3>🟥🟥🟥 {main.format_day_pretty(date(2025, 8, 15))} 🟥🟥🟥</h3>"
-    html = header + PERM_START + "perm" + PERM_END
-    html = html.replace("<!--", "&lt;!--").replace("-->", "--&gt;")
+    html_state = {
+        "value": header + PERM_START + "perm" + PERM_END
+    }
+    html_state["value"] = html_state["value"].replace("<!--", "&lt;!--").replace(
+        "-->", "--&gt;"
+    )
 
     class FakeTelegraph:
         def get_page(self, path, return_html=True):
             assert path == "p"
-            return {"content_html": html, "title": "Title"}
+            return {"content_html": html_state["value"], "title": "Title"}
 
         def edit_page(self, path, title, html_content):
             raise AssertionError("edit_page should not be called")
@@ -187,6 +191,14 @@ async def test_patch_month_page_rebuilds_when_header_without_markers(tmp_path, m
     async def fake_sync(db_obj, month_key, update_links=False):
         nonlocal called
         called = True
+        html_state["value"] = (
+            DAY_START("2025-08-15")
+            + "new"
+            + DAY_END("2025-08-15")
+            + PERM_START
+            + "perm"
+            + PERM_END
+        )
 
     monkeypatch.setattr(main, "sync_month_page", fake_sync)
 

--- a/tests/test_notifications.py
+++ b/tests/test_notifications.py
@@ -99,3 +99,52 @@ async def test_progress_notifications(tmp_path, monkeypatch):
 
     await run_event_update_jobs(db, bot, notify_chat_id=1, event_id=ev.id)
     assert bot.messages == []
+
+
+@pytest.mark.asyncio
+async def test_progress_notifications_error(tmp_path, monkeypatch):
+    db = Database(str(tmp_path / "db.sqlite"))
+    await db.init()
+    bot = DummyBot()
+
+    ev = Event(
+        title="t",
+        description="d",
+        date="2025-01-04",
+        time="12:00",
+        location_name="loc",
+        source_text="src",
+    )
+    async with db.get_session() as session:
+        session.add(ev)
+        await session.commit()
+        await session.refresh(ev)
+
+    await schedule_event_update_tasks(db, ev)
+
+    async def ok_handler(eid, db_obj, bot_obj):
+        return True
+
+    async def err_handler(eid, db_obj, bot_obj):
+        raise Exception("boom")
+
+    monkeypatch.setattr(main, "update_telegraph_event_page", ok_handler)
+    monkeypatch.setattr(main, "job_sync_vk_source_post", ok_handler)
+    monkeypatch.setattr(main, "update_month_pages_for", err_handler)
+    monkeypatch.setattr(main, "update_weekend_pages_for", ok_handler)
+    monkeypatch.setattr(main, "update_festival_pages_for_event", ok_handler)
+    monkeypatch.setattr(
+        main,
+        "JOB_HANDLERS",
+        {
+            "telegraph_build": ok_handler,
+            "vk_sync": ok_handler,
+            "month_pages": err_handler,
+            "weekend_pages": ok_handler,
+            "festival_pages": ok_handler,
+        },
+    )
+
+    await run_event_update_jobs(db, bot, notify_chat_id=1, event_id=ev.id)
+
+    assert any(m.startswith("Страница месяца: ERROR: boom") for m in bot.messages)

--- a/tests/test_render_month_spacing.py
+++ b/tests/test_render_month_spacing.py
@@ -22,5 +22,13 @@ def test_render_month_day_section_has_blank_lines():
     ]
     html = main.render_month_day_section(date(2025, 1, 15), events)
     day_end = html.index("</h3>") + len("</h3>")
-    assert html[day_end:].startswith("<br/> <h4>")
-    assert "<br/> <br/> " not in html
+    assert html[day_end:].startswith("<br/><br/><h4>")
+    assert "<br/><br/><br/><br/>" not in html
+
+
+def test_telegraph_br_no_span():
+    from telegraph.utils import nodes_to_html
+
+    html = nodes_to_html(main.telegraph_br())
+    assert html == "<br/><br/>"
+    assert "<span" not in html


### PR DESCRIPTION
## Summary
- replace `<span>` placeholder in month page blank lines with two `<br>` tags
- raise errors from month page sync and verify day markers after rebuild
- add tests for blank line rendering and error propagation

## Testing
- `pytest tests/test_render_month_spacing.py tests/test_bot.py::test_sync_month_page_error tests/test_notifications.py::test_progress_notifications_error tests/test_month_patch.py::test_patch_month_page_rebuilds_when_header_without_markers`


------
https://chatgpt.com/codex/tasks/task_e_689d17031c748332bb8ee85a1f50e97b