### PR TITLE
Avoid double link exposure

### DIFF
--- a/README.md
+++ b/README.md
@@ -238,8 +238,9 @@ footer links to all month pages and the current month is shown without a link.
 
 Telegraph pages and "source" pages use `linkify_for_telegraph` to convert
 plain URLs and patterns like `Name (https://example.com)` into clickable
-anchors. VK posts expose the original URLs in parentheses using
-`expose_links_for_vk` so the full address remains visible.
+anchors. VK posts pass the text through `sanitize_for_vk`, which exposes the
+original URLs in parentheses and strips unsupported HTML and Telegram emoji so
+the full address remains visible.
 
 
 ## Календарь (ICS)

--- a/main.py
+++ b/main.py
@@ -8498,7 +8498,7 @@ def build_vk_source_message(
 ) -> str:
     """Build detailed VK post for an event including original source text."""
 
-    text = sanitize_for_vk(expose_links_for_vk(text))
+    text = sanitize_for_vk(text)
     lines = build_vk_source_header(event, festival)
     lines.extend(text.strip().splitlines())
     lines.append(VK_BLANK_LINE)
@@ -8571,7 +8571,7 @@ async def sync_vk_source_post(
                 lines.pop()
             texts.append("\n".join(lines).strip())
 
-        text_clean = sanitize_for_vk(expose_links_for_vk(text)).strip()
+        text_clean = sanitize_for_vk(text).strip()
         if texts:
             if append_text:
                 texts.append(text_clean)


### PR DESCRIPTION
## Summary
- Use sanitize_for_vk directly in VK source message building and syncing
- Document sanitize_for_vk's link exposure and cleaning behavior in README

## Testing
- `pytest` *(fails: ClientConnectorError connecting to Catbox, AttributeError in exhibition listing, assertion error in weekend page content)*

------
https://chatgpt.com/codex/tasks/task_e_68ac681fc4348332a0e9635ecae1d653