### PR TITLE
feat: improve vk captcha and event validation

### DIFF
--- a/tests/test_bot.py
+++ b/tests/test_bot.py
@@ -1484,6 +1484,63 @@ async def test_forward_add_event(tmp_path: Path, monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_forward_missing_fields(tmp_path: Path, monkeypatch):
+    db = Database(str(tmp_path / "db.sqlite"))
+    await db.init()
+    bot = DummyBot("123:abc")
+
+    async def fake_parse(text: str, source_channel: str | None = None) -> list[dict]:
+        return [
+            {
+                "title": "Forwarded",
+                "date": FUTURE_DATE,
+                "time": "18:00",
+            }
+        ]
+
+    monkeypatch.setattr("main.parse_event_via_4o", fake_parse)
+
+    start_msg = types.Message.model_validate(
+        {
+            "message_id": 1,
+            "date": 0,
+            "chat": {"id": 1, "type": "private"},
+            "from": {"id": 1, "is_bot": False, "first_name": "A"},
+            "text": "/start",
+        }
+    )
+    await handle_start(start_msg, db, bot)
+
+    upd = DummyUpdate(-100123, "Chan")
+    await main.handle_my_chat_member(upd, db)
+
+    async with db.get_session() as session:
+        ch = await session.get(main.Channel, -100123)
+        ch.is_registered = True
+        await session.commit()
+
+    fwd_msg = types.Message.model_validate(
+        {
+            "message_id": 3,
+            "date": 0,
+            "forward_date": 0,
+            "forward_from_chat": {"id": -100123, "type": "channel", "username": "chan"},
+            "forward_from_message_id": 10,
+            "chat": {"id": 1, "type": "private"},
+            "from": {"id": 1, "is_bot": False, "first_name": "A"},
+            "text": "Some text",
+        }
+    )
+
+    await main.handle_forwarded(fwd_msg, db, bot)
+
+    assert any("Отсутствуют обязательные поля" in m[1] for m in bot.messages)
+    async with db.get_session() as session:
+        ev = (await session.execute(select(Event))).scalars().first()
+    assert ev is None
+
+
+@pytest.mark.asyncio
 async def test_forward_passes_channel_name(tmp_path: Path, monkeypatch):
     db = Database(str(tmp_path / "db.sqlite"))
     await db.init()

--- a/tests/test_vk_captcha.py
+++ b/tests/test_vk_captcha.py
@@ -1,5 +1,8 @@
 import pytest
 import main
+from aiogram import Bot, types
+from pathlib import Path
+from main import Database, User
 
 class DummyResp:
     def __init__(self, data):
@@ -37,3 +40,55 @@ async def test_vk_api_captcha_cached(monkeypatch):
     assert e2.value.captcha_sid == "sid"
     assert e2.value.captcha_img == "img"
     assert calls == 1
+
+
+class PhotoBot(Bot):
+    def __init__(self, token: str):
+        super().__init__(token)
+        self.photos = []
+        self.messages = []
+
+    async def send_photo(self, chat_id, photo, **kwargs):
+        self.photos.append((chat_id, photo, kwargs))
+
+    async def send_message(self, chat_id, text, **kwargs):
+        self.messages.append((chat_id, text, kwargs))
+
+
+@pytest.mark.asyncio
+async def test_handle_vk_captcha_flow(tmp_path: Path, monkeypatch):
+    db = Database(str(tmp_path / "db.sqlite"))
+    await db.init()
+    bot = PhotoBot("123:abc")
+    async with db.get_session() as session:
+        session.add(User(user_id=1, is_superadmin=True))
+        await session.commit()
+    main._vk_captcha_sid = "sid"
+    main._vk_captcha_img = "img"
+    main._vk_captcha_needed = True
+
+    async def fake_superadmin_id(db):
+        return 1
+
+    monkeypatch.setattr(main, "get_superadmin_id", fake_superadmin_id)
+    await main.notify_vk_captcha(db, bot, "img")
+    assert bot.photos and bot.photos[0][1] == "img"
+
+    async def fake_vk_api(method, params, db=None, bot=None, **kwargs):
+        assert params["captcha_sid"] == "sid"
+        assert params["captcha_key"] == "1234"
+        return {"response": 1}
+
+    monkeypatch.setattr(main, "_vk_api", fake_vk_api)
+    msg = types.Message.model_validate(
+        {
+            "message_id": 1,
+            "date": 0,
+            "chat": {"id": 1, "type": "private"},
+            "from": {"id": 1, "is_bot": False, "first_name": "A"},
+            "text": "/captcha 1234",
+        }
+    )
+    await main.handle_vk_captcha(msg, db, bot)
+    assert main._vk_captcha_sid is None
+    assert bot.messages and "Captcha solved" in bot.messages[0][1]


### PR DESCRIPTION
## Summary
- add inline validation when forwarded events miss required fields
- send VK captcha image to superadmin and add `/captcha` handler
- cover captcha flow and validation with tests

## Testing
- `pytest tests/test_vk_captcha.py::test_handle_vk_captcha_flow tests/test_bot.py::test_forward_missing_fields -q`

------
https://chatgpt.com/codex/tasks/task_e_68a4f6c3de548332aadbe679faf50526