### PR TITLE
feat: parse h3-based month sections

### DIFF
--- a/tests/test_parse_month_sections.py
+++ b/tests/test_parse_month_sections.py
@@ -1,0 +1,17 @@
+from datetime import date
+
+from sections import parse_month_sections
+
+
+def test_parse_month_sections_basic():
+    html = (
+        '<h3>🟥🟥🟥 9 сентября 🟥🟥🟥</h3>'
+        '<p>\u200b</p><h4>A</h4><p>\u200b</p>'
+        '<h3>🟥🟥🟥 10 сентября 🟥🟥🟥</h3><p>\u200b</p>'
+    )
+    sections = parse_month_sections(html)
+    assert [s.date for s in sections] == [date(2000, 9, 9), date(2000, 9, 10)]
+    assert sections[0].h3_idx == 0
+    assert sections[0].start_idx == 1
+    assert sections[0].end_idx == 4
+    assert sections[1].start_idx == 5


### PR DESCRIPTION
## Summary
- add DaySection dataclass and parse_month_sections utility
- test parsing of h3 month sections and index mapping

## Testing
- `pytest tests/test_parse_month_sections.py`

------
https://chatgpt.com/codex/tasks/task_e_68b6af7bd6cc8332abc42abe9c0e837b