### PR TITLE
Fix telegraph festival index small tag error

### DIFF
--- a/main.py
+++ b/main.py
@@ -2260,8 +2260,8 @@ async def sync_festivals_index_page(db: Database) -> None:
     from telegraph.utils import nodes_to_html
 
     intro_html = (
-        f"{FEST_INDEX_INTRO_START}<p><small><i>Вот какие фестивали нашёл для вас канал "
-        f'<a href="https://t.me/kenigevents">Полюбить Калининград Анонсы</a>.</i></small></p>'
+        f"{FEST_INDEX_INTRO_START}<p><i>Вот какие фестивали нашёл для вас канал "
+        f'<a href="https://t.me/kenigevents">Полюбить Калининград Анонсы</a>.</i></p>'
         f"{FEST_INDEX_INTRO_END}"
     )
     html = (
@@ -2330,9 +2330,9 @@ async def rebuild_festivals_index_if_needed(
     from telegraph.utils import nodes_to_html
 
     intro_html = (
-        f"{FEST_INDEX_INTRO_START}<p><small><i>Вот какие фестивали нашёл для вас канал "
+        f"{FEST_INDEX_INTRO_START}<p><i>Вот какие фестивали нашёл для вас канал "
         f'<a href="https://t.me/kenigevents">Полюбить Калининград Анонсы</a>.'
-        f"</i></small></p>{FEST_INDEX_INTRO_END}"
+        f"</i></p>{FEST_INDEX_INTRO_END}"
     )
     nav_html = nodes_to_html(nodes) if nodes else "<p>Пока нет ближайших фестивалей</p>"
     html = "<h3>Все фестивали региона</h3>" + intro_html + nav_html + FOOTER_LINK_HTML


### PR DESCRIPTION
## Summary
- avoid use of unsupported `<small>` tag when building festivals index pages

## Testing
- `pytest tests/test_festivals_index_page.py::test_sync_festivals_index_page_created -q`
- `pytest tests/test_festivals_index_page.py::test_sync_festivals_index_page_updated -q`
- `pytest -q` *(fails: test_create_source_page_photo_catbox, test_forward_add_festival, test_exhibition_listing, test_build_weekend_page_content, test_month_nav_and_exhibitions, test_sync_weekend_page_first_creation_includes_nav, test_event_title_link, test_emoji_not_duplicated)*

------
https://chatgpt.com/codex/tasks/task_e_68b5a9ea6784833285bf29ae9e7c1bef