### PR TITLE
Disable link for current month in month footer navigation

### DIFF
--- a/tests/test_bot.py
+++ b/tests/test_bot.py
@@ -2966,7 +2966,7 @@ async def test_month_nav_and_exhibitions(tmp_path: Path, monkeypatch):
 
     _, content, _ = await main.build_month_page_content(db, "2025-07")
     html = main.unescape_html_comments(nodes_to_html(content))
-    nav_block = await main.build_month_nav_block(db)
+    nav_block = await main.build_month_nav_block(db, "2025-07")
     html = main.replace_between_markers(
         html, main.NAV_MONTHS_START, main.NAV_MONTHS_END, nav_block
     )

--- a/tests/test_month_nav.py
+++ b/tests/test_month_nav.py
@@ -57,8 +57,8 @@ async def test_footer_links_propagate_across_all_month_pages(tmp_path: Path, mon
         await session.commit()
 
     months = ["2025-08", "2025-09", "2025-10", "2025-11"]
-    nav_block = await main.build_month_nav_block(db)
     for m in months:
+        nav_block = await main.build_month_nav_block(db, m)
         _, content, _ = await main.build_month_page_content(db, m)
         html = main.unescape_html_comments(nodes_to_html(content))
         html = main.replace_between_markers(
@@ -66,7 +66,11 @@ async def test_footer_links_propagate_across_all_month_pages(tmp_path: Path, mon
         )
         for other in months:
             name = main.month_name_nominative(other)
-            assert f'<a href="https://t.me/{other}">{name}</a>' in html
+            if other == m:
+                assert f'<a href="https://t.me/{other}">' not in html
+                assert name in html
+            else:
+                assert f'<a href="https://t.me/{other}">{name}</a>' in html
 
 
 @pytest.mark.asyncio
@@ -112,20 +116,21 @@ async def test_month_nav_skips_past_and_empty(tmp_path: Path, monkeypatch):
     html_aug = main.unescape_html_comments(nodes_to_html(content_aug))
     assert html_aug.count(main.NAV_MONTHS_START) == 1
     assert html_aug.count(main.NAV_MONTHS_END) == 1
-    nav_block = await main.build_month_nav_block(db)
+    nav_block_aug = await main.build_month_nav_block(db, "2025-08")
     html_aug = main.replace_between_markers(
-        html_aug, main.NAV_MONTHS_START, main.NAV_MONTHS_END, nav_block
+        html_aug, main.NAV_MONTHS_START, main.NAV_MONTHS_END, nav_block_aug
     )
-    assert '<h4><a href="https://t.me/2025-08">август</a> <a href="https://t.me/2025-09">сентябрь</a> <a href="https://t.me/2025-11">ноябрь</a></h4>' in html_aug
+    assert '<h4>август <a href="https://t.me/2025-09">сентябрь</a> <a href="https://t.me/2025-11">ноябрь</a></h4>' in html_aug
     assert "июль" not in html_aug
     assert "октябрь" not in html_aug
 
     _, content_sep, _ = await main.build_month_page_content(db, "2025-09")
     html_sep = main.unescape_html_comments(nodes_to_html(content_sep))
+    nav_block_sep = await main.build_month_nav_block(db, "2025-09")
     html_sep = main.replace_between_markers(
-        html_sep, main.NAV_MONTHS_START, main.NAV_MONTHS_END, nav_block
+        html_sep, main.NAV_MONTHS_START, main.NAV_MONTHS_END, nav_block_sep
     )
-    assert '<h4><a href="https://t.me/2025-08">август</a> <a href="https://t.me/2025-09">сентябрь</a> <a href="https://t.me/2025-11">ноябрь</a></h4>' in html_sep
+    assert '<h4><a href="https://t.me/2025-08">август</a> сентябрь <a href="https://t.me/2025-11">ноябрь</a></h4>' in html_sep
     assert "октябрь" not in html_sep
 
     class FakeDate2(date):
@@ -141,7 +146,7 @@ async def test_month_nav_skips_past_and_empty(tmp_path: Path, monkeypatch):
     monkeypatch.setattr(main, "date", FakeDate2)
     monkeypatch.setattr(main, "datetime", FakeDatetime2)
 
-    nav_block2 = await main.build_month_nav_block(db)
+    nav_block2 = await main.build_month_nav_block(db, "2025-08")
     _, content_aug2, _ = await main.build_month_page_content(db, "2025-08")
     html_aug2 = main.unescape_html_comments(nodes_to_html(content_aug2))
     html_aug2 = main.replace_between_markers(


### PR DESCRIPTION
## Summary
- Show the current month as plain text in the Telegraph footer navigation
- Pass the current month to navigation builder when updating month pages
- Extend month navigation tests for plain-text current month

## Testing
- `pytest tests/test_month_nav.py`
- `pytest tests/test_bot.py::test_month_nav_and_exhibitions`
- `pytest tests/test_refresh_month_nav.py::test_refresh_month_nav_creates_missing_month_page`
- `pytest tests/test_month_patch.py::test_patch_month_page_handles_content_too_big`


------
https://chatgpt.com/codex/tasks/task_e_68bb0412c1888332ae6f8fee42252d6c