### PR TITLE
Fix festival day telegraph slug collisions

### DIFF
--- a/main.py
+++ b/main.py
@@ -6275,6 +6275,41 @@ async def run_event_update_jobs(
         await asyncio.sleep(0)
 
 
+def festival_event_slug(ev: Event, fest: Festival | None) -> str | None:
+    """Return deterministic slug for festival day events."""
+    if not fest or not fest.id:
+        return None
+    d = parse_iso_date(ev.date)
+    start = parse_iso_date(fest.start_date) if fest.start_date else None
+    if d and start:
+        day_num = (d - start).days + 1
+    else:
+        day_num = 1
+    base = f"fest-{fest.id}-day-{day_num}-{ev.date}-{ev.city or ''}"
+    return slugify(base)
+
+
+async def ensure_event_telegraph_link(e: Event, fest: Festival | None, db: Database) -> None:
+    """Ensure ``e.telegraph_url`` matches its festival slug.
+
+    If mismatch is detected, rebuild the Telegraph page and fall back to the
+    source URL for the current rendering pass.
+    """
+    slug = festival_event_slug(e, fest)
+    if not slug:
+        return
+    if e.telegraph_path == slug:
+        return
+    await update_telegraph_event_page(e.id, db, None)
+    async with db.get_session() as session:
+        refreshed = await session.get(Event, e.id)
+        if refreshed:
+            e.telegraph_url = refreshed.telegraph_url or e.source_post_url
+            e.telegraph_path = refreshed.telegraph_path
+    if e.telegraph_path != slug:
+        e.telegraph_url = e.source_post_url or e.telegraph_url
+
+
 async def update_telegraph_event_page(
     event_id: int, db: Database, bot: Bot | None
 ) -> str | None:
@@ -6282,6 +6317,13 @@ async def update_telegraph_event_page(
         ev = await session.get(Event, event_id)
         if not ev:
             return None
+        fest = None
+        if ev.festival:
+            res_f = await session.execute(
+                select(Festival).where(Festival.name == ev.festival)
+            )
+            fest = res_f.scalar_one_or_none()
+        slug = festival_event_slug(ev, fest)
         display_link = False if ev.source_post_url else True
         html_content, _, _ = await build_source_page_content(
             ev.title or "Event",
@@ -6298,7 +6340,9 @@ async def update_telegraph_event_page(
 
         nodes = html_to_nodes(html_content)
         new_hash = content_hash(html_content)
-        if ev.content_hash == new_hash and ev.telegraph_url:
+        if ev.content_hash == new_hash and ev.telegraph_url and (
+            not slug or ev.telegraph_path == slug
+        ):
             await session.commit()
             return ev.telegraph_url
         token = get_telegraph_token()
@@ -6308,12 +6352,13 @@ async def update_telegraph_event_page(
             return ev.telegraph_url
         tg = Telegraph(access_token=token)
         title = ev.title or "Event"
-        if not ev.telegraph_path:
+        if not ev.telegraph_path or (slug and ev.telegraph_path != slug):
             data = await telegraph_create_page(
                 tg,
                 title=title,
                 content=nodes,
                 return_content=False,
+                slug=slug,
             )
             ev.telegraph_url = normalize_telegraph_url(data.get("url"))
             ev.telegraph_path = data.get("path")
@@ -7995,6 +8040,9 @@ async def build_month_page_content(
         async with db.get_session() as session:
             res_f = await session.execute(select(Festival))
             fest_map = {f.name.casefold(): f for f in res_f.scalars().all()}
+    for e in events:
+        fest = fest_map.get((e.festival or "").casefold())
+        await ensure_event_telegraph_link(e, fest, db)
     fest_index_url = await get_setting_value(db, "fest_index_url")
 
     async with span("render"):
@@ -8500,6 +8548,10 @@ async def build_weekend_page_content(
     async with db.get_session() as session:
         res_f = await session.execute(select(Festival))
         fest_map = {f.name.casefold(): f for f in res_f.scalars().all()}
+
+    for e in events:
+        fest = fest_map.get((e.festival or "").casefold())
+        await ensure_event_telegraph_link(e, fest, db)
 
     by_day: dict[date, list[Event]] = {}
     for e in events:

--- a/tests/test_festdays_weekend_links.py
+++ b/tests/test_festdays_weekend_links.py
@@ -1,0 +1,110 @@
+import asyncio
+from datetime import date, timedelta, datetime
+from pathlib import Path
+
+import pytest
+from aiogram import Bot
+from sqlmodel import select
+
+import main
+from main import Database, Event, Festival, upsert_event, schedule_event_update_tasks, parse_iso_date
+from telegraph.utils import nodes_to_html
+
+
+class DummyBot(Bot):
+    async def request(self, method, data=None, files=None):  # pragma: no cover - network stub
+        return None
+
+
+@pytest.mark.asyncio
+async def test_weekend_page_two_festdays(tmp_path: Path, monkeypatch):
+    db = Database(str(tmp_path / "db.sqlite"))
+    await db.init()
+
+    async with db.get_session() as session:
+        fest1 = Festival(
+            name="День города Зеленоградск",
+            start_date="2025-09-06",
+            end_date="2025-09-07",
+            city="Зеленоградск",
+            location_name="Зеленоградск",
+        )
+        fest2 = Festival(
+            name="День города Черняховск",
+            start_date="2025-09-05",
+            end_date="2025-09-07",
+            city="Черняховск",
+            location_name="Черняховск",
+        )
+        session.add_all([fest1, fest2])
+        await session.commit()
+
+    async def fake_create_page(tg, *args, **kwargs):
+        slug = kwargs.get("slug", "p")
+        return {"path": slug, "url": f"http://t.me/{slug}"}
+
+    async def fake_edit_page(tg, path, **kwargs):
+        return None
+
+    async def fake_build(*a, **k):
+        return "<p>src</p>", [], 0
+
+    monkeypatch.setattr(main, "telegraph_create_page", fake_create_page)
+    monkeypatch.setattr(main, "telegraph_edit_page", fake_edit_page)
+    monkeypatch.setattr(main, "build_source_page_content", fake_build)
+    monkeypatch.setattr(main, "Telegraph", lambda access_token=None, domain=None: object())
+    monkeypatch.setattr(main, "get_telegraph_token", lambda: "t")
+
+    async with db.get_session() as session:
+        f1 = await session.get(Festival, fest1.id)
+        f2 = await session.get(Festival, fest2.id)
+        for fest in (f1, f2):
+            start = parse_iso_date(fest.start_date)
+            end = parse_iso_date(fest.end_date)
+            for i in range((end - start).days + 1):
+                day = start + timedelta(days=i)
+                ev = Event(
+                    title=f"{fest.name} - день {i+1}",
+                    description="d",
+                    festival=fest.name,
+                    date=day.isoformat(),
+                    time="12:00",
+                    location_name=fest.location_name or "",
+                    city=fest.city,
+                    source_text=f"{fest.name} — {day.isoformat()}",
+                )
+                saved, _ = await upsert_event(session, ev)
+                await schedule_event_update_tasks(db, saved)
+        await session.commit()
+
+    bot = DummyBot("1:1")
+    async with db.get_session() as session:
+        events = (await session.execute(select(Event))).scalars().all()
+    for e in events:
+        await main.update_telegraph_event_page(e.id, db, bot)
+
+    class FakeDate(date):
+        @classmethod
+        def today(cls):
+            return date(2025, 9, 1)
+
+    class FakeDatetime(datetime):
+        @classmethod
+        def now(cls, tz=None):
+            return datetime(2025, 9, 1, tzinfo=tz)
+
+    monkeypatch.setattr(main, "date", FakeDate)
+    monkeypatch.setattr(main, "datetime", FakeDatetime)
+
+    _, content, _ = await main.build_weekend_page_content(db, "2025-09-06")
+    html = nodes_to_html(content)
+
+    async with db.get_session() as session:
+        evs = (await session.execute(select(Event))).scalars().all()
+    zel_url = next(e.telegraph_url for e in evs if e.festival == "День города Зеленоградск" and e.date == "2025-09-06")
+    chr_url = next(e.telegraph_url for e in evs if e.festival == "День города Черняховск" and e.date == "2025-09-06")
+
+    assert "#Зеленоградск" in html
+    assert "#Черняховск" in html
+    assert zel_url in html
+    assert chr_url in html

--- a/tests/test_month_festival_link.py
+++ b/tests/test_month_festival_link.py
@@ -30,6 +30,22 @@ async def test_month_page_links_festival(tmp_path: Path, monkeypatch):
         )
         await session.commit()
 
+    async def fake_create_page(tg, *args, **kwargs):
+        slug = kwargs.get("slug", "p")
+        return {"path": slug, "url": f"http://t.me/{slug}"}
+
+    async def fake_edit_page(tg, path, **kwargs):
+        return None
+
+    async def fake_build(*a, **k):
+        return "<p>src</p>", [], 0
+
+    monkeypatch.setattr(main, "telegraph_create_page", fake_create_page)
+    monkeypatch.setattr(main, "telegraph_edit_page", fake_edit_page)
+    monkeypatch.setattr(main, "build_source_page_content", fake_build)
+    monkeypatch.setattr(main, "Telegraph", lambda access_token=None, domain=None: object())
+    monkeypatch.setattr(main, "get_telegraph_token", lambda: "t")
+
     class FakeDate(date):
         @classmethod
         def today(cls):
@@ -68,6 +84,22 @@ async def test_month_render_fest_link_logged(tmp_path: Path, monkeypatch, caplog
         await session.commit()
         eid = ev.id
 
+    async def fake_create_page(tg, *args, **kwargs):
+        slug = kwargs.get("slug", "p")
+        return {"path": slug, "url": f"http://t.me/{slug}"}
+
+    async def fake_edit_page(tg, path, **kwargs):
+        return None
+
+    async def fake_build(*a, **k):
+        return "<p>src</p>", [], 0
+
+    monkeypatch.setattr(main, "telegraph_create_page", fake_create_page)
+    monkeypatch.setattr(main, "telegraph_edit_page", fake_edit_page)
+    monkeypatch.setattr(main, "build_source_page_content", fake_build)
+    monkeypatch.setattr(main, "Telegraph", lambda access_token=None, domain=None: object())
+    monkeypatch.setattr(main, "get_telegraph_token", lambda: "t")
+
     class FakeDate(date):
         @classmethod
         def today(cls):
@@ -87,6 +119,6 @@ async def test_month_render_fest_link_logged(tmp_path: Path, monkeypatch, caplog
     rec = next(r for r in caplog.records if r.message == "month_render_fest_link")
     assert rec.event_id == eid
     assert rec.festival == "Fest"
-    assert rec.has_url is False
+    assert rec.has_url is True
     assert rec.has_path is True
     assert rec.href_used == "https://telegra.ph/fest"

--- a/tests/test_weekend_festival_link.py
+++ b/tests/test_weekend_festival_link.py
@@ -29,6 +29,22 @@ async def test_weekend_page_links_festival(tmp_path: Path, monkeypatch):
         )
         await session.commit()
 
+    async def fake_create_page(tg, *args, **kwargs):
+        slug = kwargs.get("slug", "p")
+        return {"path": slug, "url": f"http://t.me/{slug}"}
+
+    async def fake_edit_page(tg, path, **kwargs):
+        return None
+
+    async def fake_build(*a, **k):
+        return "<p>src</p>", [], 0
+
+    monkeypatch.setattr(main, "telegraph_create_page", fake_create_page)
+    monkeypatch.setattr(main, "telegraph_edit_page", fake_edit_page)
+    monkeypatch.setattr(main, "build_source_page_content", fake_build)
+    monkeypatch.setattr(main, "Telegraph", lambda access_token=None, domain=None: object())
+    monkeypatch.setattr(main, "get_telegraph_token", lambda: "t")
+
     class FakeDate(date):
         @classmethod
         def today(cls):


### PR DESCRIPTION
## Summary
- ensure festival day telegraph pages use deterministic unique slugs
- rebuild mismatched event pages and verify links before rendering month/weekend pages
- add integration test for overlapping festival days and correct weekend links

## Testing
- `pytest tests/test_festdays_weekend_links.py tests/test_weekend_festival_link.py tests/test_month_festival_link.py tests/test_festdays_city.py::test_festdays_two_cities_no_mixup tests/test_bot.py::test_update_telegraph_event_page_deterministic -q`

------
https://chatgpt.com/codex/tasks/task_e_68b86eb50f6483329067b739f6a58eb2