### PR TITLE
Handle split month patching and nav task follow-up

### DIFF
--- a/tests/test_nav_drain.py
+++ b/tests/test_nav_drain.py
@@ -39,12 +39,15 @@ async def test_drain_coalesced_month_task(tmp_path, monkeypatch):
 
     await main._drain_nav_tasks(db, ev2.id, timeout=1.0)
 
-    assert processed == [ev1.id]
+    assert processed == [ev1.id, ev2.id]
     async with db.get_session() as session:
-        job = (
-            await session.execute(select(JobOutbox).where(JobOutbox.event_id == ev1.id))
-        ).scalar_one()
-        assert job.status == JobStatus.done
+        jobs = (
+            await session.execute(select(JobOutbox).order_by(JobOutbox.id))
+        ).scalars().all()
+        assert {j.event_id: j.status for j in jobs} == {
+            ev1.id: JobStatus.done,
+            ev2.id: JobStatus.done,
+        }
 
 
 @pytest.mark.asyncio
@@ -80,9 +83,12 @@ async def test_drain_coalesced_weekend_task(tmp_path, monkeypatch):
 
     await main._drain_nav_tasks(db, ev2.id, timeout=1.0)
 
-    assert processed == [ev1.id]
+    assert processed == [ev1.id, ev2.id]
     async with db.get_session() as session:
-        job = (
-            await session.execute(select(JobOutbox).where(JobOutbox.event_id == ev1.id))
-        ).scalar_one()
-        assert job.status == JobStatus.done
+        jobs = (
+            await session.execute(select(JobOutbox).order_by(JobOutbox.id))
+        ).scalars().all()
+        assert {j.event_id: j.status for j in jobs} == {
+            ev1.id: JobStatus.done,
+            ev2.id: JobStatus.done,
+        }


### PR DESCRIPTION
## Summary
- Patch correct part of split month pages, migrating legacy markers and headers
- Requeue navigation tasks merged into other jobs to ensure follow-up processing
- Add tests for split month patching and navigation task follow-up

## Testing
- `pytest tests/test_month_patch.py::test_patch_month_page_inserts_chronologically tests/test_month_patch.py::test_patch_month_page_handles_content_too_big tests/test_month_patch.py::test_patch_month_page_handles_escaped_legacy_markers tests/test_month_patch.py::test_patch_month_page_converts_legacy_header tests/test_month_patch.py::test_patch_month_page_split_updates_second_part tests/test_nav_drain.py::test_drain_coalesced_month_task tests/test_nav_drain.py::test_drain_coalesced_weekend_task -q`

------
https://chatgpt.com/codex/tasks/task_e_68b98dcc48ec83328714cca94992df6b