### PR TITLE
Disable Telegraph image uploads and enhance Catbox handling

### DIFF
--- a/net.py
+++ b/net.py
@@ -2,6 +2,7 @@
 import asyncio
 import json
 import logging
+import os
 import random
 import re
 import time
@@ -11,6 +12,9 @@ from aiohttp import ClientSession, TCPConnector
 
 _connector: TCPConnector | None = None
 _session: ClientSession | None = None
+
+# Feature flag to control Telegraph image uploads
+TELEGRAPH_IMAGE_UPLOAD = os.getenv("TELEGRAPH_IMAGE_UPLOAD", "0") != "0"
 
 # VK API error codes that trigger actor fallback from group to user token
 # include generic "Access denied" errors for posting methods
@@ -114,6 +118,8 @@ async def http_call(
 
 async def telegraph_upload(data: bytes, filename: str) -> str | None:
     """Upload an image to Telegraph and return full URL."""
+    if not TELEGRAPH_IMAGE_UPLOAD:
+        return None
     session = _get_session()
     from aiohttp import FormData
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,3 +10,4 @@ supabase==2.16.0
 icalendar==6.0.1
 cachetools>=5.3.1
 APScheduler>=3.10.4
+Pillow>=10.0.0

--- a/tests/test_bot.py
+++ b/tests/test_bot.py
@@ -4537,7 +4537,7 @@ async def test_add_events_from_text_schedules_pages(tmp_path: Path, monkeypatch)
         return "u", "p"
 
     async def fake_upload_images(media):
-        return [], [], ""
+        return [], ""
 
     async def fake_sync_vk(*args, **kwargs):
         return None
@@ -6412,7 +6412,7 @@ async def test_add_festival_updates_other_pages(tmp_path: Path, monkeypatch):
     monkeypatch.setattr(main, "sync_festival_vk_post", fake_sync_vk)
 
     async def fake_upload(images):
-        return [], [], ""
+        return [], ""
 
     monkeypatch.setattr(main, "upload_images", fake_upload)
 

--- a/tests/test_upload_images.py
+++ b/tests/test_upload_images.py
@@ -33,35 +33,22 @@ async def test_upload_images_catbox_ok(monkeypatch):
     main.CATBOX_ENABLED = True
     resp = DummyResp(200, "http://cat/1.png")
     monkeypatch.setattr(main, "get_http_session", lambda: DummySession([resp]))
-    monkeypatch.setattr(main, "telegraph_upload", lambda d, n: None)
-    urls, tg_urls, msg = await main.upload_images([(b"1", "a.png")])
+    monkeypatch.setattr(main, "detect_image_type", lambda *a, **k: "jpeg")
+    urls, msg = await main.upload_images([(b"1", "a.png")])
     assert urls == ["http://cat/1.png"]
-    assert tg_urls == []
     assert "ok" in msg
 
 
 @pytest.mark.asyncio
-async def test_upload_images_fallback(monkeypatch):
-    main.CATBOX_ENABLED = True
-    resp = DummyResp(412, "pause")
-    monkeypatch.setattr(main, "get_http_session", lambda: DummySession([resp, resp, resp]))
-    monkeypatch.setattr(main, "telegraph_upload", lambda d, n: "https://telegra.ph/file/tg.png")
-    monkeypatch.setattr(asyncio, "sleep", lambda s: None)
-    urls, tg_urls, msg = await main.upload_images([(b"1", "a.png")])
-    assert urls == []
-    assert tg_urls == ["https://telegra.ph/file/tg.png"]
-    assert "tg ok" in msg
-
-
-@pytest.mark.asyncio
-async def test_upload_images_both_fail(monkeypatch):
+async def test_upload_images_fail(monkeypatch):
     main.CATBOX_ENABLED = True
     resp = DummyResp(500, "err")
     monkeypatch.setattr(main, "get_http_session", lambda: DummySession([resp, resp, resp]))
-    monkeypatch.setattr(main, "telegraph_upload", lambda d, n: None)
-    monkeypatch.setattr(asyncio, "sleep", lambda s: None)
-    urls, tg_urls, msg = await main.upload_images([(b"1", "a.png")])
+    async def dummy_sleep(_):
+        return None
+    monkeypatch.setattr(asyncio, "sleep", dummy_sleep)
+    monkeypatch.setattr(main, "detect_image_type", lambda *a, **k: "jpeg")
+    urls, msg = await main.upload_images([(b"1", "a.png")])
     assert urls == []
-    assert tg_urls == []
-    assert "both failed" in msg
+    assert "failed" in msg
 


### PR DESCRIPTION
## Summary
- gate Telegraph image uploads behind TELEGRAPH_IMAGE_UPLOAD flag (disabled by default)
- convert WEBP/AVIF images to JPEG before uploading or posting
- add Catbox upload retries with detailed logging and drop Telegraph fallback
- document Pillow dependency

## Testing
- `pytest tests/test_upload_images.py -q`
- `pytest -q` *(fails: AttributeError, AssertionError, TimeoutError, VKAPIError)*

------
https://chatgpt.com/codex/tasks/task_e_68ad77b26fbc8332a113bed99be4f50e