### PR TITLE
Ensure clickable festival images with fallback

### DIFF
--- a/tests/test_auto_program_url.py
+++ b/tests/test_auto_program_url.py
@@ -29,6 +29,14 @@ async def test_add_events_from_text_autofills_program_url(tmp_path: Path, monkey
     monkeypatch.setattr(main, "upload_images", fake_upload)
     monkeypatch.setattr(main, "sync_festival_page", fake_sync_page)
     monkeypatch.setattr(main, "sync_festival_vk_post", fake_sync_vk)
+    async def fake_extract(url):
+        return None
+
+    monkeypatch.setattr(main, "extract_telegra_ph_cover_url", fake_extract)
+    async def fake_rebuild(*a, **k):
+        return "built", ""
+
+    monkeypatch.setattr(main, "rebuild_festivals_index_if_needed", fake_rebuild)
 
     html = '<a href="https://telegra.ph/prog">prog</a>'
     await main.add_events_from_text(db, "t", None, html, None)


### PR DESCRIPTION
## Summary
- wrap festival card images in links and verify links after publishing
- add fallback link when Telegraph strips anchors and log link stats
- expand tests for sanitizer and landing page link preservation

## Testing
- `HTTP_PROXY='' HTTPS_PROXY='' http_proxy='' https_proxy='' pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68b9a6b885f883328e89735faf43f474