### PR TITLE
Fix progress message update call

### DIFF
--- a/main.py
+++ b/main.py
@@ -4976,9 +4976,9 @@ async def publish_event_progress(event: Event, db: Database, bot: Bot, chat_id: 
         ]
         text = head if not lines else head + "\n" + "\n".join(lines)
         await bot.edit_message_text(
-            text,
             chat_id=chat_id,
             message_id=msg.message_id,
+            text=text,
         )
 
     while await _run_due_jobs_once(db, bot, updater, event.id):
@@ -4992,15 +4992,15 @@ async def publish_event_progress(event: Event, db: Database, bot: Bot, chat_id: 
         ]
         text = head if not lines else head + "\n" + "\n".join(lines)
         await bot.edit_message_text(
-            text,
             chat_id=chat_id,
             message_id=msg.message_id,
+            text=text,
         )
     else:
         await bot.edit_message_text(
-            "Готово",
             chat_id=chat_id,
             message_id=msg.message_id,
+            text="Готово",
         )
 
 


### PR DESCRIPTION
## Summary
- fix SafeBot.edit_message_text usage in publish_event_progress

## Testing
- `pytest -q` *(fails: VK_USER_TOKEN missing, network errors)*
- `pytest tests/test_notifications.py::test_progress_notifications_error -q`
- `pytest tests/test_notifications.py::test_progress_notifications -q`


------
https://chatgpt.com/codex/tasks/task_e_68a1fdef6be883328bed355462e8ec9b