### PR TITLE
Fix source keyboard and publish progress handling

### DIFF
--- a/tests/test_festivals_index_page.py
+++ b/tests/test_festivals_index_page.py
@@ -49,7 +49,7 @@ async def test_sync_festivals_index_page_created(tmp_path: Path, monkeypatch, ca
         await main.sync_festivals_index_page(db)
 
     html = stored["html"]
-    assert "<h1>Все фестивали Калининградской области</h1>" in html
+    assert "<h3>Все фестивали Калининградской области</h3>" in html
     assert "<h2>Ближайшие фестивали</h2>" in html
     assert html.count(FEST_INDEX_INTRO_START) == 1
     assert html.count(FEST_INDEX_INTRO_END) == 1
@@ -98,7 +98,7 @@ async def test_sync_festivals_index_page_updated(tmp_path: Path, monkeypatch, ca
     assert rec.target == "tg"
     assert rec.path == "fests"
     html = stored["edited"]
-    assert "<h1>Все фестивали Калининградской области</h1>" in html
+    assert "<h3>Все фестивали Калининградской области</h3>" in html
     assert html.count(FEST_INDEX_INTRO_START) == 1
     assert html.count(FEST_INDEX_INTRO_END) == 1
 

--- a/tests/test_source_keyboard.py
+++ b/tests/test_source_keyboard.py
@@ -1,5 +1,6 @@
 import pytest
 from aiogram import Bot
+from aiogram.exceptions import TelegramBadRequest
 from datetime import datetime
 
 import main
@@ -10,11 +11,17 @@ class DummyBot(Bot):
     def __init__(self, token: str):
         super().__init__(token)
         self.edits = []
+        self.sent = []
 
     async def edit_message_reply_markup(self, chat_id, message_id, reply_markup=None, **kwargs):
         self.edits.append((chat_id, message_id, reply_markup))
         from types import SimpleNamespace
         return SimpleNamespace()
+
+    async def send_message(self, chat_id, text, reply_markup=None, **kwargs):
+        from types import SimpleNamespace
+        self.sent.append((chat_id, text, reply_markup))
+        return SimpleNamespace(message_id=99, chat=SimpleNamespace(id=chat_id))
 
 
 @pytest.mark.asyncio
@@ -135,3 +142,54 @@ async def test_update_keyboard_future_event_uses_current_month(tmp_path, monkeyp
     assert len(markup.inline_keyboard[0]) == 2
     assert markup.inline_keyboard[0][0].url == "https://t.me/c/m1"
     assert markup.inline_keyboard[0][1].url == "https://t.me/c/m2"
+
+
+@pytest.mark.asyncio
+async def test_update_keyboard_fallback_service_message(tmp_path, monkeypatch):
+    db = Database(str(tmp_path / "db.sqlite"))
+    await db.init()
+    bot = DummyBot("123:abc")
+
+    class FakeDatetime(datetime):
+        @classmethod
+        def now(cls, tz=None):
+            return datetime(2025, 7, 2, tzinfo=tz)
+
+    monkeypatch.setattr(main, "datetime", FakeDatetime)
+
+    async def failing_edit(*a, **k):
+        raise TelegramBadRequest(
+            method="editMessageReplyMarkup", message="message can't be edited"
+        )
+
+    bot.edit_message_reply_markup = failing_edit  # type: ignore
+
+    async with db.get_session() as session:
+        session.add_all([
+            MonthPage(month="2025-07", url="https://t.me/c/m1", path="p1"),
+            Event(
+                id=1,
+                title="A",
+                description="d",
+                source_text="s",
+                date="2025-07-18",
+                time="19:00",
+                location_name="Hall",
+                city="Town",
+                ics_post_url="https://t.me/c/asset/1",
+                source_chat_id=-100,
+                source_message_id=10,
+            ),
+        ])
+        await session.commit()
+
+    await update_source_post_keyboard(1, db, bot)
+
+    assert bot.sent
+    chat_id, text, markup = bot.sent[0]
+    assert chat_id == -100
+    assert text == "Добавить в календарь/Навигация по месяцам"
+    assert markup.inline_keyboard[0][0].url == "https://t.me/c/asset/1"
+    async with db.get_session() as session:
+        ev = await session.get(Event, 1)
+        assert ev.source_message_id == 99


### PR DESCRIPTION
## Summary
- Correctly track forwarded message chat and id for source keyboard updates
- Add fallback service message and detailed logging when source posts can't be edited
- Improve publish progress statuses with captcha prompt, disabled state, and version markers
- Sanitize festivals index heading to allowed tag

## Testing
- `pytest tests/test_source_keyboard.py -q`
- `pytest tests/test_festivals_index_page.py -q`
- `pytest tests/test_notifications.py -q`
- `pytest tests/test_progress_captcha.py -q`
- `pytest tests/test_progress_ics.py -q`
- `pytest tests/test_bot.py::test_progress_includes_festival_tg -q`


------
https://chatgpt.com/codex/tasks/task_e_68ae16331ed08332b13df16f368b91e4