### PR TITLE
Add debounce for weekly and weekend tasks

### DIFF
--- a/tests/test_coalescing.py
+++ b/tests/test_coalescing.py
@@ -4,10 +4,12 @@ from scheduling import CoalescingScheduler, schedule_event_batch
 
 
 @pytest.mark.asyncio
-async def test_coalesce_creates_single_jobs():
+async def test_coalescing_merges_jobs():
     scheduler = CoalescingScheduler()
-    dates = ["2025-07-19"] * 5
-    schedule_event_batch(scheduler, festival_id=1, dates=dates)
+    dates1 = ["2025-07-19"] * 3
+    dates2 = ["2025-07-19"] * 3
+    schedule_event_batch(scheduler, festival_id=1, dates=dates1)
+    schedule_event_batch(scheduler, festival_id=1, dates=dates2)
 
     keys = scheduler.jobs.keys()
     assert len([k for k in keys if k.startswith("festival_pages:")]) == 1
@@ -16,3 +18,5 @@ async def test_coalesce_creates_single_jobs():
     assert len([k for k in keys if k.startswith("weekend_pages:")]) == 1
     assert len([k for k in keys if k.startswith("vk_week_post:")]) == 1
     assert len([k for k in keys if k.startswith("vk_weekend_post:")]) == 1
+    assert len(scheduler.jobs["weekend_pages:2025-07-19"].payload) == 6
+    assert len(scheduler.jobs["vk_weekend_post:2025-07-19"].payload) == 6


### PR DESCRIPTION
## Summary
- Debounce week and weekend updates and corresponding VK posts
- Track merged jobs in new coalescing test

## Testing
- `pytest tests/test_coalescing.py -q`
- `pytest -q` *(fails: AttributeError: 'NoneType' object has no attribute 'id', VK_USER_TOKEN missing, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68a78c2c3db48332ac70714e778ed6a8