### PR TITLE
Handle VK captcha by caching failure

### DIFF
--- a/tests/test_vk_captcha.py
+++ b/tests/test_vk_captcha.py
@@ -1,0 +1,26 @@
+import pytest
+import main
+
+class DummyResp:
+    def __init__(self, data):
+        self._data = data
+    def json(self):
+        return self._data
+
+
+@pytest.mark.asyncio
+async def test_vk_api_captcha_cached(monkeypatch):
+    calls = 0
+    async def fake_http_call(*args, **kwargs):
+        nonlocal calls
+        calls += 1
+        return DummyResp({"error": {"error_code": 14, "error_msg": "Captcha needed"}})
+    monkeypatch.setattr(main, "http_call", fake_http_call)
+    monkeypatch.setattr(main, "_vk_captcha_needed", False)
+    with pytest.raises(main.VKAPIError) as e:
+        await main._vk_api("wall.get", {}, token="t")
+    assert e.value.code == 14
+    assert calls == 1
+    with pytest.raises(main.VKAPIError):
+        await main._vk_api("wall.get", {}, token="t")
+    assert calls == 1


### PR DESCRIPTION
## Summary
- cache VK captcha requirement to avoid repeated API calls and notify admin
- add test ensuring VK captcha state is cached

## Testing
- `pytest` *(fails: VK_USER_TOKEN missing, network errors)*
- `pytest tests/test_vk_captcha.py`

------
https://chatgpt.com/codex/tasks/task_e_68a208f0d7f88332b3624891bac64c5e