### PR TITLE
Fix month page rebuild deadlock

### DIFF
--- a/main.py
+++ b/main.py
@@ -9740,8 +9740,6 @@ async def _sync_month_page_inner(
             await check_month_page_markers(tg, page.path2)
         if DEBUG:
             mem_info("month page after")
-        if not update_links:
-            await refresh_month_nav(db)
         changed = (
             created
             or page.content_hash != prev_hash
@@ -9755,7 +9753,8 @@ async def _sync_month_page_inner(
             logging.info("month page %s: edited path=%s size=%d", month, paths, size)
         else:
             logging.info("month page %s: nochange", month)
-
+    if not update_links:
+        await refresh_month_nav(db)
 
 async def sync_month_page(
     db: Database,

--- a/tests/test_refresh_month_nav_lock.py
+++ b/tests/test_refresh_month_nav_lock.py
@@ -1,0 +1,46 @@
+import importlib
+from pathlib import Path
+import pytest
+import main
+
+
+@pytest.mark.asyncio
+async def test_sync_month_page_refresh_nav_outside_lock(tmp_path: Path, monkeypatch):
+    m = importlib.reload(main)
+    db = m.Database(str(tmp_path / "db.sqlite"))
+    await db.init()
+
+    async with db.get_session() as session:
+        session.add(
+            m.Event(
+                title="E1",
+                description="d",
+                source_text="s",
+                date="2025-07-01",
+                time="10:00",
+                location_name="L",
+            )
+        )
+        await session.commit()
+
+    class DummyTG:
+        def create_page(self, title, content=None, html_content=None, **kwargs):
+            return {"url": "u1", "path": "p1"}
+
+        def edit_page(self, path, title=None, content=None, html_content=None, **kwargs):
+            pass
+
+    monkeypatch.setattr(m, "get_telegraph_token", lambda: "t")
+    monkeypatch.setattr(m, "Telegraph", lambda access_token=None, domain=None: DummyTG())
+
+    called = {"flag": False}
+
+    async def fake_refresh(db_obj):
+        called["flag"] = True
+        assert not m.HEAVY_SEMAPHORE.locked()
+
+    monkeypatch.setattr(m, "refresh_month_nav", fake_refresh)
+
+    await m.sync_month_page(db, "2025-07")
+
+    assert called["flag"]


### PR DESCRIPTION
## Summary
- avoid deadlock when rebuilding month pages by refreshing navigation outside the heavy semaphore
- test that month navigation refresh runs without semaphore lock

## Testing
- `pytest tests/test_refresh_month_nav_lock.py tests/test_pages_rebuild_report.py tests/test_bot.py::test_sync_month_page_split tests/test_bot.py::test_sync_month_page_split_on_error -q`

------
https://chatgpt.com/codex/tasks/task_e_68bae03a728c8332a3b422c739dc3e9a