### PR TITLE
Fix job scheduling for non-due tasks and progress propagation

### DIFF
--- a/tests/test_ics_dedup.py
+++ b/tests/test_ics_dedup.py
@@ -1,0 +1,27 @@
+import pytest
+from sqlmodel import select
+
+import main
+from main import Database, Event, JobOutbox, JobTask, JobStatus
+
+
+@pytest.mark.asyncio
+async def test_enqueue_ics_dedup(tmp_path):
+    db = Database(str(tmp_path / "db.sqlite"))
+    await db.init()
+
+    async with db.get_session() as session:
+        ev = Event(title="a", description="d", date="2025-09-05", time="10:00", location_name="x", source_text="s")
+        session.add(ev)
+        await session.commit()
+        await session.refresh(ev)
+
+    await main.enqueue_job(db, ev.id, JobTask.ics_publish)
+    await main.enqueue_job(db, ev.id, JobTask.ics_publish)
+
+    async with db.get_session() as session:
+        jobs = (
+            await session.execute(select(JobOutbox).where(JobOutbox.task == JobTask.ics_publish))
+        ).scalars().all()
+    assert len(jobs) == 1
+    assert jobs[0].status == JobStatus.pending

--- a/tests/test_job_due_filter.py
+++ b/tests/test_job_due_filter.py
@@ -1,0 +1,61 @@
+import pytest
+from datetime import datetime, timedelta
+from sqlmodel import select
+
+import main
+from main import Database, Event, JobOutbox, JobTask, JobStatus
+
+
+@pytest.mark.asyncio
+async def test_future_job_does_not_block_month_pages(tmp_path, monkeypatch):
+    db = Database(str(tmp_path / "db.sqlite"))
+    await db.init()
+
+    async with db.get_session() as session:
+        ev = Event(
+            title="t",
+            description="d",
+            date="2025-09-05",
+            time="12:00",
+            location_name="loc",
+            source_text="src",
+        )
+        session.add(ev)
+        await session.commit()
+        await session.refresh(ev)
+        future = datetime.utcnow() + timedelta(hours=1)
+        session.add(
+            JobOutbox(
+                event_id=ev.id,
+                task=JobTask.vk_sync,
+                status=JobStatus.pending,
+                next_run_at=future,
+            )
+        )
+        session.add(
+            JobOutbox(
+                event_id=ev.id,
+                task=JobTask.month_pages,
+                status=JobStatus.pending,
+                next_run_at=datetime.utcnow(),
+            )
+        )
+        await session.commit()
+
+    calls: list[int] = []
+
+    async def fake_month_pages(eid, db_obj, bot_obj):
+        calls.append(eid)
+        return True
+
+    monkeypatch.setitem(main.JOB_HANDLERS, "month_pages", fake_month_pages)
+
+    await main._run_due_jobs_once(db, None)
+
+    assert calls == [ev.id]
+
+    async with db.get_session() as session:
+        jobs = (await session.execute(select(JobOutbox))).scalars().all()
+    statuses = {j.task: j.status for j in jobs}
+    assert statuses[JobTask.month_pages] == JobStatus.done
+    assert statuses[JobTask.vk_sync] == JobStatus.pending

--- a/tests/test_progress_coalesce_update.py
+++ b/tests/test_progress_coalesce_update.py
@@ -1,0 +1,44 @@
+import pytest
+from types import SimpleNamespace
+
+import main
+from main import Database, Event, JobTask, JobStatus
+
+
+@pytest.mark.asyncio
+async def test_progress_updated_for_merged_jobs(tmp_path, monkeypatch):
+    db = Database(str(tmp_path / "db.sqlite"))
+    await db.init()
+
+    async with db.get_session() as session:
+        ev1 = Event(title="a", description="d", date="2025-09-05", time="10:00", location_name="x", source_text="s")
+        ev2 = Event(title="b", description="d", date="2025-09-06", time="10:00", location_name="x", source_text="s")
+        session.add_all([ev1, ev2])
+        await session.commit()
+        await session.refresh(ev1)
+        await session.refresh(ev2)
+
+    await main.enqueue_job(db, ev1.id, JobTask.month_pages)
+    await main.enqueue_job(db, ev2.id, JobTask.month_pages)
+
+    key = "month_pages:2025-09"
+    updates = []
+
+    async def follower_updater(task, eid, status, changed, link, err):
+        updates.append((task, eid, status))
+
+    main._EVENT_PROGRESS.clear()
+    main._EVENT_PROGRESS_KEYS.clear()
+    main._EVENT_PROGRESS[ev2.id] = SimpleNamespace(
+        updater=follower_updater, ics_progress=None, fest_progress=None, keys=[key]
+    )
+    main._EVENT_PROGRESS_KEYS.setdefault(key, set()).add(ev2.id)
+
+    async def fake_month_pages(eid, db_obj, bot_obj):
+        return True
+
+    monkeypatch.setitem(main.JOB_HANDLERS, "month_pages", fake_month_pages)
+
+    await main._run_due_jobs_once(db, None)
+
+    assert updates == [(JobTask.month_pages, ev2.id, JobStatus.done)]


### PR DESCRIPTION
## Summary
- Avoid blocking jobs by non-due siblings and log the blocking job
- Reorder event task scheduling and propagate progress to coalesced events
- Add tests for due-time filtering, progress updates, and ICS job deduplication

## Testing
- `pytest tests/test_job_due_filter.py tests/test_progress_coalesce_update.py tests/test_ics_dedup.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68b9e80c8bd08332859c80d4c2187d00