### PR TITLE
feat: unify fest nav markers and vk logging

### DIFF
--- a/markup.py
+++ b/markup.py
@@ -37,5 +37,6 @@ WEND_START = lambda key: Marker(f"<!--WEEKEND:{key} START-->")
 WEND_END = lambda key: Marker(f"<!--WEEKEND:{key} END-->")
 PERM_START: Marker = Marker("<!--PERMANENT_EXHIBITIONS START-->")
 PERM_END: Marker = Marker("<!--PERMANENT_EXHIBITIONS END-->")
-FEST_NAV_START: Marker = Marker("<!--FEST_NAV_START-->")
-FEST_NAV_END: Marker = Marker("<!--FEST_NAV_END-->")
+# Canonical festival navigation markers used across the project
+FEST_NAV_START: Marker = Marker("<!--fest-nav-start-->")
+FEST_NAV_END: Marker = Marker("<!--fest-nav-end-->")

--- a/tests/test_festival_nav.py
+++ b/tests/test_festival_nav.py
@@ -15,6 +15,8 @@ def test_apply_festival_nav_insert_when_missing():
     assert updated.count(FEST_NAV_START) == 1
     assert '<!-- FEST_NAV_START -->' not in updated
     assert '<!-- FEST_NAV_END -->' not in updated
+    assert '<!--FEST_NAV_START-->' not in updated
+    assert '<!--FEST_NAV_END-->' not in updated
     assert '<!--NAV_HASH:' in updated
     assert updated.endswith(FOOTER_LINK_HTML)
 
@@ -51,6 +53,15 @@ def test_apply_festival_nav_rewrites_spaced_markers():
     assert updated.count(FEST_NAV_START) == 1
     assert '<!-- FEST_NAV_START -->' not in updated
     assert '<!-- FEST_NAV_END -->' not in updated
+
+
+def test_apply_festival_nav_rewrites_uppercase_markers():
+    html = '<p>start</p><!--FEST_NAV_START--><p>old</p><!--FEST_NAV_END-->'
+    updated, changed = main.apply_festival_nav(html, NAV_HTML)
+    assert changed is True
+    assert updated.count(FEST_NAV_START) == 1
+    assert '<!--FEST_NAV_START-->' not in updated
+    assert '<!--FEST_NAV_END-->' not in updated
 
 
 def test_apply_footer_link_idempotent():


### PR DESCRIPTION
## Summary
- adopt canonical `<!--fest-nav-start-->` markers across project
- migrate old festival nav markers and keep footer insertion idempotent
- log VK sync results with edited/skipped/error actions

## Testing
- `pytest tests/test_festival_nav.py`
- `pytest` *(fails: VK_USER_TOKEN missing and other environment issues)*

------
https://chatgpt.com/codex/tasks/task_e_68a23287c2188332a202eb47c837588d