### PR TITLE
feat: add role-aware help command

### DIFF
--- a/docs/COMMANDS.md
+++ b/docs/COMMANDS.md
@@ -4,6 +4,7 @@
 |---------|-----------|-------------|
 | `/start` | - | Register the first user as superadmin or display status. |
 | `/register` | - | Request moderator access if slots (<10) are free. |
+| `/help` | - | Show commands available for your role. |
 | `/requests` | - | Superadmin sees pending registrations with approve/reject buttons. |
 | `/tz <±HH:MM>` | required offset | Set timezone offset (superadmin only). |
 | `/addevent <text>` | event description | Parse text with model 4o and store one or several events. The original text is published to Telegraph. Images up to 5&nbsp;MB are uploaded to Catbox and shown on that page. Forwarded messages from moderators are processed the same way. |


### PR DESCRIPTION
## Summary
- add role-aware `/help` command listing accessible commands
- document `/help` in command reference

## Testing
- `pytest -q` (fails: 33 failed, 257 passed, 1 skipped)

------
https://chatgpt.com/codex/tasks/task_e_68adead07ea48332ba1ba9435d90b942