### PR TITLE
Use zero-width space in Telegraph blank lines

### DIFF
--- a/main.py
+++ b/main.py
@@ -1705,9 +1705,9 @@ FEST_NAV_START = "<!-- FEST_NAV_START -->"
 FEST_NAV_END = "<!-- FEST_NAV_END -->"
 
 FOOTER_LINK_HTML = (
-    '<p>&nbsp;</p>'
+    '<p>&#8203;</p>'
     '<p><a href="https://t.me/kenigevents">Полюбить Калининград Анонсы</a></p>'
-    '<p>&nbsp;</p>'
+    '<p>&#8203;</p>'
 )
 
 
@@ -1779,7 +1779,7 @@ def apply_festival_nav(html_content: str, html_block: str) -> str:
 def apply_footer_link(html_content: str) -> str:
     """Ensure the Telegram channel link footer is present once."""
     pattern = re.compile(
-        r'<p><a href="https://t\.me/kenigevents">[^<]+</a></p><p>&nbsp;</p>'
+        r'<p><a href="https://t\.me/kenigevents">[^<]+</a></p><p>(?:&nbsp;|&#8203;)</p>'
     )
     html_content = pattern.sub("", html_content).rstrip()
     return html_content + FOOTER_LINK_HTML

--- a/markup.py
+++ b/markup.py
@@ -20,7 +20,8 @@ def simple_md_to_html(text: str) -> str:
 
 def telegraph_br() -> list[dict]:
     """Return a safe blank line for Telegraph rendering."""
-    return [{"tag": "br"}]
+    # U+200B survives Telegraph HTML import, unlike &nbsp; in <p>
+    return [{"tag": "p", "children": ["\u200B"]}]
 
 
 class Marker(str):

--- a/tests/test_bot.py
+++ b/tests/test_bot.py
@@ -3445,7 +3445,7 @@ async def test_update_source_page_footer(monkeypatch):
     await main.update_source_page("p", "T", "text")
     html = edited.get("html", "")
     assert "Полюбить Калининград Анонсы" in html
-    assert "&nbsp;" in html
+    assert "&#8203;" in html
 
 
 @pytest.mark.asyncio
@@ -3571,22 +3571,10 @@ async def test_create_source_page_adds_nav(tmp_path: Path, monkeypatch):
 
 @pytest.mark.asyncio
 async def test_create_source_page_footer(monkeypatch):
-    captured = {}
-
-    class DummyTG:
-        def create_page(self, title, html_content=None, **_):
-            captured["html"] = html_content
-            return {"url": "https://telegra.ph/test", "path": "p"}
-
     monkeypatch.setenv("TELEGRAPH_TOKEN", "t")
-    monkeypatch.setattr(
-        "main.Telegraph", lambda access_token=None, domain=None: DummyTG()
-    )
-
-    await main.create_source_page("T", "text", None)
-    html = captured.get("html", "")
+    html, _, _ = await main.build_source_page_content("T", "text", None, None, None, None, None)
     assert "Полюбить Калининград Анонсы" in html
-    assert "&nbsp;" in html
+    assert "&#8203;" in html
 
 
 @pytest.mark.asyncio

--- a/tests/test_render_month_spacing.py
+++ b/tests/test_render_month_spacing.py
@@ -22,21 +22,21 @@ def test_render_month_day_section_has_blank_lines():
         make_event("B", "2025-01-15", "13:00"),
     ]
     html = main.render_month_day_section(date(2025, 1, 15), events)
-    assert "<p>\u00A0</p><h4>" in html
+    assert "<p>\u200B</p><h4>" in html
 
 
 def test_telegraph_br_no_span():
     html = nodes_to_html(main.telegraph_br())
-    assert html == "<p>\u00A0</p>"
+    assert html == "<p>\u200B</p>"
     assert "<span" not in html
 
 
-def test_lint_preserves_nbsp():
-    assert main.lint_telegraph_html("<p>&nbsp;</p>") == "<p>&nbsp;</p>"
+def test_lint_preserves_zwsp():
+    assert main.lint_telegraph_html("<p>&#8203;</p>") == "<p>&#8203;</p>"
 
 
 def test_event_to_nodes_ends_with_blank_paragraph():
     event = make_event("C", "2025-01-15", "12:00")
     nodes = main.event_to_nodes(event)
     assert nodes[-1] == main.telegraph_br()[0]
-    assert nodes_to_html(nodes).endswith("<p>\u00A0</p>")
+    assert nodes_to_html(nodes).endswith("<p>\u200B</p>")


### PR DESCRIPTION
## Summary
- keep blank paragraph spacing in Telegraph HTML by using a zero-width space
- update footer insertion to use `&#8203;` and handle both fillers
- adjust tests for the new spacing behavior

## Testing
- `pytest -q` *(fails: VK_USER_TOKEN missing, other environment-related failures)*
- `pytest tests/test_render_month_spacing.py -q`
- `pytest tests/test_bot.py::test_update_source_page_footer -q`
- `pytest tests/test_bot.py::test_create_source_page_footer -q`


------
https://chatgpt.com/codex/tasks/task_e_68a1dee3b63c8332b885dfbb7c0114d4