### PR TITLE
Start job outbox worker for telegraph pages

### DIFF
--- a/main.py
+++ b/main.py
@@ -8323,6 +8323,7 @@ async def init_db_and_scheduler(
     app["daily_scheduler"] = asyncio.create_task(daily_scheduler(db, bot))
     app["add_event_worker"] = asyncio.create_task(add_event_queue_worker(db, bot))
     app["add_event_watch"] = asyncio.create_task(_watch_add_event_worker(app, db, bot))
+    app["job_outbox_worker"] = asyncio.create_task(job_outbox_worker(db, bot))
     gc.collect()
     logging.info("BOOT_OK pid=%s", os.getpid())
 

--- a/tests/test_job_worker.py
+++ b/tests/test_job_worker.py
@@ -1,0 +1,45 @@
+import asyncio
+import contextlib
+import pytest
+from aiohttp import web
+import main
+
+@pytest.mark.asyncio
+async def test_init_starts_job_outbox_worker(tmp_path, monkeypatch):
+    async def fake_get_tz_offset(db):
+        return "0"
+    async def fake_get_catbox_enabled(db):
+        return False
+    async def fake_get_vk_photos_enabled(db):
+        return False
+    async def fake_worker(*args, **kwargs):
+        pass
+    class DummyBot:
+        async def set_webhook(self, *args, **kwargs):
+            pass
+    monkeypatch.setattr(main, "get_tz_offset", fake_get_tz_offset)
+    monkeypatch.setattr(main, "get_catbox_enabled", fake_get_catbox_enabled)
+    monkeypatch.setattr(main, "get_vk_photos_enabled", fake_get_vk_photos_enabled)
+    monkeypatch.setattr(main, "scheduler_startup", lambda db, bot: None)
+    monkeypatch.setattr(main, "daily_scheduler", fake_worker)
+    monkeypatch.setattr(main, "add_event_queue_worker", fake_worker)
+    monkeypatch.setattr(main, "_watch_add_event_worker", fake_worker)
+    monkeypatch.setattr(main, "job_outbox_worker", fake_worker)
+    prev_catbox = main.CATBOX_ENABLED
+    prev_vk = main.VK_PHOTOS_ENABLED
+    app = web.Application()
+    db = main.Database(str(tmp_path / "db.sqlite"))
+    await main.init_db_and_scheduler(app, db, DummyBot(), "https://example.com")
+    assert "job_outbox_worker" in app
+    main.CATBOX_ENABLED = prev_catbox
+    main.VK_PHOTOS_ENABLED = prev_vk
+    for key in [
+        "daily_scheduler",
+        "add_event_worker",
+        "add_event_watch",
+        "job_outbox_worker",
+    ]:
+        task = app[key]
+        task.cancel()
+        with contextlib.suppress(asyncio.CancelledError):
+            await task


### PR DESCRIPTION
## Summary
- ensure background job runner starts at app init so event tasks like telegraph page build run
- cover worker startup with unit test

## Testing
- `pytest tests/test_job_worker.py -q`
- `pytest -q` *(fails: VK_USER_TOKEN missing; ProxyError to api.telegra.ph)*

------
https://chatgpt.com/codex/tasks/task_e_68a20439a814833294e00eca44e08698