### PR TITLE
Add manual page rebuild command and improve logging

### DIFF
--- a/scheduling.py
+++ b/scheduling.py
@@ -433,7 +433,7 @@ def startup(db, bot) -> AsyncIOScheduler:
         rebuild_fest_nav_if_changed,
     )
 
-    _scheduler.add_job(
+    job = _scheduler.add_job(
         _job_wrapper("vk_scheduler", vk_scheduler),
         "cron",
         id="vk_scheduler",
@@ -444,7 +444,8 @@ def startup(db, bot) -> AsyncIOScheduler:
         coalesce=True,
         misfire_grace_time=30,
     )
-    _scheduler.add_job(
+    logging.info("SCHED registered job id=%s next_run=%s", job.id, job.next_run_time)
+    job = _scheduler.add_job(
         _job_wrapper("vk_poll_scheduler", vk_poll_scheduler),
         "cron",
         id="vk_poll_scheduler",
@@ -455,7 +456,8 @@ def startup(db, bot) -> AsyncIOScheduler:
         coalesce=True,
         misfire_grace_time=30,
     )
-    _scheduler.add_job(
+    logging.info("SCHED registered job id=%s next_run=%s", job.id, job.next_run_time)
+    job = _scheduler.add_job(
         _job_wrapper("cleanup_scheduler", cleanup_scheduler),
         "cron",
         id="cleanup_scheduler",
@@ -467,7 +469,8 @@ def startup(db, bot) -> AsyncIOScheduler:
         coalesce=True,
         misfire_grace_time=30,
     )
-    _scheduler.add_job(
+    logging.info("SCHED registered job id=%s next_run=%s", job.id, job.next_run_time)
+    job = _scheduler.add_job(
         _job_wrapper("partner_notification_scheduler", partner_notification_scheduler),
         "cron",
         id="partner_notification_scheduler",
@@ -478,8 +481,9 @@ def startup(db, bot) -> AsyncIOScheduler:
         coalesce=True,
         misfire_grace_time=30,
     )
+    logging.info("SCHED registered job id=%s next_run=%s", job.id, job.next_run_time)
 
-    _scheduler.add_job(
+    job = _scheduler.add_job(
         _job_wrapper("fest_nav_rebuild", rebuild_fest_nav_if_changed),
         "cron",
         id="fest_nav_rebuild",
@@ -491,9 +495,10 @@ def startup(db, bot) -> AsyncIOScheduler:
         coalesce=True,
         misfire_grace_time=30,
     )
+    logging.info("SCHED registered job id=%s next_run=%s", job.id, job.next_run_time)
 
     if os.getenv("ENABLE_NIGHTLY_PAGE_SYNC") == "1":
-        _scheduler.add_job(
+        job = _scheduler.add_job(
             _job_wrapper("nightly_page_sync", nightly_page_sync),
             "cron",
             id="nightly_page_sync",
@@ -504,6 +509,9 @@ def startup(db, bot) -> AsyncIOScheduler:
             max_instances=1,
             coalesce=True,
             misfire_grace_time=30,
+        )
+        logging.info(
+            "SCHED registered job id=%s next_run=%s", job.id, job.next_run_time
         )
 
     async def _run_maintenance(job, name: str, timeout: float, run_id: str | None = None) -> None:

--- a/tests/test_bot.py
+++ b/tests/test_bot.py
@@ -1617,7 +1617,7 @@ async def test_forward_missing_fields(tmp_path: Path, monkeypatch):
     markup = msg[2]["reply_markup"]
     texts = [b.text for row in markup.inline_keyboard for b in row]
     assert "Добавить локацию" in texts
-    assert "Добавить город" in texts
+    assert "Добавить город" not in texts
     assert "Добавить время" not in texts
     async with db.get_session() as session:
         ev = (await session.execute(select(Event))).scalars().first()

--- a/tests/test_nightly_page_sync.py
+++ b/tests/test_nightly_page_sync.py
@@ -1,6 +1,7 @@
 import pytest
 from unittest.mock import AsyncMock
 
+import pytest
 import main
 
 
@@ -13,11 +14,27 @@ class DummySession:
     async def execute(self, stmt):
         return DummyResult()
 
+    async def get(self, model, key):
+        return DummyPage()
+
+    async def commit(self):
+        pass
+
     async def __aenter__(self):
         return self
 
     async def __aexit__(self, exc_type, exc, tb):
         pass
+
+
+class DummyPage:
+    def __init__(self):
+        self.content_hash = ""
+        self.content_hash2 = None
+        self.url = ""
+        self.path = ""
+        self.url2 = None
+        self.path2 = None
 
 
 class DummyDB:


### PR DESCRIPTION
## Summary
- log scheduler job registrations and job coalescing
- refactor page rebuild into reusable function and add /pages_rebuild command
- default city fallback and better progress tracking

## Testing
- `pytest tests/test_bot.py::test_forward_missing_fields tests/test_nightly_page_sync.py`


------
https://chatgpt.com/codex/tasks/task_e_68b82e172cf88332afc8dcbc9e71c6f6