### PR TITLE
Improve telegraph syncing and uploads

### DIFF
--- a/tests/test_bot.py
+++ b/tests/test_bot.py
@@ -2543,7 +2543,7 @@ async def test_build_month_page_content(tmp_path: Path, monkeypatch):
     title, content, _ = await main.build_month_page_content(db, "2025-07")
     assert "июле 2025" in title
     assert "Полюбить Калининград Анонсы" in title
-    assert any(n.get("tag") == "br" for n in content)
+    assert any(n.get("tag") == "p" and n.get("children") == ["\u00a0"] for n in content)
 
 
 @pytest.mark.asyncio
@@ -4378,8 +4378,8 @@ async def test_add_events_from_text_schedules_pages(tmp_path: Path, monkeypatch)
     async def fake_create(*args, db=None, **kwargs):
         return "u", "p"
 
-    async def fake_upload_to_catbox(media):
-        return [], ""
+    async def fake_upload_images(media):
+        return [], [], ""
 
     async def fake_sync_vk(*args, **kwargs):
         return None
@@ -4395,7 +4395,7 @@ async def test_add_events_from_text_schedules_pages(tmp_path: Path, monkeypatch)
 
     monkeypatch.setattr("main.parse_event_via_4o", fake_parse)
     monkeypatch.setattr("main.create_source_page", fake_create)
-    monkeypatch.setattr("main.upload_to_catbox", fake_upload_to_catbox)
+    monkeypatch.setattr("main.upload_images", fake_upload_images)
     monkeypatch.setattr("main.sync_vk_source_post", fake_sync_vk)
     monkeypatch.setattr("main.upload_ics", fake_upload_ics)
     monkeypatch.setattr("main.post_ics_asset", fake_post_ics_asset)
@@ -6420,9 +6420,9 @@ async def test_add_festival_updates_other_pages(tmp_path: Path, monkeypatch):
     monkeypatch.setattr(main, "sync_festival_vk_post", fake_sync_vk)
 
     async def fake_upload(images):
-        return [], ""
+        return [], [], ""
 
-    monkeypatch.setattr(main, "upload_to_catbox", fake_upload)
+    monkeypatch.setattr(main, "upload_images", fake_upload)
 
     async def fake_parse(text, *args, **kwargs):
         fake_parse._festival = {

--- a/tests/test_month_patch.py
+++ b/tests/test_month_patch.py
@@ -96,7 +96,7 @@ async def test_patch_month_page_handles_content_too_big(tmp_path, monkeypatch):
 
     tg = FakeTelegraph()
     changed = await main.patch_month_page_for_date(db, tg, "2025-08", date(2025, 8, 15))
-    assert changed is True
+    assert changed == "rebuild"
     assert called is True
     h = await main.get_section_hash(db, "telegraph:month:2025-08", "day:2025-08-15")
     assert h is not None

--- a/tests/test_render_month_spacing.py
+++ b/tests/test_render_month_spacing.py
@@ -22,13 +22,13 @@ def test_render_month_day_section_has_blank_lines():
     ]
     html = main.render_month_day_section(date(2025, 1, 15), events)
     day_end = html.index("</h3>") + len("</h3>")
-    assert html[day_end:].startswith("<br/><br/><h4>")
-    assert "<br/><br/><br/><br/>" not in html
+    assert html[day_end:].startswith("<p>\u00a0</p><h4>")
+    assert "<p>\u00a0</p><p>\u00a0</p>" not in html
 
 
 def test_telegraph_br_no_span():
     from telegraph.utils import nodes_to_html
 
     html = nodes_to_html(main.telegraph_br())
-    assert html == "<br/><br/>"
+    assert html == "<p>\u00a0</p>"
     assert "<span" not in html

--- a/tests/test_upload_images.py
+++ b/tests/test_upload_images.py
@@ -1,0 +1,67 @@
+import asyncio
+
+import pytest
+
+import main
+
+
+class DummyResp:
+    def __init__(self, status: int, text: str):
+        self.status = status
+        self._text = text
+
+    async def text(self):
+        return self._text
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return False
+
+
+class DummySession:
+    def __init__(self, responses):
+        self._responses = iter(responses)
+
+    async def post(self, url, data):
+        return next(self._responses)
+
+
+@pytest.mark.asyncio
+async def test_upload_images_catbox_ok(monkeypatch):
+    main.CATBOX_ENABLED = True
+    resp = DummyResp(200, "http://cat/1.png")
+    monkeypatch.setattr(main, "get_http_session", lambda: DummySession([resp]))
+    monkeypatch.setattr(main, "telegraph_upload", lambda d, n: None)
+    urls, tg_urls, msg = await main.upload_images([(b"1", "a.png")])
+    assert urls == ["http://cat/1.png"]
+    assert tg_urls == []
+    assert "ok" in msg
+
+
+@pytest.mark.asyncio
+async def test_upload_images_fallback(monkeypatch):
+    main.CATBOX_ENABLED = True
+    resp = DummyResp(412, "pause")
+    monkeypatch.setattr(main, "get_http_session", lambda: DummySession([resp, resp, resp]))
+    monkeypatch.setattr(main, "telegraph_upload", lambda d, n: "https://telegra.ph/file/tg.png")
+    monkeypatch.setattr(asyncio, "sleep", lambda s: None)
+    urls, tg_urls, msg = await main.upload_images([(b"1", "a.png")])
+    assert urls == []
+    assert tg_urls == ["https://telegra.ph/file/tg.png"]
+    assert "tg ok" in msg
+
+
+@pytest.mark.asyncio
+async def test_upload_images_both_fail(monkeypatch):
+    main.CATBOX_ENABLED = True
+    resp = DummyResp(500, "err")
+    monkeypatch.setattr(main, "get_http_session", lambda: DummySession([resp, resp, resp]))
+    monkeypatch.setattr(main, "telegraph_upload", lambda d, n: None)
+    monkeypatch.setattr(asyncio, "sleep", lambda s: None)
+    urls, tg_urls, msg = await main.upload_images([(b"1", "a.png")])
+    assert urls == []
+    assert tg_urls == []
+    assert "both failed" in msg
+


### PR DESCRIPTION
## Summary
- remove marker checks after forced month page rebuilds
- add NBSP paragraph spacer and HTML linter for Telegraph pages
- retry Catbox uploads with fallback to Telegraph upload API

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689e1cc1258483329e2b8691602bbc1c