### PR TITLE
Fix month page spacing and festival linking

### DIFF
--- a/tests/test_render_month_spacing.py
+++ b/tests/test_render_month_spacing.py
@@ -22,13 +22,13 @@ def test_render_month_day_section_has_blank_lines():
     ]
     html = main.render_month_day_section(date(2025, 1, 15), events)
     day_end = html.index("</h3>") + len("</h3>")
-    assert html[day_end:].startswith("<p>\u00a0</p><h4>")
-    assert "<p>\u00a0</p><p>\u00a0</p>" not in html
+    assert html[day_end:].startswith("<br/><br/><h4>")
+    assert "<br/><br/><br/>" not in html
 
 
 def test_telegraph_br_no_span():
     from telegraph.utils import nodes_to_html
 
     html = nodes_to_html(main.telegraph_br())
-    assert html == "<p>\u00a0</p>"
+    assert html == "<br/><br/>"
     assert "<span" not in html

--- a/tests/test_vk_weekend.py
+++ b/tests/test_vk_weekend.py
@@ -56,6 +56,7 @@ async def test_build_weekend_vk_message(tmp_path: Path):
     assert f'[https://vk.com/wall-1_2|{format_weekend_range(next_sat)}]' in msg
     assert msg.splitlines()[0] == f'{format_weekend_range(sat)} Афиша выходных'
     assert 'июль [https://vk.com/wall-1_4|август]' in msg
+    assert '\xa0' in format_weekend_range(sat)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- ensure Telegraph pages use `<br>` for reliable blank lines
- link festival names on month pages and support case-insensitive lookups
- keep weekend ranges on one line and hide expired exhibitions

## Testing
- `pytest tests/test_render_month_spacing.py tests/test_vk_weekend.py tests/test_bot.py::test_weekend_nav_and_exhibitions tests/test_bot.py::test_month_nav_and_exhibitions tests/test_bot.py::test_exhibition_future_not_listed tests/test_bot.py::test_past_exhibition_not_listed tests/test_bot.py::test_festival_page_contacts_and_dates tests/test_bot.py::test_month_page_festival_link tests/test_bot.py::test_month_page_festival_star`
- `pytest` *(fails: VK_USER_TOKEN missing and other unrelated errors)*

------
https://chatgpt.com/codex/tasks/task_e_689fb272ce648332a611d5e90774d8d6