### PR TITLE
feat: cache festival nav hash

### DIFF
--- a/alembic/versions/20250814_festival_nav_hash.py
+++ b/alembic/versions/20250814_festival_nav_hash.py
@@ -1,0 +1,19 @@
+"""add festival nav_hash"""
+
+from typing import Sequence, Union
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision: str = '20250814_festival_nav_hash'
+down_revision: Union[str, None] = '20250813_ics_fields'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column('festival', sa.Column('nav_hash', sa.String(), nullable=True))
+
+
+def downgrade() -> None:
+    op.drop_column('festival', 'nav_hash')

--- a/db.py
+++ b/db.py
@@ -207,6 +207,7 @@ class Database:
             await _add_column(conn, "festival", "location_address TEXT")
             await _add_column(conn, "festival", "city TEXT")
             await _add_column(conn, "festival", "ticket_url TEXT")
+            await _add_column(conn, "festival", "nav_hash TEXT")
 
             await conn.execute(
                 """

--- a/models.py
+++ b/models.py
@@ -149,6 +149,7 @@ class Festival(SQLModel, table=True):
     location_address: Optional[str] = None
     city: Optional[str] = None
     source_text: Optional[str] = None
+    nav_hash: Optional[str] = None
 
 
 class JobTask(str, Enum):


### PR DESCRIPTION
## Summary
- track per-festival nav hash and skip navigation updates when unchanged
- record nav hash on successful telegraph update
- include nav hash in database and upcoming festival queries
- add DB migration for nav_hash column
- skip nav updates in tests when nav hash matches

## Testing
- `pytest tests/test_festival_nav_rebuild.py::test_rebuild_festival_nav_updates_only_upcoming -q`
- `pytest tests/test_festival_nav_rebuild.py::test_vk_failure_does_not_block_tg -q`
- `pytest tests/test_festival_nav_rebuild.py::test_nav_hash_skip -q`
- `pytest` *(fails: VK user token missing and other assertions)*

------
https://chatgpt.com/codex/tasks/task_e_68aca409498883329b34384217e96731