### PR TITLE
Use batch progress snapshot with single card

### DIFF
--- a/scheduling.py
+++ b/scheduling.py
@@ -84,42 +84,52 @@ class BatchProgress:
     def _label(self, key: str) -> str:
         kind, _, ident = key.partition(":")
         if kind == "festival_pages":
-            return f"Фестиваль: {ident}"
+            return "Festival"
         if kind == "month_pages":
-            year, month = ident.split("-")
+            _, month = ident.split("-")
             name = MONTHS_NOM[int(month)].capitalize()
-            return f"Страница месяца: {name} {year}"
+            return f"Month: {name}"
         if kind == "week_pages":
             year, week = ident.split("-")
             start = datetime.fromisocalendar(int(year), int(week), 1)
             end = start + timedelta(days=6)
-            return f"Неделя: {self._format_range(start, end)}"
+            return f"Week: {self._format_range(start, end)}"
         if kind == "weekend_pages":
             start = datetime.strptime(ident, "%Y-%m-%d")
             end = start + timedelta(days=1)
-            return f"Выходные: {self._format_range(start, end)}"
+            return f"Weekend: {self._format_range(start, end)}"
         if kind == "vk_week_post":
             year, week = ident.split("-")
             start = datetime.fromisocalendar(int(year), int(week), 1)
             end = start + timedelta(days=6)
-            return f"Пост недели VK: {self._format_range(start, end)}"
+            return f"VK week: {self._format_range(start, end)}"
         if kind == "vk_weekend_post":
             start = datetime.strptime(ident, "%Y-%m-%d")
             end = start + timedelta(days=1)
-            return f"Пост выходных VK: {self._format_range(start, end)}"
+            return f"VK weekend: {self._format_range(start, end)}"
         return key
 
     def snapshot_text(self) -> str:
         icon = {
             "success": "✅",
             "error": "❌",
-            "pending": "⏳",
+            "pending": "🔄",
             "paused": "⏸",
         }
         lines = [
-            f"События (Telegraph): {self.events_done}/{self.total_events}"
+            f"Events (Telegraph): {self.events_done}/{self.total_events}"
         ]
-        for key in sorted(self.status.keys()):
+        order = {
+            "festival_pages": 0,
+            "month_pages": 1,
+            "week_pages": 2,
+            "weekend_pages": 3,
+            "vk_week_post": 4,
+            "vk_weekend_post": 5,
+        }
+        for key in sorted(
+            self.status.keys(), key=lambda k: (order.get(k.split(":")[0], 99), k)
+        ):
             lines.append(f"{icon[self.status[key]]} {self._label(key)}")
         return "\n".join(lines)
 

--- a/tests/test_coalesce.py
+++ b/tests/test_coalesce.py
@@ -6,7 +6,7 @@ from scheduling import CoalescingScheduler, schedule_event_batch
 @pytest.mark.asyncio
 async def test_coalesce_creates_single_jobs():
     scheduler = CoalescingScheduler()
-    dates = ["2025-07-16"] * 5
+    dates = ["2025-07-19"] * 5
     schedule_event_batch(scheduler, festival_id=1, dates=dates)
 
     keys = scheduler.jobs.keys()

--- a/tests/test_dependencies.py
+++ b/tests/test_dependencies.py
@@ -5,7 +5,7 @@ from scheduling import BatchProgress, CoalescingScheduler, schedule_event_batch
 
 @pytest.mark.asyncio
 async def test_festival_runs_before_month_and_vk():
-    dates = ["2025-07-16"]
+    dates = ["2025-07-19"]
     progress = BatchProgress(total_events=len(dates))
     scheduler = CoalescingScheduler(progress)
     schedule_event_batch(scheduler, festival_id=1, dates=dates)
@@ -15,9 +15,9 @@ async def test_festival_runs_before_month_and_vk():
     festival_key = "festival_pages:1"
     month_key = "month_pages:2025-07"
     week_key = "week_pages:2025-29"
-    weekend_key = "weekend_pages:2025-07-16"
+    weekend_key = "weekend_pages:2025-07-19"
     vk_week_key = "vk_week_post:2025-29"
-    vk_weekend_key = "vk_weekend_post:2025-07-16"
+    vk_weekend_key = "vk_weekend_post:2025-07-19"
 
     assert order[0] == festival_key
     assert order.index(month_key) > order.index(festival_key)

--- a/tests/test_progress_batch.py
+++ b/tests/test_progress_batch.py
@@ -4,7 +4,7 @@ from scheduling import BatchProgress, CoalescingScheduler, schedule_event_batch
 
 
 @pytest.mark.asyncio
-async def test_progress_updates_to_final_state():
+async def test_single_progress_card_final_snapshot():
     dates = [
         "2025-07-31",
         "2025-08-01",
@@ -21,9 +21,10 @@ async def test_progress_updates_to_final_state():
     assert progress.events_done == len(dates)
     assert len(progress.status) == 7
     final = progress.snapshot_text()
-    assert "⏳" not in final
-    assert final.count("Страница месяца") == 2
-    assert final.count("Неделя:") == 1
-    assert final.count("Выходные:") == 1
-    assert final.count("Пост недели VK") == 1
-    assert final.count("Пост выходных VK") == 1
+    assert "🔄" not in final
+    assert final.count("Festival") == 1
+    assert final.count("Month:") == 2
+    assert final.count("Week:") == 1
+    assert final.count("Weekend:") == 1
+    assert final.count("VK week:") == 1
+    assert final.count("VK weekend:") == 1


### PR DESCRIPTION
## Summary
- format BatchProgress snapshots with unified labels for festival, month, week, weekend and VK artifacts
- ensure pending jobs show 🔄 and output ordered consistently
- cover new snapshot format with integration test and adjust existing tests

## Testing
- `pytest tests/test_progress_batch.py tests/test_dependencies.py tests/test_coalesce.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a77c3562c48332b7b451f4cdb4e146