### PR TITLE
Handle VK sync failures in background

### DIFF
--- a/tests/test_auto_program_url.py
+++ b/tests/test_auto_program_url.py
@@ -22,7 +22,7 @@ async def test_add_events_from_text_autofills_program_url(tmp_path: Path, monkey
     async def fake_sync_page(db, name):
         return None
 
-    async def fake_sync_vk(db, name, bot):
+    async def fake_sync_vk(db, name, bot, strict=False):
         return None
 
     monkeypatch.setattr(main, "parse_event_via_4o", fake_parse)

--- a/tests/test_bot.py
+++ b/tests/test_bot.py
@@ -1947,7 +1947,7 @@ async def test_forward_add_festival(tmp_path: Path, monkeypatch):
             fest.telegraph_url = "https://telegra.ph/test"
             await session.commit()
 
-    async def fake_sync_vk(db_obj, name, bot_obj):
+    async def fake_sync_vk(db_obj, name, bot_obj, strict=False):
         async with db_obj.get_session() as session:
             fest = (await session.execute(select(main.Festival).where(main.Festival.name == name))).scalar_one()
             fest.vk_post_url = "https://vk.com/wall-1_1"
@@ -5659,7 +5659,7 @@ async def test_festdays_callback_creates_events(tmp_path: Path, monkeypatch):
     async def fake_sync_festival_page(db_obj, name, **kwargs):
         pass
 
-    async def fake_sync_vk(db_obj, name, bot_obj):
+    async def fake_sync_vk(db_obj, name, bot_obj, strict=False):
         pass
 
     async def fake_notify(db_obj, bot_obj, user, event, added):
@@ -6663,7 +6663,7 @@ async def test_add_festival_updates_other_pages(tmp_path: Path, monkeypatch):
     async def fake_sync_page(db, name, **kwargs):
         called_pages.append(name)
 
-    async def fake_sync_vk(db, name, bot=None):
+    async def fake_sync_vk(db, name, bot=None, strict=False):
         called_vk.append(name)
 
     monkeypatch.setattr(main, "sync_festival_page", fake_sync_page)
@@ -7067,7 +7067,7 @@ async def test_update_festival_pages_ignores_past_events(tmp_path: Path, monkeyp
     async def fake_page(db_obj, name):
         called.append("page")
 
-    async def fake_vk(db_obj, name, bot=None, nav_only=False, nav_lines=None):
+    async def fake_vk(db_obj, name, bot=None, nav_only=False, nav_lines=None, strict=False):
         called.append("vk")
 
     async def fake_nav(db_obj):
@@ -7246,7 +7246,7 @@ async def test_refresh_nav_triggered_on_new_festival(monkeypatch, tmp_path: Path
     async def fake_sync_page(db_obj, name):
         return None
 
-    async def fake_sync_vk(db_obj, name, bot=None, nav_only=False, nav_lines=None):
+    async def fake_sync_vk(db_obj, name, bot=None, nav_only=False, nav_lines=None, strict=False):
         return None
 
     called: dict[str, list[str]] = {}
@@ -7519,7 +7519,7 @@ async def test_progress_includes_festival_tg(tmp_path: Path, monkeypatch):
     async def fake_sync_fest_page(db_obj, name, refresh_nav_only=False, items=None):
         return "http://fest"
 
-    async def fake_sync_fest_vk(db_obj, name, bot_obj, nav_only=False, nav_lines=None):
+    async def fake_sync_fest_vk(db_obj, name, bot_obj, nav_only=False, nav_lines=None, strict=False):
         return True
 
     monkeypatch.setattr(main, "update_telegraph_event_page", ok_handler)

--- a/tests/test_festdays_city.py
+++ b/tests/test_festdays_city.py
@@ -74,7 +74,7 @@ async def test_festdays_uses_correct_city(tmp_path: Path, monkeypatch):
     async def fake_sync_festival_page(db_obj, name, **kwargs):
         pass
 
-    async def fake_sync_vk(db_obj, name, bot_obj):
+    async def fake_sync_vk(db_obj, name, bot_obj, strict=False):
         pass
 
     async def fake_notify(db_obj, bot_obj, user, event, added):

--- a/tests/test_festival_nav_rebuild.py
+++ b/tests/test_festival_nav_rebuild.py
@@ -47,7 +47,7 @@ async def test_rebuild_festival_nav_updates_only_upcoming(tmp_path, monkeypatch)
         def get_page(self, path, return_html=True):
             return {"content_html": tg_pages[path]["html"], "title": tg_pages[path]["title"]}
 
-        def edit_page(self, path, title, html_content):
+        def edit_page(self, path, title, html_content, **kwargs):
             tg_pages[path] = {"html": html_content, "title": title}
             return {}
 
@@ -62,7 +62,7 @@ async def test_rebuild_festival_nav_updates_only_upcoming(tmp_path, monkeypatch)
     vk_base["Past"] = "base_old\n"
     vk_posts = vk_base.copy()
 
-    async def fake_sync_festival_vk_post(db, name, bot, nav_only=False, nav_lines=None):
+    async def fake_sync_festival_vk_post(db, name, bot, nav_only=False, nav_lines=None, strict=False):
         assert nav_only
         _, lines = await main._build_festival_nav_block(db, exclude=name)
         nav = "\n".join(lines)
@@ -158,7 +158,7 @@ async def test_vk_failure_does_not_block_tg(tmp_path, monkeypatch):
         def get_page(self, path, return_html=True):
             return {"content_html": tg_pages[path]["html"], "title": tg_pages[path]["title"]}
 
-        def edit_page(self, path, title, html_content):
+        def edit_page(self, path, title, html_content, **kwargs):
             tg_pages[path] = {"html": html_content, "title": title}
             return {}
 
@@ -173,7 +173,7 @@ async def test_vk_failure_does_not_block_tg(tmp_path, monkeypatch):
     vk_posts = vk_base.copy()
     fail_name = "Fest1"
 
-    async def fake_sync_festival_vk_post(db, name, bot, nav_only=False, nav_lines=None):
+    async def fake_sync_festival_vk_post(db, name, bot, nav_only=False, nav_lines=None, strict=False):
         assert nav_only
         if name == fail_name:
             raise RuntimeError("vk failure")
@@ -279,7 +279,7 @@ async def test_update_tg_nav_sets_nav_hash(tmp_path, monkeypatch):
                 "title": tg_pages[path]["title"],
             }
 
-        def edit_page(self, path, title, html_content):
+        def edit_page(self, path, title, html_content, **kwargs):
             tg_pages[path] = {"html": html_content, "title": title}
             return {}
 

--- a/tests/test_festival_vk_background.py
+++ b/tests/test_festival_vk_background.py
@@ -1,0 +1,56 @@
+import asyncio
+import logging
+from datetime import date, timedelta
+from pathlib import Path
+
+import pytest
+
+import main
+from db import Database
+
+
+@pytest.mark.asyncio
+async def test_add_events_from_text_vk_failure(tmp_path: Path, monkeypatch, caplog):
+    db = Database(str(tmp_path / "db.sqlite"))
+    await db.init()
+
+    future = (date.today() + timedelta(days=30)).isoformat()
+
+    async def fake_parse(text, *args, **kwargs):
+        main.parse_event_via_4o._festival = {
+            "name": "Fest",
+            "start_date": future,
+            "location_name": "Hall",
+            "city": "Town",
+        }
+        return []
+
+    async def fake_upload(images):
+        return [], ""
+
+    async def fake_sync_page(db_obj, name, **kwargs):
+        pass
+
+    async def fake_sync_vk(db_obj, name, bot_obj, strict=False):
+        raise RuntimeError("vk fail")
+
+    notified: dict[str, str] = {}
+
+    async def fake_notify(db_obj, bot_obj, text):
+        notified["text"] = text
+
+    monkeypatch.setattr(main, "parse_event_via_4o", fake_parse)
+    monkeypatch.setattr(main, "upload_images", fake_upload)
+    monkeypatch.setattr(main, "sync_festival_page", fake_sync_page)
+    monkeypatch.setattr(main, "sync_festival_vk_post", fake_sync_vk)
+    monkeypatch.setattr(main, "notify_superadmin", fake_notify)
+
+    with caplog.at_level(logging.ERROR):
+        res = await main.add_events_from_text(db, "t", None, None, None, bot=object())
+        await asyncio.sleep(0)
+
+    fest = res[0][0]
+    assert isinstance(fest, main.Festival)
+    assert any("festival VK sync failed for Fest" in r.message for r in caplog.records)
+    assert notified["text"].startswith("festival VK sync failed for Fest")
+

--- a/tests/test_notifications.py
+++ b/tests/test_notifications.py
@@ -491,7 +491,7 @@ async def test_publish_event_progress_fest_index(tmp_path, monkeypatch):
     async def fake_sync_festival_page(db_obj, name, **kwargs):
         return "http://fest"
 
-    async def fake_sync_festival_vk_post(db_obj, name, bot_obj, nav_only=False, nav_lines=None):
+    async def fake_sync_festival_vk_post(db_obj, name, bot_obj, nav_only=False, nav_lines=None, strict=False):
         return False
 
     async def fake_rebuild(db_obj):


### PR DESCRIPTION
## Summary
- ensure festival page and VK sync run in background with error handling and admin notification
- make VK post sync tolerant with optional `strict` flag to avoid raising on failure
- cover VK sync failures with dedicated test

## Testing
- `pytest tests/test_auto_program_url.py tests/test_festival_vk_background.py -q`
- `pytest tests/test_festdays_city.py tests/test_festival_nav_rebuild.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68b8946757b08332be3a35879521138c