### PR TITLE
Deduplicate festival navigation blocks and add one-off migration

### DIFF
--- a/tests/test_festival_logging.py
+++ b/tests/test_festival_logging.py
@@ -265,7 +265,7 @@ async def test_festivals_fix_nav_force(tmp_path: Path, monkeypatch, caplog):
         if r.message == "fest_nav_force_rebuild" and getattr(r, "action", None) == "finish"
     )
     assert rec_finish.pages == 2
-    assert rec_finish.duplicates_fixed == 1
+    assert rec_finish.duplicates_removed == 1
 
 
 @pytest.mark.asyncio

--- a/tests/test_festival_nav.py
+++ b/tests/test_festival_nav.py
@@ -64,6 +64,27 @@ def test_apply_festival_nav_rewrites_uppercase_markers():
     assert '<!--FEST_NAV_END-->' not in updated
 
 
+def test_apply_festival_nav_deduplicates_multiple_blocks():
+    html = (
+        f"<p>start</p>{FEST_NAV_START}<p>old</p>{FEST_NAV_END}"
+        f"<p>mid</p>{FEST_NAV_START}<p>old2</p>{FEST_NAV_END}"
+    )
+    updated, changed = main.apply_festival_nav(html, NAV_HTML)
+    assert changed is True
+    assert updated.count(FEST_NAV_START) == 1
+    assert '<p>old</p>' not in updated
+    assert '<p>old2</p>' not in updated
+
+
+def test_apply_festival_nav_removes_heading_with_subheading():
+    html = '<p>start</p><h3>Ближайшие фестивали</h3><h4>old</h4><p>end</p>'
+    updated, changed = main.apply_festival_nav(html, NAV_HTML)
+    assert changed is True
+    assert '<h3>Ближайшие фестивали</h3>' not in updated
+    assert '<h4>old</h4>' not in updated
+    assert updated.count(FEST_NAV_START) == 1
+
+
 def test_apply_footer_link_idempotent():
     html = '<p>start</p>'
     first = main.apply_footer_link(html)


### PR DESCRIPTION
## Summary
- ensure festival pages contain only one navigation block by removing legacy markers, headers, and duplicates
- add `/festivals_nav_dedup` admin command and improved `festivals_fix_nav` reporting to track removed duplicates
- test navigation deduplication and updated logging

## Testing
- `pytest tests/test_festival_nav.py tests/test_festival_logging.py::test_festivals_fix_nav_force -q`
- `pytest -q` *(fails: VK_API token missing and other environment-specific tests)*

------
https://chatgpt.com/codex/tasks/task_e_68b41b0424b083329e29c7bc789e0eb0