### PR TITLE
Force Telegraph pages rebuild and fix weekend slugs

### DIFF
--- a/main.py
+++ b/main.py
@@ -8572,9 +8572,12 @@ async def build_weekend_page_content(
         add_many(month_nav)
         add_many(telegraph_br())
 
+    label = format_weekend_range(saturday)
+    if saturday.month == sunday.month:
+        label = f"{saturday.day}-{sunday.day} {MONTHS[saturday.month - 1]}"
     title = (
         "Чем заняться на выходных в Калининградской области "
-        f"{format_weekend_range(saturday)}"
+        f"{label}"
     )
     if DEBUG:
         from telegraph.utils import nodes_to_html
@@ -10609,7 +10612,8 @@ async def rebuild_pages(
         async with db.get_session() as session:
             page = await session.get(MonthPage, month)
         if page and (
-            prev is None
+            force
+            or prev is None
             or page.content_hash != prev_hash
             or page.content_hash2 != prev_hash2
         ):
@@ -10636,7 +10640,7 @@ async def rebuild_pages(
             continue
         async with db.get_session() as session:
             page = await session.get(WeekendPage, start)
-        if page and (prev is None or page.content_hash != prev_hash):
+        if page and (force or prev is None or page.content_hash != prev_hash):
             urls = [page.url] if page.url else []
             weekends_updated[start] = urls
             logging.info(
@@ -11311,7 +11315,7 @@ def _parse_pages_rebuild_args(text: str) -> tuple[list[str], int, int, bool]:
 
 
 async def handle_pages_rebuild(message: types.Message, db: Database, bot: Bot):
-    months, past, future, force = _parse_pages_rebuild_args(message.text or "")
+    months, past, future, _ = _parse_pages_rebuild_args(message.text or "")
     if not months and (message.text or "").strip() == "/pages_rebuild":
         options = _expand_months([], past, future)
         buttons = [
@@ -11329,7 +11333,7 @@ async def handle_pages_rebuild(message: types.Message, db: Database, bot: Bot):
         )
         return
     months_list = _expand_months(months, past, future)
-    report = await _perform_pages_rebuild(db, months_list, force)
+    report = await _perform_pages_rebuild(db, months_list, force=True)
     await bot.send_message(message.chat.id, report)
 
 
@@ -11342,7 +11346,7 @@ async def handle_pages_rebuild_cb(
         months = _expand_months([], 0, 2)
     else:
         months = [val]
-    report = await _perform_pages_rebuild(db, months)
+    report = await _perform_pages_rebuild(db, months, force=True)
     await bot.send_message(callback.message.chat.id, report)
 
 

--- a/tests/test_bot.py
+++ b/tests/test_bot.py
@@ -2784,7 +2784,7 @@ async def test_build_weekend_page_content(tmp_path: Path):
     db = Database(str(tmp_path / "db.sqlite"))
     await db.init()
 
-    saturday = main.next_weekend_start(date.today())
+    saturday = date(2025, 9, 6)
     async with db.get_session() as session:
         session.add(
             Event(
@@ -2798,6 +2798,7 @@ async def test_build_weekend_page_content(tmp_path: Path):
         )
         await session.commit()
 
+    sunday = saturday + timedelta(days=1)
     title, content, _ = await main.build_weekend_page_content(db, saturday.isoformat())
     assert "выходных" in title
     assert any(n.get("tag") == "h4" for n in content)
@@ -2809,7 +2810,9 @@ async def test_build_weekend_page_content(tmp_path: Path):
         if isinstance(c, dict) and c.get("tag") == "a"
     )
     assert link.get("attrs", {}).get("href") == "https://t.me/kenigevents"
-    assert str(saturday.day) in title
+    assert (
+        f"{saturday.day}-{sunday.day} {main.MONTHS[saturday.month - 1]}" in title
+    )
 
     cross = date(2025, 1, 31)
     async with db.get_session() as session:


### PR DESCRIPTION
## Summary
- Always force month page rebuild when triggered via command or callback
- Treat forced rebuilds as updates and adjust weekend page titles to use hyphenated date ranges
- Test weekend page title formatting with hyphenated ranges

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b848c10b7c83329cbbb98a0afe8ffb