### PR TITLE
Handle coalesced navigation jobs

### DIFF
--- a/tests/test_nav_drain.py
+++ b/tests/test_nav_drain.py
@@ -1,0 +1,88 @@
+import pytest
+from datetime import datetime
+from sqlalchemy import select
+
+import main
+from main import Database, Event, JobOutbox, JobTask, JobStatus
+
+
+@pytest.mark.asyncio
+async def test_drain_coalesced_month_task(tmp_path, monkeypatch):
+    db = Database(str(tmp_path / "db.sqlite"))
+    await db.init()
+    async with db.get_session() as session:
+        ev1 = Event(title="a", description="d", date="2025-09-04", time="10:00", location_name="x", source_text="s")
+        ev2 = Event(title="b", description="d", date="2025-09-05", time="11:00", location_name="x", source_text="s")
+        session.add_all([ev1, ev2])
+        await session.commit()
+        await session.refresh(ev1)
+        await session.refresh(ev2)
+        session.add(
+            JobOutbox(
+                event_id=ev1.id,
+                task=JobTask.month_pages,
+                status=JobStatus.pending,
+                coalesce_key="month_pages:2025-09",
+                updated_at=datetime.utcnow(),
+                next_run_at=datetime.utcnow(),
+            )
+        )
+        await session.commit()
+
+    processed: list[int] = []
+
+    async def fake_month_pages(event_id: int, db: Database, bot):
+        processed.append(event_id)
+        return True
+
+    monkeypatch.setitem(main.JOB_HANDLERS, "month_pages", fake_month_pages)
+
+    await main._drain_nav_tasks(db, ev2.id, timeout=1.0)
+
+    assert processed == [ev1.id]
+    async with db.get_session() as session:
+        job = (
+            await session.execute(select(JobOutbox).where(JobOutbox.event_id == ev1.id))
+        ).scalar_one()
+        assert job.status == JobStatus.done
+
+
+@pytest.mark.asyncio
+async def test_drain_coalesced_weekend_task(tmp_path, monkeypatch):
+    db = Database(str(tmp_path / "db.sqlite"))
+    await db.init()
+    async with db.get_session() as session:
+        ev1 = Event(title="a", description="d", date="2025-09-06", time="10:00", location_name="x", source_text="s")
+        ev2 = Event(title="b", description="d", date="2025-09-07", time="11:00", location_name="x", source_text="s")
+        session.add_all([ev1, ev2])
+        await session.commit()
+        await session.refresh(ev1)
+        await session.refresh(ev2)
+        session.add(
+            JobOutbox(
+                event_id=ev1.id,
+                task=JobTask.weekend_pages,
+                status=JobStatus.pending,
+                coalesce_key="weekend_pages:2025-09-06",
+                updated_at=datetime.utcnow(),
+                next_run_at=datetime.utcnow(),
+            )
+        )
+        await session.commit()
+
+    processed: list[int] = []
+
+    async def fake_weekend_pages(event_id: int, db: Database, bot):
+        processed.append(event_id)
+        return True
+
+    monkeypatch.setitem(main.JOB_HANDLERS, "weekend_pages", fake_weekend_pages)
+
+    await main._drain_nav_tasks(db, ev2.id, timeout=1.0)
+
+    assert processed == [ev1.id]
+    async with db.get_session() as session:
+        job = (
+            await session.execute(select(JobOutbox).where(JobOutbox.event_id == ev1.id))
+        ).scalar_one()
+        assert job.status == JobStatus.done


### PR DESCRIPTION
## Summary
- run navigation jobs for merged coalesce keys when draining
- add tests for draining coalesced month/weekend jobs

## Testing
- `pytest tests/test_nav_drain.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b945efa3888332befa68df662efe5f