### PR TITLE
feat: rebuild festival index after events

### DIFF
--- a/README_cron.md
+++ b/README_cron.md
@@ -8,6 +8,7 @@ The bot uses APScheduler to run periodic maintenance tasks every 15 minutes. Eac
 - **cleanup old events** – removes past events after 03:00 local time and notifies the superadmin.
 - **VK daily posts and polls** – publishes daily announcements and festival polls when posting times are reached and a VK group is configured.
 - **Telegraph pages sync** – refreshes month and weekend Telegraph pages after 01:00 local time.
+- **festival navigation rebuild** – rebuilds festival navigation and landing page nightly.
 
 ## Environment variables
 

--- a/scheduling.py
+++ b/scheduling.py
@@ -425,6 +425,7 @@ def startup(db, bot) -> AsyncIOScheduler:
         cleanup_scheduler,
         partner_notification_scheduler,
         nightly_page_sync,
+        rebuild_fest_nav_if_changed,
     )
 
     _scheduler.add_job(
@@ -467,6 +468,19 @@ def startup(db, bot) -> AsyncIOScheduler:
         id="partner_notification_scheduler",
         minute="5",
         args=[db, bot],
+        replace_existing=True,
+        max_instances=1,
+        coalesce=True,
+        misfire_grace_time=30,
+    )
+
+    _scheduler.add_job(
+        _job_wrapper("fest_nav_rebuild", rebuild_fest_nav_if_changed),
+        "cron",
+        id="fest_nav_rebuild",
+        hour="3",
+        minute="0",
+        args=[db],
         replace_existing=True,
         max_instances=1,
         coalesce=True,


### PR DESCRIPTION
## Summary
- rebuild festival navigation during event publishing and report in progress
- schedule nightly festival navigation rebuild
- document new cron task and test landing rebuild notification

## Testing
- `pytest` *(fails: VK_USER_TOKEN missing and other failures)*
- `pytest tests/test_notifications.py::test_publish_event_progress_fest_index -vv`


------
https://chatgpt.com/codex/tasks/task_e_68b417bc9b0883329c41fbf1dc996a93