### PR TITLE
feat: force month/weekend page rebuild

### DIFF
--- a/tests/test_pages_rebuild_report.py
+++ b/tests/test_pages_rebuild_report.py
@@ -1,4 +1,5 @@
 import pytest
+from datetime import date
 import main
 
 
@@ -17,5 +18,8 @@ async def test_pages_rebuild_report_errors(monkeypatch):
         lambda months: (['2025-09-06'], {"2025-09": ['2025-09-06']})
     )
     report = await main._perform_pages_rebuild(None, ["2025-09"], force=True)
+    label = main.format_weekend_range(date(2025, 9, 6))
     assert "❌ 2025-09 — ошибка: boom" in report
-    assert "❌ 2025-09 — ошибка: 2025-09-06: fail" in report
+    assert "❌ 2025-09 — ошибка:" in report
+    assert f"• {label}: ❌ fail" in report
+    assert "без изменений" not in report


### PR DESCRIPTION
## Summary
- ensure manual page rebuild skips event page creation and rebuilds month and weekend pages from scratch
- add detailed month/weekend rebuild report with per-page links
- cover report errors in tests

## Testing
- `pytest tests/test_pages_rebuild_report.py -q`
- `pytest -q` *(fails: KeyboardInterrupt after 9 tests, 2923 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68bac830a6248332ae38b9f053b5cd33