### PR TITLE
Add festival index landing page and month footer link

### DIFF
--- a/tests/test_festival_nav_rebuild.py
+++ b/tests/test_festival_nav_rebuild.py
@@ -75,6 +75,13 @@ async def test_rebuild_festival_nav_updates_only_upcoming(tmp_path, monkeypatch)
 
     monkeypatch.setattr(main, "get_vk_group_id", lambda db: 1)
     monkeypatch.setattr(main, "sync_festival_vk_post", fake_sync_festival_vk_post)
+    called_index = False
+
+    async def fake_sync_index(db):
+        nonlocal called_index
+        called_index = True
+
+    monkeypatch.setattr(main, "sync_festivals_index_page", fake_sync_index)
 
     changed = await main.rebuild_fest_nav_if_changed(db)
     assert changed
@@ -93,6 +100,7 @@ async def test_rebuild_festival_nav_updates_only_upcoming(tmp_path, monkeypatch)
     for name in ["Fest1", "Fest2", "Fest3"]:
         assert vk_posts[name] != vk_base[name]
     assert vk_posts["Past"] == vk_base["Past"]
+    assert called_index
 
     changed2 = await main.rebuild_fest_nav_if_changed(db)
     assert not changed2
@@ -175,6 +183,11 @@ async def test_vk_failure_does_not_block_tg(tmp_path, monkeypatch):
 
     monkeypatch.setattr(main, "get_vk_group_id", lambda db: 1)
     monkeypatch.setattr(main, "sync_festival_vk_post", fake_sync_festival_vk_post)
+
+    async def fake_sync_index2(db):
+        return None
+
+    monkeypatch.setattr(main, "sync_festivals_index_page", fake_sync_index2)
 
     await main.rebuild_fest_nav_if_changed(db)
     for _ in range(3):

--- a/tests/test_festivals_index_page.py
+++ b/tests/test_festivals_index_page.py
@@ -1,0 +1,90 @@
+import pytest
+from datetime import date, datetime
+from pathlib import Path
+
+import main
+from db import Database
+from models import Festival, Event
+from telegraph.utils import nodes_to_html
+
+
+@pytest.mark.asyncio
+async def test_sync_festivals_index_page(tmp_path: Path, monkeypatch):
+    db = Database(str(tmp_path / "db.sqlite"))
+    await db.init()
+    today = date.today().isoformat()
+    async with db.get_session() as session:
+        session.add(Festival(name="Fest", start_date=today, end_date=today))
+        await session.commit()
+
+    stored = {}
+
+    class DummyTelegraph:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        def create_page(self, title, html_content):
+            stored["html"] = html_content
+            return {"url": "https://telegra.ph/fests", "path": "fests"}
+
+        def edit_page(self, path, title, html_content):
+            stored["edited"] = html_content
+            return {}
+
+    async def fake_telegraph_call(func, *args, **kwargs):
+        return func(*args, **kwargs)
+
+    monkeypatch.setattr(main, "Telegraph", DummyTelegraph)
+    monkeypatch.setattr(main, "telegraph_call", fake_telegraph_call)
+
+    async def fake_create_page(tg, *a, **k):
+        return tg.create_page(*a, **k)
+
+    monkeypatch.setattr(main, "telegraph_create_page", fake_create_page)
+    monkeypatch.setattr(main, "get_telegraph_token", lambda: "token")
+
+    await main.sync_festivals_index_page(db)
+
+    assert "Ближайшие фестивали" in stored["html"]
+    url = await main.get_setting_value(db, "fest_index_url")
+    path = await main.get_setting_value(db, "fest_index_path")
+    assert url == "https://telegra.ph/fests"
+    assert path == "fests"
+
+
+@pytest.mark.asyncio
+async def test_month_page_has_festivals_link(tmp_path: Path, monkeypatch):
+    db = Database(str(tmp_path / "db.sqlite"))
+    await db.init()
+
+    async with db.get_session() as session:
+        session.add(
+            Event(
+                title="E",
+                description="d",
+                source_text="s",
+                date="2025-07-16",
+                time="18:00",
+                location_name="Hall",
+            )
+        )
+        await session.commit()
+
+    await main.set_setting_value(db, "fest_index_url", "https://telegra.ph/fests")
+
+    class FakeDate(date):
+        @classmethod
+        def today(cls):
+            return date(2025, 7, 10)
+
+    class FakeDatetime(datetime):
+        @classmethod
+        def now(cls, tz=None):
+            return datetime(2025, 7, 10, 12, 0, tzinfo=tz)
+
+    monkeypatch.setattr(main, "date", FakeDate)
+    monkeypatch.setattr(main, "datetime", FakeDatetime)
+
+    _, content, _ = await main.build_month_page_content(db, "2025-07")
+    html = nodes_to_html(content)
+    assert '<a href="https://telegra.ph/fests">🎪 Все фестивали региона</a>' in html


### PR DESCRIPTION
## Summary
- add `sync_festivals_index_page` to build and store Telegraph landing with all festivals
- update monthly pages to link to the festival landing
- cover index synchronization and month footer link with tests

## Testing
- `pytest tests/test_festivals_index_page.py::test_sync_festivals_index_page -q`
- `pytest tests/test_festivals_index_page.py::test_month_page_has_festivals_link -q`
- `pytest tests/test_festival_nav_rebuild.py -q`
- `pytest tests/test_month_festival_link.py -q`
- `pytest tests/test_weekend_festival_link.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68ac6dd9036883328b6fcf28e7035b43