### PR TITLE
feat: rebuild festivals landing when fixing navigation

### DIFF
--- a/tests/test_festival_logging.py
+++ b/tests/test_festival_logging.py
@@ -20,10 +20,10 @@ async def test_rebuild_fest_nav_if_changed_logs_nav_hash(tmp_path, monkeypatch, 
         session.add(Festival(name="Fest", start_date=today, end_date=today))
         await session.commit()
 
-    async def fake_sync_index(db):
-        return None
+    async def fake_sync_index(db, telegraph=None, force: bool = False):
+        return "built", ""
 
-    monkeypatch.setattr(main, "sync_festivals_index_page", fake_sync_index)
+    monkeypatch.setattr(main, "rebuild_festivals_index_if_needed", fake_sync_index)
 
     with caplog.at_level(logging.INFO):
         changed = await main.rebuild_fest_nav_if_changed(db)

--- a/tests/test_festival_nav_rebuild.py
+++ b/tests/test_festival_nav_rebuild.py
@@ -78,11 +78,12 @@ async def test_rebuild_festival_nav_updates_only_upcoming(tmp_path, monkeypatch)
     monkeypatch.setattr(main, "sync_festival_vk_post", fake_sync_festival_vk_post)
     called_index = False
 
-    async def fake_sync_index(db):
+    async def fake_sync_index(db, telegraph=None, force: bool = False):
         nonlocal called_index
         called_index = True
+        return "built", ""
 
-    monkeypatch.setattr(main, "sync_festivals_index_page", fake_sync_index)
+    monkeypatch.setattr(main, "rebuild_festivals_index_if_needed", fake_sync_index)
 
     changed = await main.rebuild_fest_nav_if_changed(db)
     assert changed
@@ -185,10 +186,10 @@ async def test_vk_failure_does_not_block_tg(tmp_path, monkeypatch):
     monkeypatch.setattr(main, "get_vk_group_id", lambda db: 1)
     monkeypatch.setattr(main, "sync_festival_vk_post", fake_sync_festival_vk_post)
 
-    async def fake_sync_index2(db):
-        return None
+    async def fake_sync_index2(db, telegraph=None, force: bool = False):
+        return "built", ""
 
-    monkeypatch.setattr(main, "sync_festivals_index_page", fake_sync_index2)
+    monkeypatch.setattr(main, "rebuild_festivals_index_if_needed", fake_sync_index2)
 
     await main.rebuild_fest_nav_if_changed(db)
     for _ in range(3):


### PR DESCRIPTION
## Summary
- add page lock and new helper to rebuild festivals landing page only when its content hash changes
- rebuild index and individual festival navigation from `/festivals_fix_nav` in a single locked operation

## Testing
- `pytest tests/test_festival_logging.py tests/test_festival_nav_rebuild.py tests/test_festivals_index_page.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b595e586388332b30bb47d7ef06768