### PR TITLE
Make VK post links clickable and hide past weekend links

### DIFF
--- a/main.py
+++ b/main.py
@@ -6484,7 +6484,11 @@ async def build_weekend_vk_message(db: Database, start: str) -> str:
                 if location_parts:
                     lines.append(", ".join(location_parts))
 
-        nav_pages = [w for w in weekend_pages if w.vk_post_url or w.start == start]
+        nav_pages = [
+            w
+            for w in weekend_pages
+            if w.start >= start and (w.vk_post_url or w.start == start)
+        ]
         if nav_pages:
             parts = []
             for w in nav_pages:
@@ -7334,21 +7338,17 @@ async def build_daily_sections_vk(
         lines1.pop()
     link_lines: list[str] = []
     if wpage and wpage.vk_post_url:
-        sunday = w_start + timedelta(days=1)
+        label = f"выходные {format_weekend_range(w_start)}"
         prefix = f"(+{weekend_count}) " if weekend_count else ""
-        link_lines.append(
-            f"{prefix}выходные {w_start.day} {sunday.day} {MONTHS[w_start.month - 1]}: {wpage.vk_post_url}"
-        )
+        link_lines.append(f"{prefix}[{wpage.vk_post_url}|{label}]")
     if week_cur:
+        label = month_name_nominative(cur_month)
         prefix = f"(+{cur_count}) " if cur_count else ""
-        link_lines.append(
-            f"{prefix}{month_name_nominative(cur_month)}: {week_cur.vk_post_url}"
-        )
+        link_lines.append(f"{prefix}[{week_cur.vk_post_url}|{label}]")
     if week_next:
+        label = month_name_nominative(next_month_str)
         prefix = f"(+{next_count}) " if next_count else ""
-        link_lines.append(
-            f"{prefix}{month_name_nominative(next_month_str)}: {week_next.vk_post_url}"
-        )
+        link_lines.append(f"{prefix}[{week_next.vk_post_url}|{label}]")
     if link_lines:
         lines1.append(VK_EVENT_SEPARATOR)
         lines1.extend(link_lines)

--- a/tests/test_vk_daily.py
+++ b/tests/test_vk_daily.py
@@ -1,9 +1,17 @@
-import pytest
 from datetime import date, datetime, timezone
 from pathlib import Path
 
+import pytest
+
 import main
-from main import Database, WeekendPage, WeekPage, Event
+from main import (
+    Database,
+    WeekendPage,
+    WeekPage,
+    Event,
+    format_weekend_range,
+    month_name_nominative,
+)
 
 
 @pytest.mark.asyncio
@@ -56,7 +64,12 @@ async def test_build_daily_sections_vk_links(tmp_path: Path):
     sec1, _ = await main.build_daily_sections_vk(
         db, timezone.utc, now=datetime(2025, 7, 10, tzinfo=timezone.utc)
     )
-    assert "https://vk.com/wall-1_2" in sec1
-    assert "https://vk.com/wall-1_3" in sec1
-    assert "https://vk.com/wall-1_4" in sec1
+    label_weekend = f"выходные {format_weekend_range(w_start)}"
+    assert f"[https://vk.com/wall-1_2|{label_weekend}]" in sec1
+    assert (
+        f"[https://vk.com/wall-1_3|{month_name_nominative('2025-07')}]" in sec1
+    )
+    assert (
+        f"[https://vk.com/wall-1_4|{month_name_nominative('2025-08')}]" in sec1
+    )
     assert "u1" not in sec1

--- a/tests/test_vk_weekend.py
+++ b/tests/test_vk_weekend.py
@@ -13,7 +13,16 @@ async def test_build_weekend_vk_message(tmp_path: Path):
     await db.init()
     sat = date(2025, 7, 12)
     next_sat = sat + timedelta(days=7)
+    prev_sat = sat - timedelta(days=7)
     async with db.get_session() as session:
+        session.add(
+            WeekendPage(
+                start=prev_sat.isoformat(),
+                url='u_prev',
+                path='p_prev',
+                vk_post_url='https://vk.com/wall-1_prev',
+            )
+        )
         session.add(WeekendPage(start=sat.isoformat(), url='u1', path='p1'))
         session.add(
             WeekendPage(
@@ -54,6 +63,8 @@ async def test_build_weekend_vk_message(tmp_path: Path):
 
     assert 'NoVK' not in msg
     assert f'[https://vk.com/wall-1_2|{format_weekend_range(next_sat)}]' in msg
+    assert 'https://vk.com/wall-1_prev' not in msg
+    assert format_weekend_range(prev_sat) not in msg
     assert msg.splitlines()[0] == f'{format_weekend_range(sat)} Афиша выходных'
     assert 'июль [https://vk.com/wall-1_4|август]' in msg
     assert '\xa0' in format_weekend_range(sat)


### PR DESCRIPTION
## Summary
- Render daily VK footer links as clickable text for weekend and monthly posts
- Skip links to past weekends in VK weekend post navigation
- Add tests for new link formatting and navigation filtering

## Testing
- `pytest tests/test_vk_daily.py tests/test_vk_weekend.py`

------
https://chatgpt.com/codex/tasks/task_e_68a18c3a6044833280f5db4528e2740a