### PR TITLE
Standardize telegraph blank lines

### DIFF
--- a/main.py
+++ b/main.py
@@ -101,7 +101,7 @@ import aiosqlite
 import gc
 import atexit
 from cachetools import TTLCache
-from markup import simple_md_to_html, DAY_START, DAY_END, PERM_START, PERM_END
+from markup import simple_md_to_html, telegraph_br, DAY_START, DAY_END, PERM_START, PERM_END
 from sections import replace_between_markers, content_hash
 from db import Database
 from scheduler import startup as scheduler_startup, cleanup as scheduler_cleanup
@@ -5069,12 +5069,6 @@ def md_to_html(text: str) -> str:
     html_text = re.sub(r"<(\/?)h[12]>", r"<\1h3>", html_text)
     html_text = re.sub(r"</?tg-emoji[^>]*>", "", html_text)
     return html_text
-
-
-def telegraph_br() -> list[dict]:
-    """Return a safe blank line for Telegraph rendering."""
-    return [{"tag": "br"}, {"tag": "br"}]
-
 
 _DISALLOWED_TAGS_RE = re.compile(r"</?(?:span|div|style|script)[^>]*>", re.IGNORECASE)
 

--- a/markup.py
+++ b/markup.py
@@ -18,6 +18,11 @@ def simple_md_to_html(text: str) -> str:
     return text.replace('\n', '<br>')
 
 
+def telegraph_br() -> list[dict]:
+    """Return a safe blank line for Telegraph rendering."""
+    return [{"tag": "p", "children": ["\u00A0"]}]
+
+
 class Marker(str):
     """Str subclass that mimics dict.get for test compatibility."""
 

--- a/tests/test_render_month_spacing.py
+++ b/tests/test_render_month_spacing.py
@@ -21,14 +21,16 @@ def test_render_month_day_section_has_blank_lines():
         make_event("B", "2025-01-15", "13:00"),
     ]
     html = main.render_month_day_section(date(2025, 1, 15), events)
-    day_end = html.index("</h3>") + len("</h3>")
-    assert html[day_end:].startswith("<br/><br/><h4>")
-    assert "<br/><br/><br/>" not in html
+    assert "<p>\u00A0</p><h4>" in html
 
 
 def test_telegraph_br_no_span():
     from telegraph.utils import nodes_to_html
 
     html = nodes_to_html(main.telegraph_br())
-    assert html == "<br/><br/>"
+    assert html == "<p>\u00A0</p>"
     assert "<span" not in html
+
+
+def test_lint_preserves_nbsp():
+    assert main.lint_telegraph_html("<p>&nbsp;</p>") == "<p>&nbsp;</p>"


### PR DESCRIPTION
## Summary
- centralize `telegraph_br` in `markup.py`
- ensure blank lines render as `<p>&nbsp;</p>` across month pages
- add unit tests guarding spacing and sanitizer behaviour

## Testing
- `pytest tests/test_render_month_spacing.py -q`
- `pytest -q` *(fails: VKAPIError, network/config dependencies, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_689fbe9b55e48332a9d338423baf1aaa