### PR TITLE
feat: add helpers to format links for telegraph and VK

### DIFF
--- a/tests/test_markup.py
+++ b/tests/test_markup.py
@@ -1,32 +1,25 @@
 import pytest
 
-from markup import simple_md_to_html
-
+from markup import simple_md_to_html, linkify_for_telegraph, expose_links_for_vk
 
 def test_bold():
     assert simple_md_to_html('**bold** __bold__') == '<b>bold</b> <b>bold</b>'
 
-
 def test_italic():
     assert simple_md_to_html('*it* _it_') == '<i>it</i> <i>it</i>'
-
 
 def test_link():
     assert simple_md_to_html('see [site](https://example.com)') == 'see <a href="https://example.com">site</a>'
 
-
 def test_header_and_newline():
     assert simple_md_to_html('# Title\ntext') == '<h1>Title</h1><br>text'
-
 
 def test_emoji_preserved():
     assert simple_md_to_html('smile 😀') == 'smile 😀'
 
-
 def test_no_italic_in_urls():
     url = 'https://example.com/image_2024_08.jpg'
     assert simple_md_to_html(url) == url
-
 
 def test_link_with_underscore_url():
     assert (
@@ -34,7 +27,17 @@ def test_link_with_underscore_url():
         == '<a href="https://site.com/a_b_c">doc</a>'
     )
 
-
 def test_plain_underscores_unchanged():
     assert simple_md_to_html('file_name') == 'file_name'
 
+def test_linkify_plain_url():
+    assert linkify_for_telegraph("https://example.com") == '<a href="https://example.com">https://example.com</a>'
+
+def test_linkify_text_url():
+    assert linkify_for_telegraph("Site (https://example.com)") == '<a href="https://example.com">Site</a>'
+
+def test_expose_links_from_html():
+    assert expose_links_for_vk('see <a href="https://example.com">site</a>') == 'see site (https://example.com)'
+
+def test_expose_links_from_md():
+    assert expose_links_for_vk('see [site](https://example.com)') == 'see site (https://example.com)'


### PR DESCRIPTION
## Summary
- add `linkify_for_telegraph` and `expose_links_for_vk` utilities
- use telegraph linkification in `md_to_html`
- replace bespoke VK link exposure and cover in tests

## Testing
- `pytest` *(fails: AssertionError and missing tokens)*

------
https://chatgpt.com/codex/tasks/task_e_68a467a5a6088332ae446f56bc4dff11