### PR TITLE
test: ensure festival links on weekend pages

### DIFF
--- a/tests/test_weekend_festival_link.py
+++ b/tests/test_weekend_festival_link.py
@@ -1,0 +1,47 @@
+import pytest
+from pathlib import Path
+from datetime import date, datetime
+
+import main
+from db import Database
+from models import Event, Festival
+from telegraph.utils import nodes_to_html
+
+
+@pytest.mark.asyncio
+async def test_weekend_page_links_festival(tmp_path: Path, monkeypatch):
+    db = Database(str(tmp_path / "db.sqlite"))
+    await db.init()
+
+    async with db.get_session() as session:
+        fest = Festival(name="Fest", telegraph_url="https://telegra.ph/fest", telegraph_path="fest")
+        session.add(fest)
+        session.add(
+            Event(
+                title="E",
+                description="d",
+                source_text="s",
+                date="2025-07-12",
+                time="18:00",
+                location_name="Hall",
+                festival=fest.name,
+            )
+        )
+        await session.commit()
+
+    class FakeDate(date):
+        @classmethod
+        def today(cls):
+            return date(2025, 7, 10)
+
+    class FakeDatetime(datetime):
+        @classmethod
+        def now(cls, tz=None):
+            return datetime(2025, 7, 10, 12, 0, tzinfo=tz)
+
+    monkeypatch.setattr(main, "date", FakeDate)
+    monkeypatch.setattr(main, "datetime", FakeDatetime)
+
+    _, content, _ = await main.build_weekend_page_content(db, "2025-07-12")
+    html = nodes_to_html(content)
+    assert '<a href="https://telegra.ph/fest">Fest</a>' in html


### PR DESCRIPTION
## Summary
- add regression test for weekend page ensuring festival names become links when `telegraph_url` is present

## Testing
- `pytest tests/test_weekend_festival_link.py -q`
- `pytest tests/test_month_festival_link.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a48c41fbe8833287ffd30ef975959d