### PR TITLE
Refine VK progress steps and error handling

### DIFF
--- a/tests/test_bot.py
+++ b/tests/test_bot.py
@@ -7222,9 +7222,9 @@ async def test_publication_plan_and_updates(tmp_path: Path, monkeypatch):
     final_text = bot.text_edits[-1][2]
     assert final_text.startswith("Готово")
     assert "✅ Telegraph (событие) — t" in final_text
-    assert "✅ VK — v" in final_text
+    assert "✅ VK (событие) — v" in final_text
     assert "✅ Страница месяца" in final_text
-    assert "✅ Неделя" in final_text
-    assert "✅ Выходные" in final_text
+    assert "✅ VK (неделя" in final_text
+    assert "✅ VK (выходные" in final_text
 
 

--- a/tests/test_notifications.py
+++ b/tests/test_notifications.py
@@ -89,9 +89,9 @@ async def test_progress_notifications(tmp_path, monkeypatch):
 
     assert "Telegraph (событие): OK — http://t" in bot.messages
     assert "Страница месяца: без изменений" in bot.messages
-    assert "Неделя: OK — http://wk" in bot.messages
-    assert "Выходные: OK — http://w" in bot.messages
-    assert "VK: OK — http://v" in bot.messages
+    assert "VK (неделя): OK — http://wk" in bot.messages
+    assert "VK (выходные): OK — http://w" in bot.messages
+    assert "VK (событие): OK — http://v" in bot.messages
 
     bot.messages.clear()
     async with db.get_session() as session:
@@ -298,8 +298,8 @@ async def test_publish_event_progress_single_message(tmp_path, monkeypatch):
     final = bot.edits[-1]
     assert final.startswith("Готово")
     assert "✅ Telegraph (событие) — http://t" in final
-    assert "✅ VK — http://v" in final
-    assert "✅ Неделя — http://wk" in final
+    assert "✅ VK (событие) — http://v" in final
+    assert "✅ VK (неделя) — http://wk" in final
 
 
 @pytest.mark.asyncio
@@ -362,7 +362,7 @@ async def test_publish_event_progress_waits_for_pending(tmp_path, monkeypatch):
     final = bot.edits[-1]
     assert final.startswith("Готово")
     assert "✅ Telegraph (событие) — http://t" in final
-    assert "✅ Неделя — http://wk" in final
+    assert "✅ VK (неделя) — http://wk" in final
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- Distinguish VK steps for event, week, weekend, and festival posts with scope display
- Return VK post links for weekend and festival jobs
- Handle VK captcha and errors with clearer user-facing notes

## Testing
- `pytest` *(fails: 29 failed)*

------
https://chatgpt.com/codex/tasks/task_e_68ad7992f46c8332b5011f293e2c1954