### PR TITLE
feat: schedule festival navigation updates via outbox

### DIFF
--- a/models.py
+++ b/models.py
@@ -155,6 +155,8 @@ class JobTask(str, Enum):
     weekend_pages = "weekend_pages"
     week_pages = "week_pages"
     festival_pages = "festival_pages"
+    fest_nav_tg = "fest_nav_tg"
+    fest_nav_vk = "fest_nav_vk"
 
 
 class JobStatus(str, Enum):

--- a/tests/test_festival_nav_rebuild.py
+++ b/tests/test_festival_nav_rebuild.py
@@ -1,0 +1,177 @@
+import pytest
+import main
+from models import Festival, JobOutbox, JobStatus
+from markup import FEST_NAV_START
+from sqlalchemy import select
+from datetime import date
+
+
+@pytest.mark.asyncio
+async def test_rebuild_festival_nav_updates_all(tmp_path, monkeypatch):
+    db = main.Database(str(tmp_path / "db.sqlite"))
+    await db.init()
+
+    # prepare festivals
+    today = date.today().isoformat()
+    async with db.get_session() as session:
+        for i in range(3):
+            session.add(
+                Festival(
+                    name=f"Fest{i+1}",
+                    telegraph_path=f"p{i+1}",
+                    vk_post_url=f"u{i+1}",
+                    start_date=today,
+                    end_date=today,
+                )
+            )
+        await session.commit()
+
+    tg_pages = {f"p{i+1}": {"html": "<p>start</p>", "title": f"Fest{i+1}"} for i in range(3)}
+
+    class DummyTelegraph:
+        def __init__(self, *_, **__):
+            pass
+
+        def get_page(self, path, return_html=True):
+            return {"content_html": tg_pages[path]["html"], "title": tg_pages[path]["title"]}
+
+        def edit_page(self, path, title, html_content):
+            tg_pages[path] = {"html": html_content, "title": title}
+            return {}
+
+    async def fake_telegraph_call(func, *args, **kwargs):
+        return func(*args, **kwargs)
+
+    monkeypatch.setattr(main, "Telegraph", DummyTelegraph)
+    monkeypatch.setattr(main, "telegraph_call", fake_telegraph_call)
+    monkeypatch.setattr(main, "get_telegraph_token", lambda: "token")
+
+    vk_base = {f"Fest{i+1}": f"base{i+1}\n" for i in range(3)}
+    vk_posts = vk_base.copy()
+
+    async def fake_sync_festival_vk_post(db, name, bot, nav_only=False, nav_lines=None):
+        assert nav_only
+        _, lines = await main._build_festival_nav_block(db, exclude=name)
+        nav = "\n".join(lines)
+        base = vk_base[name]
+        cur = vk_posts.get(name, base)
+        new = base + nav
+        if cur == new:
+            return False
+        vk_posts[name] = new
+        return True
+
+    monkeypatch.setattr(main, "get_vk_group_id", lambda db: 1)
+    monkeypatch.setattr(main, "sync_festival_vk_post", fake_sync_festival_vk_post)
+
+    changed = await main.rebuild_fest_nav_if_changed(db)
+    assert changed
+    while await main._run_due_jobs_once(db, None):
+        pass
+
+    for page in tg_pages.values():
+        assert FEST_NAV_START in page["html"]
+        assert page["html"].endswith(main.FOOTER_LINK_HTML)
+    for name in vk_posts:
+        assert vk_posts[name] != vk_base[name]
+
+    changed2 = await main.rebuild_fest_nav_if_changed(db)
+    assert not changed2
+
+    async with db.get_session() as session:
+        session.add(
+            Festival(
+                name="Fest4",
+                telegraph_path="p4",
+                vk_post_url="u4",
+                start_date=today,
+                end_date=today,
+            )
+        )
+        await session.commit()
+    tg_pages["p4"] = {"html": "<p>start</p>", "title": "Fest4"}
+    vk_base["Fest4"] = "base4\n"
+    vk_posts["Fest4"] = vk_base["Fest4"]
+
+    changed3 = await main.rebuild_fest_nav_if_changed(db)
+    assert changed3
+    while await main._run_due_jobs_once(db, None):
+        pass
+    for name in vk_posts:
+        assert vk_posts[name] != vk_base[name]
+
+
+@pytest.mark.asyncio
+async def test_vk_failure_does_not_block_tg(tmp_path, monkeypatch):
+    db = main.Database(str(tmp_path / "db.sqlite"))
+    await db.init()
+    today = date.today().isoformat()
+    async with db.get_session() as session:
+        for i in range(2):
+            session.add(
+                Festival(
+                    name=f"Fest{i+1}",
+                    telegraph_path=f"p{i+1}",
+                    vk_post_url=f"u{i+1}",
+                    start_date=today,
+                    end_date=today,
+                )
+            )
+        await session.commit()
+
+    tg_pages = {f"p{i+1}": {"html": "<p>start</p>", "title": f"Fest{i+1}"} for i in range(2)}
+
+    class DummyTelegraph:
+        def __init__(self, *_, **__):
+            pass
+
+        def get_page(self, path, return_html=True):
+            return {"content_html": tg_pages[path]["html"], "title": tg_pages[path]["title"]}
+
+        def edit_page(self, path, title, html_content):
+            tg_pages[path] = {"html": html_content, "title": title}
+            return {}
+
+    async def fake_telegraph_call(func, *args, **kwargs):
+        return func(*args, **kwargs)
+
+    monkeypatch.setattr(main, "Telegraph", DummyTelegraph)
+    monkeypatch.setattr(main, "telegraph_call", fake_telegraph_call)
+    monkeypatch.setattr(main, "get_telegraph_token", lambda: "token")
+
+    vk_base = {f"Fest{i+1}": f"base{i+1}\n" for i in range(2)}
+    vk_posts = vk_base.copy()
+    fail_name = "Fest1"
+
+    async def fake_sync_festival_vk_post(db, name, bot, nav_only=False, nav_lines=None):
+        assert nav_only
+        if name == fail_name:
+            raise RuntimeError("vk failure")
+        _, lines = await main._build_festival_nav_block(db, exclude=name)
+        nav = "\n".join(lines)
+        base = vk_base[name]
+        vk_posts[name] = base + nav
+        return True
+
+    monkeypatch.setattr(main, "get_vk_group_id", lambda db: 1)
+    monkeypatch.setattr(main, "sync_festival_vk_post", fake_sync_festival_vk_post)
+
+    await main.rebuild_fest_nav_if_changed(db)
+    for _ in range(3):
+        if not await main._run_due_jobs_once(db, None):
+            break
+
+    for page in tg_pages.values():
+        assert FEST_NAV_START in page["html"]
+    assert vk_posts["Fest2"] != vk_base["Fest2"]
+    assert vk_posts["Fest1"] == vk_base["Fest1"]
+
+    async with db.get_session() as session:
+        rows = (
+            await session.execute(
+                select(JobOutbox.event_id, JobOutbox.task, JobOutbox.status)
+            )
+        ).all()
+    vk_statuses = [r.status for r in rows if r.task.value == "fest_nav_vk"]
+    assert JobStatus.error in vk_statuses
+


### PR DESCRIPTION
## Summary
- track festival navigation hash and enqueue per-festival TG/VK update jobs when it changes
- add job handlers to apply canonical navigation block to Telegraph pages and VK posts
- cover navigation rebuild and error handling with tests

## Testing
- `pytest tests/test_festival_nav_rebuild.py::test_rebuild_festival_nav_updates_all -q`
- `pytest tests/test_festival_nav_rebuild.py::test_vk_failure_does_not_block_tg -q`
- `pytest -q` *(fails: 27 failed, 198 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68a25211ae8883329d096b79aba9ceb6