### PR TITLE
Handle telegraph flood and content too big

### DIFF
--- a/scheduling.py
+++ b/scheduling.py
@@ -395,7 +395,7 @@ def _on_event(event):
     next_run = None
     if _scheduler:
         job = _scheduler.get_job(job_id)
-        next_run = job.next_run_time if job else None
+        next_run = getattr(job, "next_run_time", None) if job else None
     tb_excerpt = None
     tb = getattr(event, "traceback", None)
     if tb:
@@ -444,7 +444,9 @@ def startup(db, bot) -> AsyncIOScheduler:
         coalesce=True,
         misfire_grace_time=30,
     )
-    logging.info("SCHED registered job id=%s next_run=%s", job.id, job.next_run_time)
+    logging.info(
+        "SCHED registered job id=%s next_run=%s", job.id, getattr(job, "next_run_time", None)
+    )
     job = _scheduler.add_job(
         _job_wrapper("vk_poll_scheduler", vk_poll_scheduler),
         "cron",
@@ -456,7 +458,9 @@ def startup(db, bot) -> AsyncIOScheduler:
         coalesce=True,
         misfire_grace_time=30,
     )
-    logging.info("SCHED registered job id=%s next_run=%s", job.id, job.next_run_time)
+    logging.info(
+        "SCHED registered job id=%s next_run=%s", job.id, getattr(job, "next_run_time", None)
+    )
     job = _scheduler.add_job(
         _job_wrapper("cleanup_scheduler", cleanup_scheduler),
         "cron",
@@ -469,7 +473,9 @@ def startup(db, bot) -> AsyncIOScheduler:
         coalesce=True,
         misfire_grace_time=30,
     )
-    logging.info("SCHED registered job id=%s next_run=%s", job.id, job.next_run_time)
+    logging.info(
+        "SCHED registered job id=%s next_run=%s", job.id, getattr(job, "next_run_time", None)
+    )
     job = _scheduler.add_job(
         _job_wrapper("partner_notification_scheduler", partner_notification_scheduler),
         "cron",
@@ -481,7 +487,9 @@ def startup(db, bot) -> AsyncIOScheduler:
         coalesce=True,
         misfire_grace_time=30,
     )
-    logging.info("SCHED registered job id=%s next_run=%s", job.id, job.next_run_time)
+    logging.info(
+        "SCHED registered job id=%s next_run=%s", job.id, getattr(job, "next_run_time", None)
+    )
 
     job = _scheduler.add_job(
         _job_wrapper("fest_nav_rebuild", rebuild_fest_nav_if_changed),
@@ -495,7 +503,9 @@ def startup(db, bot) -> AsyncIOScheduler:
         coalesce=True,
         misfire_grace_time=30,
     )
-    logging.info("SCHED registered job id=%s next_run=%s", job.id, job.next_run_time)
+    logging.info(
+        "SCHED registered job id=%s next_run=%s", job.id, getattr(job, "next_run_time", None)
+    )
 
     if os.getenv("ENABLE_NIGHTLY_PAGE_SYNC") == "1":
         job = _scheduler.add_job(
@@ -511,7 +521,9 @@ def startup(db, bot) -> AsyncIOScheduler:
             misfire_grace_time=30,
         )
         logging.info(
-            "SCHED registered job id=%s next_run=%s", job.id, job.next_run_time
+            "SCHED registered job id=%s next_run=%s",
+            job.id,
+            getattr(job, "next_run_time", None),
         )
 
     async def _run_maintenance(job, name: str, timeout: float, run_id: str | None = None) -> None:

--- a/tests/test_pages_rebuild_report.py
+++ b/tests/test_pages_rebuild_report.py
@@ -1,0 +1,21 @@
+import pytest
+import main
+
+
+@pytest.mark.asyncio
+async def test_pages_rebuild_report_errors(monkeypatch):
+    async def fake_rebuild_pages(db, months, weekends, force=False):
+        return {
+            "months": {"updated": {}, "failed": {"2025-09": "boom"}},
+            "weekends": {"updated": {}, "failed": {"2025-09-06": "fail"}},
+        }
+
+    monkeypatch.setattr(main, "rebuild_pages", fake_rebuild_pages)
+    monkeypatch.setattr(
+        main,
+        "_weekends_for_months",
+        lambda months: (['2025-09-06'], {"2025-09": ['2025-09-06']})
+    )
+    report = await main._perform_pages_rebuild(None, ["2025-09"], force=True)
+    assert "❌ 2025-09 — ошибка: boom" in report
+    assert "❌ 2025-09 — ошибка: 2025-09-06: fail" in report


### PR DESCRIPTION
## Summary
- split month pages on generic CONTENT_TOO_BIG errors
- track failed month and weekend rebuilds in reports
- retry Telegraph calls on flood control and log wait times
- avoid AttributeError accessing `job.next_run_time`

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b8a93f114c8332aeb57731a35c00a6