### PR TITLE
Centralize festival nav rebuild and clean landing

### DIFF
--- a/tests/test_festival_index_link.py
+++ b/tests/test_festival_index_link.py
@@ -22,8 +22,10 @@ async def test_festival_page_has_index_link(tmp_path: Path, caplog):
     with caplog.at_level(logging.INFO):
         _, nodes = await main.build_festival_page_content(db, fest)
     html = nodes_to_html(nodes)
-    assert "Все фестивали Калининградской области" in html
-    assert "https://telegra.ph/fests" in html
+    assert (
+        '<a href="https://telegra.ph/fests">🎪 Все фестивали Калининградской области →</a>'
+        in html
+    )
     rec = next(r for r in caplog.records if r.message == "festival_page_index_link")
     assert rec.festival == "Fest"
     assert rec.fest_index_url == "https://telegra.ph/fests"

--- a/tests/test_festival_logging.py
+++ b/tests/test_festival_logging.py
@@ -193,10 +193,11 @@ async def test_sync_festival_vk_post_nav_only_no_change(tmp_path, monkeypatch, c
     monkeypatch.setattr(main, "get_vk_group_id", fake_group_id)
 
     async def fake_nav_block(db, exclude=None, today=None, items=None):
-        return [], ["nav"]
+        return [], [main.VK_BLANK_LINE, "Ближайшие фестивали", "nav"]
 
     async def fake_vk_api(method, params, db, bot, token=None, token_kind=None):
-        return {"response": [{"text": "base\nnav"}]}
+        text = f"base\n{main.VK_BLANK_LINE}\nБлижайшие фестивали\nnav"
+        return {"response": [{"text": text}]}
 
     edit_called = {"called": False}
 


### PR DESCRIPTION
## Summary
- Trigger festival navigation rebuild only on festival-level changes and remove event-level rebuilds
- Generate festival descriptions only when missing and make the index link a single clickable phrase
- Drop legacy landing builder and ensure landing uses a unified header and intro

## Testing
- `pytest tests/test_festival_index_link.py tests/test_festivals_index_page.py tests/test_festival_nav_rebuild.py tests/test_festival_logging.py`


------
https://chatgpt.com/codex/tasks/task_e_68ae12d02cb48332aa8f0bab5c65e67b