### PR TITLE
Ensure festival description appears in VK posts

### DIFF
--- a/main.py
+++ b/main.py
@@ -6688,6 +6688,11 @@ async def build_festival_page_content(db: Database, fest: Festival) -> tuple[str
         desc = await generate_festival_description(fest, events)
         if desc:
             fest.description = desc
+            await session.execute(
+                update(Festival)
+                .where(Festival.id == fest.id)
+                .values(description=desc)
+            )
             await session.commit()
 
     nodes: list[dict] = []
@@ -6878,6 +6883,16 @@ async def build_festival_vk_message(db: Database, fest: Festival) -> str:
             select(Event).where(Event.festival == fest.name).order_by(Event.date, Event.time)
         )
         events = res.scalars().all()
+        if not fest.description:
+            desc = await generate_festival_description(fest, events)
+            if desc:
+                fest.description = desc
+                await session.execute(
+                    update(Festival)
+                    .where(Festival.id == fest.id)
+                    .values(description=desc)
+                )
+                await session.commit()
     lines = [fest.full_name or fest.name]
     start, end = festival_dates(fest, events)
 


### PR DESCRIPTION
## Summary
- save generated festival descriptions to the database
- include festival description when building VK posts
- test that VK festival posts generate and persist a description

## Testing
- `pytest -q` *(fails: VK_USER_TOKEN missing and other environment-related errors)*
- `pytest tests/test_bot.py::test_festival_vk_message_generates_description -q`


------
https://chatgpt.com/codex/tasks/task_e_68a1cd70507c8332ad7de9c6aad4d381