### PR TITLE
feat: improve VK fallback and ICS progress links

### DIFF
--- a/tests/test_job_dedup.py
+++ b/tests/test_job_dedup.py
@@ -1,0 +1,23 @@
+import logging
+import pytest
+import main
+from main import Database, JobTask, JobOutbox
+from sqlalchemy import select
+
+
+@pytest.mark.asyncio
+async def test_enqueue_job_dedup(tmp_path, caplog):
+    db = Database(str(tmp_path / "db.sqlite"))
+    await db.init()
+    caplog.set_level(logging.INFO)
+    await main.enqueue_job(db, 1, JobTask.week_pages)
+    await main.enqueue_job(db, 1, JobTask.week_pages)
+    await main.enqueue_job(db, 1, JobTask.month_pages)
+    await main.enqueue_job(db, 1, JobTask.month_pages)
+    async with db.get_session() as session:
+        res = await session.execute(select(JobOutbox).where(JobOutbox.event_id == 1))
+        jobs = res.scalars().all()
+    kinds = [j.task for j in jobs]
+    assert kinds.count(JobTask.week_pages) == 1
+    assert kinds.count(JobTask.month_pages) == 1
+    assert any("merged job_key=week_pages:1" in r.message for r in caplog.records)


### PR DESCRIPTION
## Summary
- add message-link builder and caption formatter for ICS exports
- support single-attempt VK group fallback with circuit logging
- merge duplicate week/month page jobs by job key

## Testing
- `pytest -q` *(fails: 24 failed, 234 passed, 1 skipped)*

------
https://chatgpt.com/codex/tasks/task_e_68ab8dcdbb748332bd4e05bd7ccf11e0