### PR TITLE
feat: add detailed progress status icons

### DIFF
--- a/tests/test_progress_batch.py
+++ b/tests/test_progress_batch.py
@@ -21,7 +21,7 @@ async def test_single_progress_card_final_snapshot():
     assert progress.events_done == len(dates)
     assert len(progress.status) == 7
     final = progress.snapshot_text()
-    assert "🔄" not in final
+    assert "⏳" not in final
     assert final.count("Festival") == 1
     assert final.count("Month:") == 2
     assert final.count("Week:") == 1

--- a/tests/test_progress_captcha.py
+++ b/tests/test_progress_captcha.py
@@ -67,7 +67,7 @@ async def test_progress_captcha_flow(tmp_path, monkeypatch):
     )
 
     await scheduler.run()
-    assert progress.status["vk_week_post:2025-30"] == "paused"
+    assert progress.status["vk_week_post:2025-30"] == "captcha"
     assert progress.status["vk_week_post:2025-31"] == "pending"
     assert bot.photos and bot.photos[0][1] == "img"
 
@@ -82,8 +82,8 @@ async def test_progress_captcha_flow(tmp_path, monkeypatch):
     )
     await main.handle_vk_captcha(msg, db, bot)
 
-    assert progress.status["vk_week_post:2025-30"] == "success"
+    assert progress.status["vk_week_post:2025-30"] == "done"
     assert progress.status["vk_week_post:2025-31"] == "error"
-    assert "paused" not in progress.status.values()
+    assert "captcha" not in progress.status.values()
     assert "pending" not in progress.status.values()
     assert calls == ["wall.post", "wall.post", "wall.post"]

--- a/tests/test_progress_icons.py
+++ b/tests/test_progress_icons.py
@@ -1,0 +1,23 @@
+import pytest
+from scheduling import BatchProgress
+
+
+def test_icons_single_and_batch_states():
+    progress = BatchProgress(total_events=0)
+    progress.status = {
+        "job_pending": "pending",
+        "job_running": "running",
+        "job_deferred": "deferred",
+        "job_captcha": "captcha",
+        "job_done": "done",
+        "job_error": "error",
+        "job_skipped": "skipped_nochange",
+    }
+    text = progress.snapshot_text()
+    assert "⏳" in text
+    assert "🔄" in text
+    assert "⏸" in text
+    assert "🧩⏸" in text
+    assert "✅" in text
+    assert "❌" in text
+    assert "⏭" in text


### PR DESCRIPTION
## Summary
- expand progress tracking with running, deferred, captcha and other states
- display new icons for job statuses and update scheduler handling
- cover icon mapping with tests

## Testing
- `pytest tests/test_progress_batch.py tests/test_progress_captcha.py tests/test_progress_icons.py`
- `pytest` *(fails: 21 failed, 230 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68ab4f4b3c748332ac8a5542ad471c56