### PR TITLE
Force festival navigation rebuild and landing refresh

### DIFF
--- a/tests/test_festival_nav_rebuild.py
+++ b/tests/test_festival_nav_rebuild.py
@@ -234,7 +234,7 @@ async def test_nav_hash_skip(tmp_path, monkeypatch):
 
     async def fake_tg(eid, db, bot):
         calls["tg"] += 1
-        return True
+        return main.NavUpdateResult(True, 0, False)
 
     async def fake_vk(eid, db, bot):
         calls["vk"] += 1
@@ -291,7 +291,7 @@ async def test_update_tg_nav_sets_nav_hash(tmp_path, monkeypatch):
     monkeypatch.setattr(main, "get_telegraph_token", lambda: "token")
 
     res = await main.update_festival_tg_nav(-fid * main.FEST_JOB_MULT, db, None)
-    assert res
+    assert res.changed
     async with db.get_session() as session:
         fest_db = await session.get(Festival, fid)
         assert fest_db.nav_hash == "abc"


### PR DESCRIPTION
## Summary
- Add `NavUpdateResult` and return detailed stats from `update_festival_tg_nav`
- Force `/festivals_fix_nav` to rebuild navigation for all festival pages and refresh landing
- Simplify command handler to always rebuild landing and report results

## Testing
- `pytest tests/test_festival_logging.py::test_update_festival_tg_nav_logs_edited -q`
- `pytest tests/test_festival_logging.py::test_update_festival_tg_nav_logs_skipped -q`
- `pytest tests/test_festival_logging.py::test_festivals_fix_nav_force -q`
- `pytest tests/test_festival_nav_rebuild.py::test_update_tg_nav_sets_nav_hash -q`


------
https://chatgpt.com/codex/tasks/task_e_68b99fad4f20833285177afef71eeacc