### PR TITLE
feat: show festival ids on /fest buttons

### DIFF
--- a/main.py
+++ b/main.py
@@ -4721,8 +4721,12 @@ async def send_festivals_list(message: types.Message, db: Database, bot: Bot, ed
         lines.append(" ".join(parts))
     keyboard = [
         [
-            types.InlineKeyboardButton(text="Edit", callback_data=f"festedit:{f.id}"),
-            types.InlineKeyboardButton(text="Delete", callback_data=f"festdel:{f.id}"),
+            types.InlineKeyboardButton(
+                text=f"Edit {f.id}", callback_data=f"festedit:{f.id}"
+            ),
+            types.InlineKeyboardButton(
+                text=f"Delete {f.id}", callback_data=f"festdel:{f.id}"
+            ),
         ]
         for f in fests
     ]


### PR DESCRIPTION
## Summary
- display festival IDs on Edit/Delete buttons in `/fest`
- test that `/fest` shows ID-labeled buttons

## Testing
- `pytest tests/test_bot.py::test_handle_fest_list -q`


------
https://chatgpt.com/codex/tasks/task_e_68b84b4f1ae48332b512eddddda5510a