### PR TITLE
Support festival photo albums and cover selection

### DIFF
--- a/alembic/versions/20250902_festival_photo_urls.py
+++ b/alembic/versions/20250902_festival_photo_urls.py
@@ -1,0 +1,27 @@
+"""add festival photo_urls"""
+
+from typing import Sequence, Union
+from alembic import op
+import sqlalchemy as sa
+import json
+
+revision: str = '20250902_festival_photo_urls'
+down_revision: Union[str, None] = '20250901_festday_city_fix'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column('festival', sa.Column('photo_urls', sa.JSON(), nullable=False, server_default='[]'))
+    conn = op.get_bind()
+    festival = sa.table('festival', sa.column('id', sa.Integer), sa.column('photo_url', sa.String), sa.column('photo_urls', sa.JSON))
+    rows = conn.execute(sa.select(festival.c.id, festival.c.photo_url)).fetchall()
+    for fid, url in rows:
+        if url:
+            conn.execute(
+                sa.update(festival).where(festival.c.id == fid).values(photo_urls=json.dumps([url]))
+            )
+
+
+def downgrade() -> None:
+    op.drop_column('festival', 'photo_urls')

--- a/db.py
+++ b/db.py
@@ -192,6 +192,7 @@ class Database:
                     vk_post_url TEXT,
                     vk_poll_url TEXT,
                     photo_url TEXT,
+                    photo_urls JSON,
                     website_url TEXT,
                     program_url TEXT,
                     vk_url TEXT,
@@ -210,6 +211,7 @@ class Database:
             await _add_column(conn, "festival", "program_url TEXT")
             await _add_column(conn, "festival", "ticket_url TEXT")
             await _add_column(conn, "festival", "nav_hash TEXT")
+            await _add_column(conn, "festival", "photo_urls JSON")
 
             await conn.execute(
                 """

--- a/models.py
+++ b/models.py
@@ -141,6 +141,7 @@ class Festival(SQLModel, table=True):
     vk_post_url: Optional[str] = None
     vk_poll_url: Optional[str] = None
     photo_url: Optional[str] = None
+    photo_urls: list[str] = Field(default_factory=list, sa_column=Column(JSON))
     website_url: Optional[str] = None
     program_url: Optional[str] = None
     vk_url: Optional[str] = None

--- a/tests/test_festival_album.py
+++ b/tests/test_festival_album.py
@@ -1,0 +1,50 @@
+import pytest
+from pathlib import Path
+
+import main
+from db import Database
+from models import Festival
+
+
+@pytest.mark.asyncio
+async def test_ensure_festival_merges_photo_urls(tmp_path: Path, monkeypatch):
+    db = Database(str(tmp_path / "db.sqlite"))
+    await db.init()
+
+    async def nop(*a, **k):
+        return None
+
+    monkeypatch.setattr(main, "sync_festival_page", nop)
+    monkeypatch.setattr(main, "sync_festival_vk_post", nop)
+    monkeypatch.setattr(main, "sync_festivals_index_page", nop)
+    monkeypatch.setattr(main, "notify_superadmin", nop)
+    monkeypatch.setattr(main, "rebuild_fest_nav_if_changed", nop)
+
+    urls1 = [f"https://catbox.moe/{i}.jpg" for i in range(3)]
+    fest, created, updated = await main.ensure_festival(db, "Fest", photo_urls=urls1)
+    assert created and updated
+    assert fest.photo_url == urls1[0]
+    assert fest.photo_urls == urls1
+
+    urls2 = [urls1[1], "https://catbox.moe/new.jpg"]
+    fest2, created2, updated2 = await main.ensure_festival(db, "Fest", photo_urls=urls2)
+    assert not created2 and updated2
+    assert fest2.photo_urls == urls1 + ["https://catbox.moe/new.jpg"]
+    assert fest2.photo_url == urls1[0]
+
+
+@pytest.mark.asyncio
+async def test_build_festival_page_content_shows_album(tmp_path: Path):
+    db = Database(str(tmp_path / "db.sqlite"))
+    await db.init()
+    urls = [f"https://example.com/{i}.jpg" for i in range(3)]
+    async with db.get_session() as session:
+        fest = Festival(name="Fest", photo_url=urls[1], photo_urls=urls, description="desc")
+        session.add(fest)
+        await session.commit()
+        fid = fest.id
+    async with db.get_session() as session:
+        fest = await session.get(Festival, fid)
+    _, nodes = await main.build_festival_page_content(db, fest)
+    imgs = [n for n in nodes if n.get("tag") == "img"]
+    assert [img["attrs"]["src"] for img in imgs] == [urls[1], urls[0], urls[2]]


### PR DESCRIPTION
## Summary
- allow up to 10 images per festival by introducing MAX_ALBUM_IMAGES and processing albums fully
- store all festival images in new `photo_urls` field and render them linearly on Telegraph
- add admin UI to pick a festival cover from uploaded images

## Testing
- `pytest tests/test_festival_album.py`


------
https://chatgpt.com/codex/tasks/task_e_68b9e0864f6c8332ba30740299948e50