### PR TITLE
Update defaults for VK schedule and captcha

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,16 +52,17 @@ browse upcoming announcements. The command accepts dates like `2025-07-10`,
   export WEEK_EDIT_CRON=02:30     # HH:MM local time
   # Optional: fine-grained weekly edit control
   export VK_WEEK_EDIT_ENABLED=false
-  export VK_WEEK_EDIT_SCHEDULE=02:30
-  export VK_WEEK_EDIT_TZ=UTC
+  export VK_WEEK_EDIT_SCHEDULE=02:10
+  export VK_WEEK_EDIT_TZ=Europe/Kaliningrad
 
   # Captcha handling parameters
   export CAPTCHA_WAIT_S=600
   export CAPTCHA_MAX_ATTEMPTS=2
   export CAPTCHA_NIGHT_RANGE=00:00-07:00
   export CAPTCHA_RETRY_AT=08:10
-  export VK_CAPTCHA_TTL_MIN=5
-  export VK_CAPTCHA_QUIET=00:00-07:00
+  export VK_CAPTCHA_TTL_MIN=60
+  # optional quiet hours for captcha notifications (HH:MM-HH:MM)
+  export VK_CAPTCHA_QUIET=
  python main.py
   ```
 

--- a/main.py
+++ b/main.py
@@ -281,16 +281,19 @@ WEEK_EDIT_CRON = os.getenv("WEEK_EDIT_CRON", "02:30")
 VK_WEEK_EDIT_ENABLED = (
     os.getenv("VK_WEEK_EDIT_ENABLED", "false").lower() == "true"
 )
-VK_WEEK_EDIT_SCHEDULE = os.getenv("VK_WEEK_EDIT_SCHEDULE", "02:30")
-VK_WEEK_EDIT_TZ = os.getenv("VK_WEEK_EDIT_TZ", "UTC")
+# schedule for VK week post edits (HH:MM)
+VK_WEEK_EDIT_SCHEDULE = os.getenv("VK_WEEK_EDIT_SCHEDULE", "02:10")
+# timezone for schedule and captcha quiet hours
+VK_WEEK_EDIT_TZ = os.getenv("VK_WEEK_EDIT_TZ", "Europe/Kaliningrad")
 
 # captcha handling configuration
 CAPTCHA_WAIT_S = int(os.getenv("CAPTCHA_WAIT_S", "600"))
 CAPTCHA_MAX_ATTEMPTS = int(os.getenv("CAPTCHA_MAX_ATTEMPTS", "2"))
 CAPTCHA_NIGHT_RANGE = os.getenv("CAPTCHA_NIGHT_RANGE", "00:00-07:00")
 CAPTCHA_RETRY_AT = os.getenv("CAPTCHA_RETRY_AT", "08:10")
-VK_CAPTCHA_TTL_MIN = int(os.getenv("VK_CAPTCHA_TTL_MIN", "5"))
-VK_CAPTCHA_QUIET = os.getenv("VK_CAPTCHA_QUIET", "00:00-07:00")
+VK_CAPTCHA_TTL_MIN = int(os.getenv("VK_CAPTCHA_TTL_MIN", "60"))
+# quiet hours for captcha notifications (HH:MM-HH:MM, empty = disabled)
+VK_CAPTCHA_QUIET = os.getenv("VK_CAPTCHA_QUIET", "")
 
 # metrics counters
 vk_fallback_group_to_user_total = 0

--- a/tests/test_env_config.py
+++ b/tests/test_env_config.py
@@ -26,7 +26,7 @@ def test_new_config_defaults(monkeypatch):
     assert main.CAPTCHA_NIGHT_RANGE == "00:00-07:00"
     assert main.CAPTCHA_RETRY_AT == "08:10"
     assert main.VK_WEEK_EDIT_ENABLED is False
-    assert main.VK_WEEK_EDIT_SCHEDULE == "02:30"
-    assert main.VK_WEEK_EDIT_TZ == "UTC"
-    assert main.VK_CAPTCHA_TTL_MIN == 5
-    assert main.VK_CAPTCHA_QUIET == "00:00-07:00"
+    assert main.VK_WEEK_EDIT_SCHEDULE == "02:10"
+    assert main.VK_WEEK_EDIT_TZ == "Europe/Kaliningrad"
+    assert main.VK_CAPTCHA_TTL_MIN == 60
+    assert main.VK_CAPTCHA_QUIET == ""


### PR DESCRIPTION
## Summary
- adjust VK-related environment defaults
- document new defaults and quiet hours option
- update env config tests

## Testing
- `pytest tests/test_env_config.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68ab41ec0fb0833285a066a193ca4661