### PR TITLE
Pause VK jobs on VK captcha and deduplicate progress message

### DIFF
--- a/models.py
+++ b/models.py
@@ -168,6 +168,7 @@ class JobStatus(str, Enum):
     running = "running"
     done = "done"
     error = "error"
+    paused = "paused"
 
 
 class JobOutbox(SQLModel, table=True):

--- a/tests/test_job_captcha_pause.py
+++ b/tests/test_job_captcha_pause.py
@@ -1,0 +1,62 @@
+import pytest
+from sqlmodel import select
+
+import main
+from main import Database, Event, JobOutbox, JobTask, JobStatus
+
+
+@pytest.mark.asyncio
+async def test_vk_jobs_paused_and_resumed(tmp_path, monkeypatch):
+    db = Database(str(tmp_path / "db.sqlite"))
+    await db.init()
+
+    ev = Event(
+        title="t",
+        description="d",
+        date="2025-01-04",
+        time="12:00",
+        location_name="loc",
+        source_text="src",
+    )
+    async with db.get_session() as session:
+        session.add(ev)
+        await session.commit()
+        await session.refresh(ev)
+        session.add(JobOutbox(event_id=ev.id, task=JobTask.vk_sync))
+        session.add(JobOutbox(event_id=ev.id, task=JobTask.week_pages))
+        await session.commit()
+
+    calls: list[str] = []
+
+    async def fake_vk_job(event_id, db, bot):
+        calls.append("call")
+        if len(calls) == 1:
+            raise main.VKAPIError(14, "Captcha needed")
+        return True
+
+    monkeypatch.setitem(main.JOB_HANDLERS, "vk_sync", fake_vk_job)
+    monkeypatch.setitem(main.JOB_HANDLERS, "week_pages", fake_vk_job)
+
+    await main._run_due_jobs_once(db, None)
+
+    async with db.get_session() as session:
+        jobs = (await session.execute(select(JobOutbox))).scalars().all()
+    assert all(j.status == JobStatus.paused for j in jobs)
+    assert all(j.attempts == 0 for j in jobs)
+    assert len(calls) == 1
+
+    resume = main._vk_captcha_resume
+    assert resume is not None
+    await resume()
+    main._vk_captcha_resume = None
+
+    async with db.get_session() as session:
+        jobs = (await session.execute(select(JobOutbox))).scalars().all()
+        assert all(j.status == JobStatus.pending for j in jobs)
+
+    await main._run_due_jobs_once(db, None)
+
+    async with db.get_session() as session:
+        jobs = (await session.execute(select(JobOutbox))).scalars().all()
+    assert all(j.status == JobStatus.done for j in jobs)
+    assert len(calls) == 3

--- a/tests/test_notifications.py
+++ b/tests/test_notifications.py
@@ -459,7 +459,8 @@ async def test_publish_event_progress_captcha_flag(tmp_path, monkeypatch):
 
     assert bot.messages
     text = bot.messages[0]
-    assert "❌ VK (событие) — требуется капча" in text
+    assert "⏸ VK — требуется капча; нажмите «Ввести код»" in text
+    assert text.count("VK") == 1
     markup = bot.markups[0]
     assert markup.inline_keyboard[0][0].callback_data == "captcha_input"
     main._vk_captcha_needed = False


### PR DESCRIPTION
## Summary
- add `paused` job status and track VK tasks globally
- pause all VK jobs on captcha and resume them once solved
- show a single pause line for VK captcha in event progress

## Testing
- `pytest tests/test_job_captcha_pause.py tests/test_notifications.py::test_publish_event_progress_captcha_flag -q`
- `pytest -q` *(fails: many tests including test_create_source_page_photo_catbox, test_exhibition_listing, test_build_weekend_page_content, test_month_nav_and_exhibitions, test_sync_weekend_page_first_creation_includes_nav, test_event_title_link, test_emoji_not_duplicated, test_create_source_page_adds_nav, test_add_event_lines_include_vk_link, test_update_event_description_error_does_not_stop_sync, test_month_links_future, test_daily_posts_festival_link, test_festival_auto_page_creation, test_add_event_with_festival_message, test_festdays_callback_creates_events, test_forward_adds_calendar_button, test_festival_description_dash, test_add_festival_updates_other_pages, test_festival_page_contacts_and_dates, test_festival_vk_message_period_location, test_festival_vk_message_filters_past_events, test_refresh_nav_triggered_on_new_festival, test_edit_vk_post_preserves_photos, test_edit_vk_post_add_photo, test_publication_plan_and_updates, test_enqueue_job_dedup, test_month_render_fest_link_logged, test_month_page_has_markers, test_patch_month_page_inserts_chronologically, test_patch_month_page_handles_content_too_big, test_patch_month_page_handles_escaped_legacy_markers)*

------
https://chatgpt.com/codex/tasks/task_e_68b40cb7b69083329b765607a5b2c0fc