### PR TITLE
Improve festival linking and notifications

### DIFF
--- a/tests/test_festival_index_link.py
+++ b/tests/test_festival_index_link.py
@@ -1,0 +1,24 @@
+import pytest
+from pathlib import Path
+
+import main
+from db import Database
+from models import Festival
+from telegraph.utils import nodes_to_html
+
+
+@pytest.mark.asyncio
+async def test_festival_page_has_index_link(tmp_path: Path):
+    db = Database(str(tmp_path / "db.sqlite"))
+    await db.init()
+    await main.set_setting_value(db, "fest_index_url", "https://telegra.ph/fests")
+
+    async with db.get_session() as session:
+        fest = Festival(name="Fest")
+        session.add(fest)
+        await session.commit()
+
+    _, nodes = await main.build_festival_page_content(db, fest)
+    html = nodes_to_html(nodes)
+    assert "Все фестивали Калининградской области" in html
+    assert "https://telegra.ph/fests" in html

--- a/tests/test_month_festival_link.py
+++ b/tests/test_month_festival_link.py
@@ -14,7 +14,7 @@ async def test_month_page_links_festival(tmp_path: Path, monkeypatch):
     await db.init()
 
     async with db.get_session() as session:
-        fest = Festival(name="Fest", telegraph_url="https://telegra.ph/fest", telegraph_path="fest")
+        fest = Festival(name="Fest", telegraph_path="fest")
         session.add(fest)
         session.add(
             Event(

--- a/tests/test_weekend_festival_link.py
+++ b/tests/test_weekend_festival_link.py
@@ -14,7 +14,7 @@ async def test_weekend_page_links_festival(tmp_path: Path, monkeypatch):
     await db.init()
 
     async with db.get_session() as session:
-        fest = Festival(name="Fest", telegraph_url="https://telegra.ph/fest", telegraph_path="fest")
+        fest = Festival(name="Fest", telegraph_path="fest")
         session.add(fest)
         session.add(
             Event(


### PR DESCRIPTION
## Summary
- Construct Telegraph URLs from festival path when building month pages and in event rendering
- Always mention festival additions/updates when adding events, with optional day-creation button
- Link each festival page to the overall festival index page

## Testing
- `pytest` *(fails: LLM environment missing, vk token, and other unrelated tests)*

------
https://chatgpt.com/codex/tasks/task_e_68add346961883328c8bce3b89b43e63