### PR TITLE
Improve navigation task draining and job runner resilience

### DIFF
--- a/tests/test_bot.py
+++ b/tests/test_bot.py
@@ -7579,7 +7579,7 @@ async def test_progress_includes_festival_tg(tmp_path: Path, monkeypatch):
         await session.commit()
         await session.refresh(ev)
 
-    await main.schedule_event_update_tasks(db, ev)
+    await main.schedule_event_update_tasks(db, ev, drain_nav=False)
 
     async def ok_handler(eid, db_obj, bot_obj):
         return True

--- a/tests/test_festdays_city.py
+++ b/tests/test_festdays_city.py
@@ -233,7 +233,7 @@ async def test_festdays_two_cities_no_mixup(tmp_path: Path, monkeypatch):
                     source_text=f"{fest.name} — {day.isoformat()}",
                 )
                 saved, _ = await upsert_event(session, ev)
-                await schedule_event_update_tasks(db, saved)
+                await schedule_event_update_tasks(db, saved, drain_nav=False)
         await session.commit()
 
     async with db.get_session() as session:

--- a/tests/test_festdays_weekend_links.py
+++ b/tests/test_festdays_weekend_links.py
@@ -73,7 +73,7 @@ async def test_weekend_page_two_festdays(tmp_path: Path, monkeypatch):
                     source_text=f"{fest.name} — {day.isoformat()}",
                 )
                 saved, _ = await upsert_event(session, ev)
-                await schedule_event_update_tasks(db, saved)
+                await schedule_event_update_tasks(db, saved, drain_nav=False)
         await session.commit()
 
     bot = DummyBot("1:1")

--- a/tests/test_notifications.py
+++ b/tests/test_notifications.py
@@ -46,7 +46,7 @@ async def test_progress_notifications(tmp_path, monkeypatch):
         await session.commit()
         await session.refresh(ev)
 
-    await schedule_event_update_tasks(db, ev)
+    await schedule_event_update_tasks(db, ev, drain_nav=False)
 
     async def ok_handler(eid, db_obj, bot_obj):
         return True
@@ -125,7 +125,7 @@ async def test_progress_notifications_forced_rebuild(tmp_path, monkeypatch):
         await session.commit()
         await session.refresh(ev)
 
-    await schedule_event_update_tasks(db, ev)
+    await schedule_event_update_tasks(db, ev, drain_nav=False)
 
     async def month_handler(eid, db_obj, bot_obj):
         return "rebuild"
@@ -184,7 +184,7 @@ async def test_progress_notifications_error(tmp_path, monkeypatch):
         await session.commit()
         await session.refresh(ev)
 
-    await schedule_event_update_tasks(db, ev)
+    await schedule_event_update_tasks(db, ev, drain_nav=False)
 
     async def ok_handler(eid, db_obj, bot_obj):
         return True


### PR DESCRIPTION
## Summary
- run navigation page jobs immediately after scheduling events
- prioritize navigation tasks over VK and continue pipeline after captcha
- add watchdog for stalled aggregated jobs and always notify on navigation progress

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b8bab8bcec8332afa201d6231a3b0a