### PR TITLE
Update festival landing and navigation rebuild

### DIFF
--- a/tests/test_festivals_index_page.py
+++ b/tests/test_festivals_index_page.py
@@ -49,7 +49,7 @@ async def test_sync_festivals_index_page_created(tmp_path: Path, monkeypatch, ca
         await main.sync_festivals_index_page(db)
 
     html = stored["html"]
-    assert "<h1>Все фестивали региона</h1>" in html
+    assert "<h1>Все фестивали Калининградской области</h1>" in html
     assert "<h2>Ближайшие фестивали</h2>" in html
     assert html.count(FEST_INDEX_INTRO_START) == 1
     assert html.count(FEST_INDEX_INTRO_END) == 1
@@ -98,7 +98,7 @@ async def test_sync_festivals_index_page_updated(tmp_path: Path, monkeypatch, ca
     assert rec.target == "tg"
     assert rec.path == "fests"
     html = stored["edited"]
-    assert "<h1>Все фестивали региона</h1>" in html
+    assert "<h1>Все фестивали Калининградской области</h1>" in html
     assert html.count(FEST_INDEX_INTRO_START) == 1
     assert html.count(FEST_INDEX_INTRO_END) == 1
 
@@ -138,4 +138,4 @@ async def test_month_page_has_festivals_link(tmp_path: Path, monkeypatch):
 
     _, content, _ = await main.build_month_page_content(db, "2025-07")
     html = nodes_to_html(content)
-    assert '<a href="https://telegra.ph/fests">🎪 Все фестивали региона</a>' in html
+    assert '<a href="https://telegra.ph/fests">🎪 Все фестивали Калининградской области</a>' in html

--- a/tests/test_month_festival_link.py
+++ b/tests/test_month_festival_link.py
@@ -1,6 +1,7 @@
 import pytest
 from pathlib import Path
 from datetime import date, datetime
+import logging
 
 import main
 from db import Database
@@ -45,3 +46,47 @@ async def test_month_page_links_festival(tmp_path: Path, monkeypatch):
     _, content, _ = await main.build_month_page_content(db, "2025-07")
     html = nodes_to_html(content)
     assert '<a href="https://telegra.ph/fest">Fest</a>' in html
+
+
+@pytest.mark.asyncio
+async def test_month_render_fest_link_logged(tmp_path: Path, monkeypatch, caplog):
+    db = Database(str(tmp_path / "db.sqlite"))
+    await db.init()
+
+    async with db.get_session() as session:
+        fest = Festival(name="Fest", telegraph_path="fest")
+        ev = Event(
+            title="E",
+            description="d",
+            source_text="s",
+            date="2025-07-16",
+            time="18:00",
+            location_name="Hall",
+            festival=fest.name,
+        )
+        session.add_all([fest, ev])
+        await session.commit()
+        eid = ev.id
+
+    class FakeDate(date):
+        @classmethod
+        def today(cls):
+            return date(2025, 7, 10)
+
+    class FakeDatetime(datetime):
+        @classmethod
+        def now(cls, tz=None):
+            return datetime(2025, 7, 10, 12, 0, tzinfo=tz)
+
+    monkeypatch.setattr(main, "date", FakeDate)
+    monkeypatch.setattr(main, "datetime", FakeDatetime)
+
+    with caplog.at_level(logging.INFO):
+        await main.build_month_page_content(db, "2025-07")
+
+    rec = next(r for r in caplog.records if r.message == "month_render_fest_link")
+    assert rec.event_id == eid
+    assert rec.festival == "Fest"
+    assert rec.has_url is False
+    assert rec.has_path is True
+    assert rec.href_used == "https://telegra.ph/fest"


### PR DESCRIPTION
## Summary
- Rename festival index heading/link to "Все фестивали Калининградской области"
- Add `/festivals_fix_nav` admin command to force rebuild festival navigation and log duplicates
- Log festival link rendering, notifications, and index link insertions

## Testing
- `pytest` *(fails: test_festdays_callback_creates_events, test_forward_adds_calendar_button, test_add_festival_updates_other_pages, test_festival_page_contacts_and_dates, test_festival_vk_message_period_location, test_festival_vk_message_filters_past_events, test_refresh_nav_triggered_on_new_festival, test_edit_vk_post_preserves_photos, test_edit_vk_post_add_photo, test_publication_plan_and_updates, test_sync_festival_vk_post_nav_only_no_change, test_enqueue_job_dedup, test_month_render_fest_link_logged, test_month_page_has_markers, test_patch_month_page_inserts_chronologically, test_patch_month_page_handles_content_too_big, test_patch_month_page_handles_escaped_legacy_markers, test_add_day_sections_weekend_headers_adjacent, test_scheduler_offsets_and_limits and others)*

------
https://chatgpt.com/codex/tasks/task_e_68ade0f6273483329a38a9ec4d016686