### PR TITLE
Ensure month navigation covers all months

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,6 +227,12 @@ captcha input and resolves to `✅` or `❌` afterwards.
 When a festival already has a Telegraph page (`telegraph_url` is set) the month
 page renders the festival name as a clickable link.
 
+## Month navigation footer
+
+Each month page ends with a navigation block that lists every available month.
+When a new month is created the navigation is rebuilt on all pages so that each
+footer links to all month pages and the current month is shown without a link.
+
 ## Link formatting
 
 Telegraph pages and "source" pages use `linkify_for_telegraph` to convert

--- a/main.py
+++ b/main.py
@@ -1974,13 +1974,8 @@ def apply_footer_link(html_content: str) -> str:
 
 
 async def build_month_nav_html(db: Database) -> str:
-    cur_month = datetime.now(LOCAL_TZ).strftime("%Y-%m")
     async with db.get_session() as session:
-        result = await session.execute(
-            select(MonthPage)
-            .where(MonthPage.month >= cur_month)
-            .order_by(MonthPage.month)
-        )
+        result = await session.execute(select(MonthPage).order_by(MonthPage.month))
         months = result.scalars().all()
     if not months:
         return ""
@@ -6328,11 +6323,10 @@ def _build_month_page_content_sync(
 
     add_day_sections(sorted(by_day), by_day, fest_map, add_many, use_markers=True)
 
-    future_pages = [p for p in nav_pages if p.month >= month]
     month_nav: list[dict] = []
-    nav_children = []
-    if future_pages:
-        for idx, p in enumerate(future_pages):
+    nav_children: list = []
+    if nav_pages:
+        for idx, p in enumerate(nav_pages):
             name = month_name_nominative(p.month)
             if p.month == month:
                 nav_children.append(name)
@@ -6340,7 +6334,7 @@ def _build_month_page_content_sync(
                 nav_children.append(
                     {"tag": "a", "attrs": {"href": p.url}, "children": [name]}
                 )
-            if idx < len(future_pages) - 1:
+            if idx < len(nav_pages) - 1:
                 nav_children.append(" ")
     else:
         nav_children = [month_name_nominative(month)]

--- a/tests/test_month_nav.py
+++ b/tests/test_month_nav.py
@@ -1,0 +1,68 @@
+import pytest
+from pathlib import Path
+from datetime import date, datetime
+
+import main
+from db import Database
+from models import Event, MonthPage
+from telegraph.utils import nodes_to_html
+
+@pytest.mark.asyncio
+async def test_footer_links_propagate_across_all_month_pages(tmp_path: Path, monkeypatch):
+    db = Database(str(tmp_path / "db.sqlite"))
+    await db.init()
+
+    # Existing months: August, September, October
+    async with db.get_session() as session:
+        for month in ("2025-08", "2025-09", "2025-10"):
+            session.add(
+                Event(
+                    title="E",
+                    description="d",
+                    source_text="s",
+                    date=f"{month}-10",
+                    time="18:00",
+                    location_name="Hall",
+                )
+            )
+            session.add(MonthPage(month=month, url=f"https://t.me/{month}", path=month))
+        await session.commit()
+
+    class FakeDate(date):
+        @classmethod
+        def today(cls):
+            return date(2025, 7, 10)
+
+    class FakeDatetime(datetime):
+        @classmethod
+        def now(cls, tz=None):
+            return datetime(2025, 7, 10, 12, 0, tzinfo=tz)
+
+    monkeypatch.setattr(main, "date", FakeDate)
+    monkeypatch.setattr(main, "datetime", FakeDatetime)
+
+    # Add November month and event
+    async with db.get_session() as session:
+        session.add(
+            Event(
+                title="E",
+                description="d",
+                source_text="s",
+                date="2025-11-10",
+                time="18:00",
+                location_name="Hall",
+            )
+        )
+        session.add(MonthPage(month="2025-11", url="https://t.me/2025-11", path="2025-11"))
+        await session.commit()
+
+    months = ["2025-08", "2025-09", "2025-10", "2025-11"]
+    for m in months:
+        _, content, _ = await main.build_month_page_content(db, m)
+        html = nodes_to_html(content)
+        for other in months:
+            name = main.month_name_nominative(other)
+            if other == m:
+                assert name in html
+            else:
+                assert f'<a href="https://t.me/{other}">{name}</a>' in html


### PR DESCRIPTION
## Summary
- include all months when building month page footer navigation
- select all MonthPage entries for telegraph month nav block
- document month navigation footer and add regression test

## Testing
- `pytest tests/test_month_nav.py::test_footer_links_propagate_across_all_month_pages tests/test_month_festival_link.py::test_month_page_links_festival -q`

------
https://chatgpt.com/codex/tasks/task_e_68a6e466621083328270097168878d26