### PR TITLE
Enable nightly Telegraph page resync

### DIFF
--- a/README_cron.md
+++ b/README_cron.md
@@ -7,7 +7,7 @@ The bot uses APScheduler to run periodic maintenance tasks every 15 minutes. Eac
 - **partner reminders** – reminds inactive partners after 09:00 local time.
 - **cleanup old events** – removes past events after 03:00 local time and notifies the superadmin.
 - **VK daily posts and polls** – publishes daily announcements and festival polls when posting times are reached and a VK group is configured.
-- **Telegraph pages sync** – refreshes month and weekend Telegraph pages after 01:00 local time.
+- **Telegraph pages sync** – refreshes month and weekend Telegraph pages after 01:00 local time. Disabled by default; enable with `ENABLE_NIGHTLY_PAGE_SYNC=1`. Nightly runs update both page content and the month navigation block.
 - **festival navigation rebuild** – rebuilds festival navigation and landing page nightly.
 
 ## Environment variables

--- a/fly.toml
+++ b/fly.toml
@@ -8,6 +8,7 @@ app = "events-bot-new"
 [env]
   PORT = "8080"
   PYTHONOPTIMIZE = "2"
+  ENABLE_NIGHTLY_PAGE_SYNC = "1"
 
 
 [[mounts]]

--- a/main.py
+++ b/main.py
@@ -10497,12 +10497,12 @@ async def nightly_page_sync(db: Database, run_id: str | None = None) -> None:
             weekends.add(w.isoformat())
     for month in months:
         try:
-            await sync_month_page(db, month, update_links=False)
+            await sync_month_page(db, month, update_links=True)
         except Exception as e:  # pragma: no cover - log and continue
             logging.error("nightly_page_sync month %s failed: %s", month, e)
     for start in weekends:
         try:
-            await sync_weekend_page(db, start, update_links=False, post_vk=False)
+            await sync_weekend_page(db, start, update_links=True, post_vk=False)
         except Exception as e:  # pragma: no cover - log and continue
             logging.error("nightly_page_sync weekend %s failed: %s", start, e)
 

--- a/tests/test_nightly_page_sync.py
+++ b/tests/test_nightly_page_sync.py
@@ -1,0 +1,39 @@
+import pytest
+from unittest.mock import AsyncMock
+
+import main
+
+
+class DummyResult:
+    def all(self):
+        return [("2024-05-11",)]
+
+
+class DummySession:
+    async def execute(self, stmt):
+        return DummyResult()
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        pass
+
+
+class DummyDB:
+    def get_session(self):
+        return DummySession()
+
+
+@pytest.mark.asyncio
+async def test_nightly_page_sync_updates_links(monkeypatch):
+    db = DummyDB()
+    month_mock = AsyncMock()
+    weekend_mock = AsyncMock()
+    monkeypatch.setattr(main, "sync_month_page", month_mock)
+    monkeypatch.setattr(main, "sync_weekend_page", weekend_mock)
+
+    await main.nightly_page_sync(db)
+
+    month_mock.assert_awaited_once_with(db, "2024-05", update_links=True)
+    weekend_mock.assert_awaited_once_with(db, "2024-05-11", update_links=True, post_vk=False)


### PR DESCRIPTION
## Summary
- always update navigation when nightly Telegraph pages are rebuilt
- enable nightly page sync job via ENV and document the flag
- test nightly sync respects update_links and disables VK posts

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b757b540588332a736f6c1867304da