### PR TITLE
Handle VK nav-only fallback and nav hash tests

### DIFF
--- a/main.py
+++ b/main.py
@@ -7982,6 +7982,12 @@ async def sync_festival_vk_post(
                     extra={"action": "error", "target": "vk", "url": fest.vk_post_url},
                 )
                 raise RuntimeError("vk edit failed")
+            if os.getenv("VK_NAV_FALLBACK") == "skip":
+                logging.info(
+                    "festival post %s skipping VK edit", name,
+                    extra={"action": "vk_nav_skip_edit", "target": "vk", "url": fest.vk_post_url},
+                )
+                return False
             can_edit = False  # editing not possible, create new post
 
     message = await build_festival_vk_message(db, fest)


### PR DESCRIPTION
## Summary
- Skip creating new VK posts when nav-only update cannot edit and VK_NAV_FALLBACK=skip
- Ensure festival nav_hash is stored after Telegraph nav update
- Test VK nav-only skip and nav_hash persistence

## Testing
- `pytest tests/test_festival_nav_rebuild.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68acbcc0674483329d295d6a71d66a26