### PR TITLE
Use h3 headers to patch month days and fill ICS links

### DIFF
--- a/tests/test_month_patch.py
+++ b/tests/test_month_patch.py
@@ -1,23 +1,39 @@
-import pytest
 from datetime import date
-from sqlalchemy import select
+
+import pytest
 
 import main
-from markup import DAY_START, DAY_END, PERM_START, PERM_END
+from models import Event, MonthPage
+from markup import PERM_START, PERM_END
+
+
+class FakeTelegraph:
+    def __init__(self, html: str, title: str = "Title"):
+        self.html = html
+        self.title = title
+        self.edited_html: str | None = None
+        self.edits: list[tuple[str, str]] = []
+
+    def get_page(self, path, return_html=True):
+        return {"content_html": self.html, "title": self.title}
+
+    def edit_page(self, path, title=None, html_content=None, **kwargs):
+        self.edited_html = html_content
+        self.edits.append((path, html_content))
+        return {"path": path}
 
 
 @pytest.mark.asyncio
-async def test_patch_month_page_inserts_chronologically(tmp_path):
+async def test_patch_adds_links_and_idempotent(tmp_path):
     db = main.Database(str(tmp_path / "db.sqlite"))
     await db.init()
-    # insert month page and sample event for 15th
     async with db.get_session() as session:
-        session.add(main.MonthPage(month="2025-08", url="u", path="p"))
+        session.add(MonthPage(month="2025-09", url="u", path="p"))
         session.add(
-            main.Event(
+            Event(
                 title="Concert",
                 description="desc",
-                date="2025-08-15",
+                date="2025-09-08",
                 time="12:00",
                 location_name="loc",
                 source_text="src",
@@ -25,259 +41,95 @@ async def test_patch_month_page_inserts_chronologically(tmp_path):
         )
         await session.commit()
 
-    html = (
-        "Intro"
-        + DAY_START("2025-08-14")
-        + "14"
-        + DAY_END("2025-08-14")
-        + DAY_START("2025-08-17")
-        + "17"
-        + DAY_END("2025-08-17")
-        + PERM_START
-        + "perm"
-        + PERM_END
-    )
+    async with db.get_session() as session:
+        ev = await session.get(Event, 1)
+        html = main.render_month_day_section(date(2025, 9, 8), [ev])
 
-    class FakeTelegraph:
-        def __init__(self):
-            self.edited_html = None
+    tg = FakeTelegraph(html)
 
-        def get_page(self, path, return_html=True):
-            assert path == "p"
-            return {"content_html": html, "title": "Title"}
+    async with db.get_session() as session:
+        ev = await session.get(Event, 1)
+        ev.telegraph_url = "https://t.me/test"
+        ev.ics_post_url = "https://t.me/file"
+        await session.commit()
 
-        def edit_page(self, path, title, html_content, **kwargs):
-            self.edited_html = html_content
-            return {"path": path}
-
-    tg = FakeTelegraph()
-    changed = await main.patch_month_page_for_date(db, tg, "2025-08", date(2025, 8, 15))
+    changed = await main.patch_month_page_for_date(db, tg, "2025-09", date(2025, 9, 8))
     assert changed is True
-    result = tg.edited_html
-    # ensure new day inserted before 17th and before permanent section
-    assert result.index(DAY_START("2025-08-14")) < result.index(DAY_START("2025-08-15")) < result.index(DAY_START("2025-08-17"))
-    assert result.index(DAY_START("2025-08-15")) < result.index(PERM_START)
+    assert "подробнее" in tg.edited_html and "https://t.me/test" in tg.edited_html
+    assert "Добавить в календарь" in tg.edited_html and "https://t.me/file" in tg.edited_html
+
+    tg.edited_html = None
+    changed2 = await main.patch_month_page_for_date(db, tg, "2025-09", date(2025, 9, 8))
+    assert changed2 is False
+    assert tg.edited_html is None
 
 
 @pytest.mark.asyncio
-async def test_patch_month_page_handles_content_too_big(tmp_path, monkeypatch):
+async def test_patch_inserts_missing_section(tmp_path):
     db = main.Database(str(tmp_path / "db.sqlite"))
     await db.init()
     async with db.get_session() as session:
-        session.add(main.MonthPage(month="2025-08", url="u", path="p"))
+        session.add(MonthPage(month="2025-09", url="u", path="p"))
         session.add(
-            main.Event(
+            Event(
                 title="Concert",
                 description="desc",
-                date="2025-08-15",
+                date="2025-09-08",
                 time="12:00",
                 location_name="loc",
                 source_text="src",
+                telegraph_url="https://t.me/test",
+                ics_url="https://sup.ics",
             )
         )
         await session.commit()
 
     html = PERM_START + "perm" + PERM_END
+    tg = FakeTelegraph(html)
 
-    class FakeTelegraph:
-        def __init__(self):
-            self.calls = 0
-
-        def get_page(self, path, return_html=True):
-            assert path in ("p", "p2")
-            return {"content_html": html if path == "p" else "", "title": "Title"}
-
-        def edit_page(self, path, title=None, html_content=None, **kwargs):
-            self.calls += 1
-            if self.calls == 1:
-                raise main.TelegraphException("CONTENT_TOO_BIG")
-            return {"path": path}
-
-        def create_page(self, title=None, content=None, html_content=None, **kwargs):
-            return {"url": "u2", "path": "p2"}
-
-    tg = FakeTelegraph()
-
-    async def create_page_async(tg_obj, *a, **k):
-        return tg_obj.create_page(*a, **k)
-
-    async def edit_page_async(tg_obj, path, **k):
-        return tg_obj.edit_page(path, **k)
-
-    monkeypatch.setattr(main, "telegraph_create_page", create_page_async)
-    monkeypatch.setattr(main, "telegraph_edit_page", edit_page_async)
-
-    changed = await main.patch_month_page_for_date(
-        db, tg, "2025-08", date(2025, 8, 15)
-    )
+    changed = await main.patch_month_page_for_date(db, tg, "2025-09", date(2025, 9, 8))
     assert changed is True
-    async with db.get_session() as session:
-        page = await session.get(main.MonthPage, "2025-08")
-    assert page.url2 is not None
-    h = await main.get_section_hash(
-        db, "telegraph:month:2025-08", "day:2025-08-15"
-    )
-    assert h is not None
+    assert "<h3>🟥🟥🟥 8 сентября 🟥🟥🟥</h3>" in tg.edited_html
+    assert "https://t.me/test" in tg.edited_html
+    assert "https://sup.ics" in tg.edited_html
 
 
 @pytest.mark.asyncio
-async def test_patch_month_page_handles_escaped_legacy_markers(tmp_path):
-    db = main.Database(str(tmp_path / "db.sqlite"))
-    await db.init()
-    async with db.get_session() as session:
-        session.add(main.MonthPage(month="2025-08", url="u", path="p"))
-        session.add(
-            main.Event(
-                title="Concert",
-                description="desc",
-                date="2025-08-15",
-                time="12:00",
-                location_name="loc",
-                source_text="src",
-            )
-        )
-        await session.commit()
-
-    html = (
-        "Intro"
-        + "<!-- DAY:2025-08-15 START -->OLD<!-- DAY:2025-08-15 END -->"
-        + PERM_START
-        + "perm"
-        + PERM_END
-    )
-    html = html.replace("<!--", "&lt;!--").replace("-->", "--&gt;")
-
-    class FakeTelegraph:
-        def __init__(self):
-            self.edited_html = None
-
-        def get_page(self, path, return_html=True):
-            assert path == "p"
-            return {"content_html": html, "title": "Title"}
-
-        def edit_page(self, path, title, html_content, **kwargs):
-            self.edited_html = html_content
-            return {"path": path}
-
-    tg = FakeTelegraph()
-    changed = await main.patch_month_page_for_date(db, tg, "2025-08", date(2025, 8, 15))
-    assert changed is True
-    result = tg.edited_html
-    assert result.count(DAY_START("2025-08-15")) == 1
-    assert "OLD" not in result
-    assert "<!-- DAY:2025-08-15 START -->" not in result
-    assert result.index(DAY_START("2025-08-15")) < result.index(PERM_START)
-    assert "&lt;!--" not in result
-
-
-@pytest.mark.asyncio
-async def test_patch_month_page_converts_legacy_header(tmp_path):
-    db = main.Database(str(tmp_path / "db.sqlite"))
-    await db.init()
-    async with db.get_session() as session:
-        session.add(main.MonthPage(month="2025-08", url="u", path="p"))
-        session.add(
-            main.Event(
-                title="Concert",
-                description="desc",
-                date="2025-08-15",
-                time="12:00",
-                location_name="loc",
-                source_text="src",
-            )
-        )
-        await session.commit()
-
-    header = f"<h3>🟥🟥🟥 {main.format_day_pretty(date(2025, 8, 15))} 🟥🟥🟥</h3>"
-    html = header + PERM_START + "perm" + PERM_END
-
-    class FakeTelegraph:
-        def __init__(self):
-            self.edited_html = None
-
-        def get_page(self, path, return_html=True):
-            assert path == "p"
-            return {"content_html": html, "title": "Title"}
-
-        def edit_page(self, path, title, html_content, **kwargs):
-            self.edited_html = html_content
-            return {"path": path}
-
-    tg = FakeTelegraph()
-    changed = await main.patch_month_page_for_date(db, tg, "2025-08", date(2025, 8, 15))
-    assert changed is True
-    result = tg.edited_html
-    assert DAY_START("2025-08-15") in result
-    assert DAY_END("2025-08-15") in result
-    assert result.count(header) == 1
-    assert result.index(DAY_START("2025-08-15")) < result.index(header) < result.index(
-        DAY_END("2025-08-15")
-    )
-
-
-@pytest.mark.asyncio
-async def test_patch_month_page_split_updates_second_part(tmp_path):
+async def test_patch_split_updates_second_part(tmp_path):
     db = main.Database(str(tmp_path / "db.sqlite"))
     await db.init()
     async with db.get_session() as session:
         session.add(
-            main.MonthPage(month="2025-08", url="u1", path="p1", url2="u2", path2="p2")
+            MonthPage(month="2025-09", url="u1", path="p1", url2="u2", path2="p2")
         )
         session.add(
-            main.Event(
+            Event(
                 title="Concert",
                 description="desc",
-                date="2025-08-30",
+                date="2025-09-30",
                 time="12:00",
                 location_name="loc",
                 source_text="src",
+                telegraph_url="https://t.me/test",
+                ics_url="https://sup.ics",
             )
         )
         await session.commit()
 
-    html1 = DAY_START("2025-08-01") + "1" + DAY_END("2025-08-01")
-    html2 = (
-        DAY_START("2025-08-29")
-        + "29"
-        + DAY_END("2025-08-29")
-        + PERM_START
-        + "perm"
-        + PERM_END
-    )
+    html1 = main.render_month_day_section(date(2025, 9, 1), [])
+    html2 = PERM_START + "perm" + PERM_END
+    tg = FakeTelegraph("", title="")
 
-    class FakeTelegraph:
-        def __init__(self):
-            self.edits: list[tuple[str, str]] = []
+    def get_page(path, return_html=True):
+        if path == "p1":
+            return {"content_html": html1, "title": "T1"}
+        assert path == "p2"
+        return {"content_html": html2, "title": "T2"}
 
-        def get_page(self, path, return_html=True):
-            if path == "p1":
-                return {"content_html": html1, "title": "T1"}
-            assert path == "p2"
-            return {"content_html": html2, "title": "T2"}
+    tg.get_page = get_page
 
-        def edit_page(self, path, title, html_content, **kwargs):
-            self.edits.append((path, html_content))
-            return {"path": path}
-
-    tg = FakeTelegraph()
-    changed = await main.patch_month_page_for_date(db, tg, "2025-08", date(2025, 8, 30))
+    changed = await main.patch_month_page_for_date(db, tg, "2025-09", date(2025, 9, 30))
     assert changed is True
     assert tg.edits[0][0] == "p2"
-    result = tg.edits[0][1]
-    assert DAY_START("2025-08-30") in result
-    assert DAY_END("2025-08-30") in result
-
-    async with db.get_session() as session:
-        page = await session.get(main.MonthPage, "2025-08")
-        evs = (
-            await session.execute(
-                select(main.Event).where(main.Event.date.like("2025-08-30%"))
-            )
-        ).scalars().all()
-        assert page.content_hash2 == main.content_hash(result)
-        expected_section = main.render_month_day_section(date(2025, 8, 30), evs)
-
-    h = await main.get_section_hash(
-        db, "telegraph:month:2025-08", "day:2025-08-30"
-    )
-    assert h == main.content_hash(expected_section)
+    assert "https://t.me/test" in tg.edits[0][1]
+    assert "https://sup.ics" in tg.edits[0][1]

--- a/tests/test_parse_month_sections.py
+++ b/tests/test_parse_month_sections.py
@@ -15,3 +15,13 @@ def test_parse_month_sections_basic():
     assert sections[0].start_idx == 1
     assert sections[0].end_idx == 4
     assert sections[1].start_idx == 5
+
+
+def test_parse_month_sections_spaces_and_case():
+    html = (
+        '<h3>🟥🟥🟥  9  СЕНТЯБРЯ  🟥🟥🟥</h3>'
+        '<p>\u200b</p>'
+    )
+    sections = parse_month_sections(html)
+    assert len(sections) == 1
+    assert sections[0].date == date(2000, 9, 9)


### PR DESCRIPTION
## Summary
- Anchor month day patching on `<h3>` headers via `parse_month_sections` and always update link block
- Render "Добавить в календарь" using Supabase ICS or Telegram fallback
- Add tests for section parsing and day patch behaviour

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68bc03aaf58483328fe3aa6717584a52