### PR TITLE
Improve ICS captions and progress links

### DIFF
--- a/tests/test_bot.py
+++ b/tests/test_bot.py
@@ -5907,8 +5907,11 @@ async def test_forward_adds_calendar_button(tmp_path: Path, monkeypatch):
 
     async def fake_send_document(self, chat_id, document, caption=None, parse_mode=None):
         class Msg:
-            message_id = 77
-        return Msg()
+            def __init__(self, cid):
+                self.message_id = 77
+                self.chat = type("C", (), {"id": cid})()
+                self.document = type("D", (), {"file_id": "f1"})()
+        return Msg(chat_id)
 
     monkeypatch.setattr(DummyBot, "send_document", fake_send_document, raising=False)
 

--- a/tests/test_db_ics_fields.py
+++ b/tests/test_db_ics_fields.py
@@ -10,9 +10,14 @@ class DummyBot(Bot):
         self.docs = []
 
     async def send_document(self, chat_id, document, caption=None, **kwargs):
-        self.docs.append((chat_id, caption))
+        self.docs.append((chat_id, caption, kwargs.get("parse_mode")))
         from types import SimpleNamespace
-        return SimpleNamespace(document=SimpleNamespace(file_id="file" + str(len(self.docs))), message_id=len(self.docs))
+        chat = SimpleNamespace(id=chat_id)
+        return SimpleNamespace(
+            document=SimpleNamespace(file_id="file" + str(len(self.docs))),
+            message_id=len(self.docs),
+            chat=chat,
+        )
 
 
 class FakeClient:

--- a/tests/test_ics_pipeline.py
+++ b/tests/test_ics_pipeline.py
@@ -13,9 +13,14 @@ class DummyBot(Bot):
         self.docs = []
 
     async def send_document(self, chat_id, document, caption=None, **kwargs):
-        self.docs.append((chat_id, caption))
+        self.docs.append((chat_id, caption, kwargs.get("parse_mode")))
         from types import SimpleNamespace
-        return SimpleNamespace(document=SimpleNamespace(file_id="file" + str(len(self.docs))), message_id=len(self.docs))
+        chat = SimpleNamespace(id=chat_id)
+        return SimpleNamespace(
+            document=SimpleNamespace(file_id="file" + str(len(self.docs))),
+            message_id=len(self.docs),
+            chat=chat,
+        )
 
 
 class FakeClient:

--- a/tests/test_progress_ics.py
+++ b/tests/test_progress_ics.py
@@ -11,9 +11,14 @@ class DummyBot(Bot):
         self.docs = []
 
     async def send_document(self, chat_id, document, caption=None, **kwargs):
-        self.docs.append((chat_id, caption))
+        self.docs.append((chat_id, caption, kwargs.get("parse_mode")))
         from types import SimpleNamespace
-        return SimpleNamespace(document=SimpleNamespace(file_id="file" + str(len(self.docs))), message_id=len(self.docs))
+        chat = SimpleNamespace(id=chat_id)
+        return SimpleNamespace(
+            document=SimpleNamespace(file_id="file" + str(len(self.docs))),
+            message_id=len(self.docs),
+            chat=chat,
+        )
 
 
 class FakeClient:
@@ -71,14 +76,15 @@ async def test_progress_lines_for_ics_states(tmp_path, monkeypatch):
     await main.ics_publish(1, db, bot, pr)
     assert ("ics_supabase", "done", "https://supabase/event-1-2025-07-18.ics") in pr.marks
     assert any(
-        m[0] == "ics_telegram" and m[1] == "done" and m[2].startswith("https://t.me/")
+        m[0] == "ics_telegram" and m[1] == "done" and m[2].startswith("https://t.me/c/")
         for m in pr.marks
     )
-    caption = bot.docs[0][1]
+    caption, parse_mode = bot.docs[0][1], bot.docs[0][2]
+    assert parse_mode == "HTML"
     lines = caption.splitlines()
-    assert lines[0] == "<b>A</b>"
-    assert "Hall" in lines[1] and "#Town" in lines[1]
-    assert lines[2] == "Подробнее: https://tg/1"
+    assert lines[0] == "A"
+    assert lines[1] == '<a href="https://tg/1">Подробнее</a>'
+    assert "Hall" in lines[2] and "#Town" in lines[2] and ", 19:00" in lines[2]
 
     os.environ["SUPABASE_DISABLED"] = "1"
     pr = Progress()
@@ -94,10 +100,7 @@ async def test_progress_lines_for_ics_states(tmp_path, monkeypatch):
     pr = Progress()
     await main.ics_publish(1, db, bot, pr)
     assert ("ics_supabase", "skipped_nochange", "no change") in pr.marks
-    assert any(
-        m[0] == "ics_telegram" and m[1] == "done" and m[2].startswith("https://t.me/")
-        for m in pr.marks
-    )
+    assert ("ics_telegram", "skipped_nochange", "no change") in pr.marks
 
     class BadClient(FakeClient):
         def upload(self, *a, **k):
@@ -112,3 +115,49 @@ async def test_progress_lines_for_ics_states(tmp_path, monkeypatch):
         await main.ics_publish(1, db, bot, pr)
     assert any(m[0] == "ics_supabase" and m[1] == "error" for m in pr.marks)
     assert any(m[0] == "ics_telegram" and m[1] == "done" for m in pr.marks)
+
+
+class HTMLFailBot(DummyBot):
+    async def send_document(self, chat_id, document, caption=None, parse_mode=None, **kwargs):
+        if parse_mode == "HTML":
+            from aiogram.exceptions import TelegramBadRequest
+            raise TelegramBadRequest(object(), "fail")
+        return await super().send_document(chat_id, document, caption=caption, **kwargs)
+
+
+@pytest.mark.asyncio
+async def test_html_fallback(tmp_path, monkeypatch):
+    db = Database(str(tmp_path / "db.sqlite"))
+    await db.init()
+    bot = HTMLFailBot("123:abc")
+    async with db.get_session() as session:
+        session.add(Channel(channel_id=-100, title="Asset", is_admin=True, is_asset=True))
+        session.add(
+            Event(
+                id=1,
+                title="A",
+                description="d",
+                source_text="s",
+                date="2025-07-18",
+                time="19:00",
+                location_name="Hall",
+                city="Town",
+                telegraph_url="https://tg/1",
+                silent=True,
+            )
+        )
+        await session.commit()
+    fake = FakeClient()
+    monkeypatch.setattr(main, "get_supabase_client", lambda: fake)
+    async def fake_update(*a, **k):
+        pass
+    monkeypatch.setattr(main, "update_source_page_ics", fake_update)
+    pr = Progress()
+    await main.ics_publish(1, db, bot, pr)
+    caption, parse_mode = bot.docs[0][1], bot.docs[0][2]
+    assert parse_mode is None
+    assert "Подробнее: https://tg/1" in caption
+    assert any(
+        m[0] == "ics_telegram" and m[1] == "done" and m[2].startswith("https://t.me/c/")
+        for m in pr.marks
+    )


### PR DESCRIPTION
## Summary
- Refactor ICS caption formatting to match daily announcements and include optional HTML link
- Provide message links for posted ICS files and graceful HTML fallback
- Extend tests for ICS caption, progress states and HTML parse fallback

## Testing
- `pytest tests/test_progress_ics.py::test_progress_lines_for_ics_states -q`
- `pytest tests/test_progress_ics.py::test_html_fallback -q`
- `pytest tests/test_db_ics_fields.py tests/test_ics_pipeline.py -q`
- `pytest -q` *(fails: VK_USER_TOKEN missing, network issues)*

------
https://chatgpt.com/codex/tasks/task_e_68ab946a3fa08332939b72127c78878b