### PR TITLE
Force nightly page rebuild and improve telegraph handling

### DIFF
--- a/tests/test_festdays_weekend_links.py
+++ b/tests/test_festdays_weekend_links.py
@@ -40,8 +40,7 @@ async def test_weekend_page_two_festdays(tmp_path: Path, monkeypatch):
         await session.commit()
 
     async def fake_create_page(tg, *args, **kwargs):
-        slug = kwargs.get("slug", "p")
-        return {"path": slug, "url": f"http://t.me/{slug}"}
+        return {"path": "p", "url": "http://t.me/p"}
 
     async def fake_edit_page(tg, path, **kwargs):
         return None

--- a/tests/test_month_festival_link.py
+++ b/tests/test_month_festival_link.py
@@ -31,8 +31,7 @@ async def test_month_page_links_festival(tmp_path: Path, monkeypatch):
         await session.commit()
 
     async def fake_create_page(tg, *args, **kwargs):
-        slug = kwargs.get("slug", "p")
-        return {"path": slug, "url": f"http://t.me/{slug}"}
+        return {"path": "p", "url": "http://t.me/p"}
 
     async def fake_edit_page(tg, path, **kwargs):
         return None
@@ -85,8 +84,7 @@ async def test_month_render_fest_link_logged(tmp_path: Path, monkeypatch, caplog
         eid = ev.id
 
     async def fake_create_page(tg, *args, **kwargs):
-        slug = kwargs.get("slug", "p")
-        return {"path": slug, "url": f"http://t.me/{slug}"}
+        return {"path": "p", "url": "http://t.me/p"}
 
     async def fake_edit_page(tg, path, **kwargs):
         return None

--- a/tests/test_nightly_page_sync.py
+++ b/tests/test_nightly_page_sync.py
@@ -52,5 +52,7 @@ async def test_nightly_page_sync_updates_links(monkeypatch):
 
     await main.nightly_page_sync(db)
 
-    month_mock.assert_awaited_once_with(db, "2024-05", update_links=True)
-    weekend_mock.assert_awaited_once_with(db, "2024-05-11", update_links=True, post_vk=False)
+    month_mock.assert_awaited_once_with(db, "2024-05", update_links=True, force=True)
+    weekend_mock.assert_awaited_once_with(
+        db, "2024-05-11", update_links=True, post_vk=False, force=True
+    )

--- a/tests/test_weekend_festival_link.py
+++ b/tests/test_weekend_festival_link.py
@@ -30,8 +30,7 @@ async def test_weekend_page_links_festival(tmp_path: Path, monkeypatch):
         await session.commit()
 
     async def fake_create_page(tg, *args, **kwargs):
-        slug = kwargs.get("slug", "p")
-        return {"path": slug, "url": f"http://t.me/{slug}"}
+        return {"path": "p", "url": "http://t.me/p"}
 
     async def fake_edit_page(tg, path, **kwargs):
         return None


### PR DESCRIPTION
## Summary
- Always force nightly rebuilds so months and weekends are marked updated
- Drop slug arg and keep Telegraph URLs when slugs mismatch
- Correct weekend slugs, split overfull months, and await festival sync

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b8a11d44b08332a2e357128fd3348b