### PR TITLE
Linkify links on Telegraph source pages

### DIFF
--- a/tests/test_bot.py
+++ b/tests/test_bot.py
@@ -3596,6 +3596,20 @@ async def test_create_source_page_footer(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_build_source_page_content_linkify():
+    html, _, _ = await main.build_source_page_content(
+        "T", "See https://example.com", None, None, None, None, None
+    )
+    assert (
+        '<a href="https://example.com">https://example.com</a>' in html
+    )
+    html2, _, _ = await main.build_source_page_content(
+        "T", "", None, "Site (https://example.com)", None, None, None
+    )
+    assert '<a href="https://example.com">Site</a>' in html2
+
+
+@pytest.mark.asyncio
 async def test_update_event_description_from_telegraph(tmp_path: Path, monkeypatch):
     db = Database(str(tmp_path / "db.sqlite"))
     await db.init()

--- a/tests/test_vk_source.py
+++ b/tests/test_vk_source.py
@@ -101,7 +101,8 @@ async def test_add_events_from_text_preserves_links(tmp_path: Path, monkeypatch)
     html = "<a href='http://reg'>Регистрация</a>"
     res = await main.add_events_from_text(db, "Регистрация", None, html, None)
     ev = res[0][0]
-    assert "Регистрация (http://reg)" in ev.source_text
+    assert "http://reg" in ev.source_text
+    assert "(http://reg)" not in ev.source_text
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- Preserve original source text when saving events
- Linkify bare URLs and "text (url)" pairs in Telegraph source pages
- Test source page linkification and adjust source text expectations

## Testing
- `pytest tests/test_vk_source.py tests/test_bot.py::test_create_source_page_footer tests/test_bot.py::test_build_source_page_content_linkify`


------
https://chatgpt.com/codex/tasks/task_e_68a4ecc13fd883328c19bbb6cfb0b18f