### PR TITLE
propagate vk captcha details

### DIFF
--- a/tests/test_vk_captcha.py
+++ b/tests/test_vk_captcha.py
@@ -14,13 +14,26 @@ async def test_vk_api_captcha_cached(monkeypatch):
     async def fake_http_call(*args, **kwargs):
         nonlocal calls
         calls += 1
-        return DummyResp({"error": {"error_code": 14, "error_msg": "Captcha needed"}})
+        return DummyResp({
+            "error": {
+                "error_code": 14,
+                "error_msg": "Captcha needed",
+                "captcha_sid": "sid",
+                "captcha_img": "img",
+            }
+        })
     monkeypatch.setattr(main, "http_call", fake_http_call)
     monkeypatch.setattr(main, "_vk_captcha_needed", False)
-    with pytest.raises(main.VKAPIError) as e:
+    monkeypatch.setattr(main, "_vk_captcha_sid", None)
+    monkeypatch.setattr(main, "_vk_captcha_img", None)
+    with pytest.raises(main.VKAPIError) as e1:
         await main._vk_api("wall.get", {}, token="t")
-    assert e.value.code == 14
+    assert e1.value.code == 14
+    assert e1.value.captcha_sid == "sid"
+    assert e1.value.captcha_img == "img"
     assert calls == 1
-    with pytest.raises(main.VKAPIError):
+    with pytest.raises(main.VKAPIError) as e2:
         await main._vk_api("wall.get", {}, token="t")
+    assert e2.value.captcha_sid == "sid"
+    assert e2.value.captcha_img == "img"
     assert calls == 1


### PR DESCRIPTION
## Summary
- remember captcha sid & image between VK API retries
- surface captcha info on cached VK errors
- cover VK captcha details with tests

## Testing
- `pytest tests/test_vk_captcha.py::test_vk_api_captcha_cached -q`
- `pytest -q` *(fails: assert '(Открытие) Expo' in 'Events on 10.07.2025\nNo events', assert False, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68a38e84084c83329b0b297790c61788