### PR TITLE
feat: add festival ticket link

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -189,6 +189,10 @@
 
 - Added support for `кинопоказ` event type and automatic detection of film screenings.
 
+## v0.3.30 - Festival ticket links
+
+- Festival records support a `ticket_url` and VK/Telegraph festival posts show a ticket icon and link below the location.
+
 
 
 

--- a/alembic/versions/20250811_festival_ticket_url.py
+++ b/alembic/versions/20250811_festival_ticket_url.py
@@ -1,0 +1,18 @@
+"""add festival ticket_url"""
+
+from typing import Sequence, Union
+from alembic import op
+import sqlalchemy as sa
+
+revision: str = '20250811_festival_ticket_url'
+down_revision: Union[str, None] = '20250810_job_outbox_last_result'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column('festival', sa.Column('ticket_url', sa.String(), nullable=True))
+
+
+def downgrade() -> None:
+    op.drop_column('festival', 'ticket_url')

--- a/db.py
+++ b/db.py
@@ -187,6 +187,7 @@ class Database:
                     website_url TEXT,
                     vk_url TEXT,
                     tg_url TEXT,
+                    ticket_url TEXT,
                     location_name TEXT,
                     location_address TEXT,
                     city TEXT,
@@ -197,6 +198,7 @@ class Database:
             await _add_column(conn, "festival", "location_name TEXT")
             await _add_column(conn, "festival", "location_address TEXT")
             await _add_column(conn, "festival", "city TEXT")
+            await _add_column(conn, "festival", "ticket_url TEXT")
 
             await conn.execute(
                 """

--- a/models.py
+++ b/models.py
@@ -141,6 +141,7 @@ class Festival(SQLModel, table=True):
     website_url: Optional[str] = None
     vk_url: Optional[str] = None
     tg_url: Optional[str] = None
+    ticket_url: Optional[str] = None
     location_name: Optional[str] = None
     location_address: Optional[str] = None
     city: Optional[str] = None


### PR DESCRIPTION
## Summary
- support `ticket_url` for festivals
- show ticket link with an icon under festival location
- allow editing festival ticket link and store in DB

## Testing
- `pytest tests/test_bot.py::test_edit_festival_contacts tests/test_bot.py::test_festival_vk_message_no_events tests/test_bot.py::test_festival_page_no_events_shows_info -q`
- `pytest tests/test_bot.py::test_festival_page_contacts_and_dates -q`


------
https://chatgpt.com/codex/tasks/task_e_68a1c97a04c08332b59a2cf357dbb3c6