### PR TITLE
Ensure idempotent festival navigation and day markers

### DIFF
--- a/tests/test_ensure_day_markers.py
+++ b/tests/test_ensure_day_markers.py
@@ -1,0 +1,16 @@
+from datetime import date
+
+import main
+from markup import DAY_START, DAY_END, PERM_START, PERM_END
+
+
+def test_ensure_day_markers_once():
+    html = f"<p>x</p>{PERM_START}{PERM_END}"
+    d = date(2025, 8, 15)
+    updated, changed = main.ensure_day_markers(html, d)
+    assert changed is True
+    assert DAY_START(d) in updated and DAY_END(d) in updated
+    assert updated.index(DAY_START(d)) < updated.index(PERM_START)
+    again, changed2 = main.ensure_day_markers(updated, d)
+    assert changed2 is False
+    assert again == updated

--- a/tests/test_month_patch.py
+++ b/tests/test_month_patch.py
@@ -204,5 +204,5 @@ async def test_patch_month_page_rebuilds_when_header_without_markers(tmp_path, m
 
     tg = FakeTelegraph()
     changed = await main.patch_month_page_for_date(db, tg, "2025-08", date(2025, 8, 15))
-    assert changed is True
+    assert changed == "rebuild"
     assert called is True


### PR DESCRIPTION
## Summary
- refactor festival navigation handling to use shared markers and NAV_HASH for idempotency
- add ensure_day_markers helper and integrate into month patching
- expand tests for festival navigation and day marker insertion

## Testing
- `pytest tests/test_festival_nav.py tests/test_ensure_day_markers.py -q`
- `pytest tests/test_month_patch.py::test_patch_month_page_rebuilds_when_header_without_markers -q`
- `pytest -q` *(fails: VKAPIError: VK_USER_TOKEN missing, ProxyError: Unable to connect to proxy, and other failures)*

------
https://chatgpt.com/codex/tasks/task_e_68a220180b988332a678e3589d1154b3