### PR TITLE
Fix month page splitting and navigation

### DIFF
--- a/tests/test_bot.py
+++ b/tests/test_bot.py
@@ -76,7 +76,17 @@ def _sync_event_updates(monkeypatch):
 
 
 @pytest.fixture(autouse=True)
-def _mock_page_sync(monkeypatch):
+def _mock_page_sync(monkeypatch, request):
+    if any(
+        key in request.node.nodeid
+        for key in (
+            "sync_month_page_split",
+            "sync_month_page_split_on_error",
+            "month_page_split_filters_past_events",
+        )
+    ):
+        return
+
     async def fake_month(db_obj, month):
         return None
 


### PR DESCRIPTION
## Summary
- ensure month pages split across Telegraph use direct API calls and preserve navigation
- add explicit `<br>` spacing after headers and filter month nav to upcoming months
- allow tests that exercise month page sync to run the real sync function

## Testing
- `pytest tests/test_bot.py::test_sync_month_page_split tests/test_bot.py::test_sync_month_page_split_on_error tests/test_bot.py::test_month_page_split_filters_past_events tests/test_bot.py::test_create_source_page_adds_nav tests/test_bot.py::test_spacing_after_headers -q`

------
https://chatgpt.com/codex/tasks/task_e_68a78f27a1f08332aa665c4f75324eaf