### PR TITLE
Fix month parser for Telegraph DOM and enforce job dependencies

### DIFF
--- a/tests/test_parse_month_sections.py
+++ b/tests/test_parse_month_sections.py
@@ -9,7 +9,8 @@ def test_parse_month_sections_basic():
         '<p>\u200b</p><h4>A</h4><p>\u200b</p>'
         '<h3>🟥🟥🟥 10 сентября 🟥🟥🟥</h3><p>\u200b</p>'
     )
-    sections = parse_month_sections(html)
+    sections, rebuild = parse_month_sections(html)
+    assert not rebuild
     assert [s.date for s in sections] == [date(2000, 9, 9), date(2000, 9, 10)]
     assert sections[0].h3_idx == 0
     assert sections[0].start_idx == 1
@@ -22,6 +23,19 @@ def test_parse_month_sections_spaces_and_case():
         '<h3>🟥🟥🟥  9  СЕНТЯБРЯ  🟥🟥🟥</h3>'
         '<p>\u200b</p>'
     )
-    sections = parse_month_sections(html)
+    sections, rebuild = parse_month_sections(html)
+    assert not rebuild
     assert len(sections) == 1
     assert sections[0].date == date(2000, 9, 9)
+
+
+def test_parse_month_sections_nodes_with_text():
+    nodes = [
+        " \n",
+        {"tag": "h3", "children": ["8 сентября"]},
+        {"tag": "p", "children": ["\u200b"]},
+    ]
+    sections, rebuild = parse_month_sections(nodes)
+    assert not rebuild
+    assert len(sections) == 1
+    assert sections[0].date == date(2000, 9, 8)


### PR DESCRIPTION
## Summary
- make month section parser robust to text nodes, add explicit month regex and rebuild signal
- ensure telegraph build and ICS publish complete before updating month/week/weekend pages
- add tests for text-node headers and update schedule_event_update_tasks dependencies

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bc1b9a7b6c8332ad3813cc741d31e3