### PR TITLE
Sanitize VK post markup

### DIFF
--- a/main.py
+++ b/main.py
@@ -115,6 +115,7 @@ from markup import (
     FEST_NAV_END,
     linkify_for_telegraph,
     expose_links_for_vk,
+    sanitize_for_vk,
 )
 from sections import replace_between_markers, content_hash
 from db import Database
@@ -8478,7 +8479,7 @@ def build_vk_source_message(
 ) -> str:
     """Build detailed VK post for an event including original source text."""
 
-    text = expose_links_for_vk(text)
+    text = sanitize_for_vk(expose_links_for_vk(text))
     lines = build_vk_source_header(event, festival)
     lines.extend(text.strip().splitlines())
     lines.append(VK_BLANK_LINE)
@@ -8551,7 +8552,7 @@ async def sync_vk_source_post(
                 lines.pop()
             texts.append("\n".join(lines).strip())
 
-        text_clean = expose_links_for_vk(text).strip()
+        text_clean = sanitize_for_vk(expose_links_for_vk(text)).strip()
         if texts:
             if append_text:
                 texts.append(text_clean)

--- a/markup.py
+++ b/markup.py
@@ -57,6 +57,27 @@ def expose_links_for_vk(text_or_html: str) -> str:
     text = re.sub(r"\[([^\]]+)\]\((https?://[^)]+)\)", repl_md, text)
     return text
 
+
+def sanitize_for_vk(text_or_html: str) -> str:
+    """Expose links and strip unsupported HTML for VK posts."""
+    s = expose_links_for_vk(text_or_html)
+    s = html.unescape(s)
+    s = s.replace("\xa0", " ")
+    s = re.sub(r"</?tg-emoji[^>]*>", "", s, flags=re.I)
+    s = re.sub(r"&lt;/?tg-emoji.*?&gt;", "", s, flags=re.I)
+    s = re.sub(r"<\s*(?:b|strong)\s*>(.*?)<\s*/\s*(?:b|strong)\s*>", r"*\1*", s, flags=re.I | re.S)
+    s = re.sub(r"<\s*(?:i|em)\s*>(.*?)<\s*/\s*(?:i|em)\s*>", r"_\1_", s, flags=re.I | re.S)
+    s = re.sub(r"<\s*(?:s|del)\s*>(.*?)<\s*/\s*(?:s|del)\s*>", r"~\1~", s, flags=re.I | re.S)
+    s = re.sub(r"<\s*br\s*/?\s*>", "\n", s, flags=re.I)
+    s = re.sub(r"</\s*p\s*>", "\n", s, flags=re.I)
+    s = re.sub(r"</\s*li\s*>", "\n", s, flags=re.I)
+    s = re.sub(r"<\s*li\s*>", "• ", s, flags=re.I)
+    s = re.sub(r"<\s*/?(?:p|ul|ol)\s*>", "", s, flags=re.I)
+    s = re.sub(r"</?[^>]+>", "", s)
+    s = re.sub(r"[ \t]{2,}", " ", s)
+    s = re.sub(r"\n{3,}", "\n\n", s).strip()
+    return s
+
 def telegraph_br() -> list[dict]:
     """Return a safe blank line for Telegraph rendering."""
     # U+200B survives Telegraph HTML import, unlike &nbsp; in <p>

--- a/tests/test_sanitize_for_vk.py
+++ b/tests/test_sanitize_for_vk.py
@@ -1,0 +1,16 @@
+from markup import sanitize_for_vk
+
+
+def test_sanitize_for_vk_strips_html_and_tg_emoji():
+    src = (
+        '<tg-emoji emoji-id="1"> 🗞 </tg-emoji> <i>Личный бренд на дзене</i>\n'
+        'Приглашаем... <a href="https://forms.yandex.ru/u/68a392b2">регистрация</a><br>'
+        '<i>Создаём своё имя...</i>'
+    )
+    expected = (
+        '🗞 _Личный бренд на дзене_\n'
+        'Приглашаем... регистрация (https://forms.yandex.ru/u/68a392b2)\n'
+        '_Создаём своё имя..._'
+    )
+    assert sanitize_for_vk(src) == expected
+


### PR DESCRIPTION
## Summary
- add `sanitize_for_vk` utility to strip Telegram emoji tags and unsupported HTML
- sanitize source messages before posting to VK
- test VK sanitization logic

## Testing
- `pytest -q` *(fails: Cannot connect to host telegra.ph:443; VK_USER_TOKEN missing; other failures)*

------
https://chatgpt.com/codex/tasks/task_e_68ac4ba814088332aacfe4fa267fdb20