### PR TITLE
feat: consolidate publish progress

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -193,6 +193,10 @@
 
 - Festival records support a `ticket_url` and VK/Telegraph festival posts show a ticket icon and link below the location.
 
+## v0.3.31 - Unified publish progress
+
+- Event publication statuses now appear in one updating message with inline status icons.
+
 
 
 


### PR DESCRIPTION
## Summary
- show event publication progress in a single updating message
- support structured job notifications
- add tests for progress updates

## Testing
- `pytest -q` *(fails: VK_USER_TOKEN missing, month page assertions, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68a1e50a5fc08332b180337702dcc849