### PR TITLE
feat: refine ics pipeline and task deps

### DIFF
--- a/models.py
+++ b/models.py
@@ -158,6 +158,7 @@ class JobTask(str, Enum):
     telegraph_build = "telegraph_build"
     vk_sync = "vk_sync"
     ics_publish = "ics_publish"
+    tg_ics_post = "tg_ics_post"
     month_pages = "month_pages"
     weekend_pages = "weekend_pages"
     week_pages = "week_pages"

--- a/tests/test_bot.py
+++ b/tests/test_bot.py
@@ -379,7 +379,7 @@ async def test_month_page_sync(tmp_path: Path, monkeypatch):
 
     called = {}
 
-    async def fake_sync(db_obj, month):
+    async def fake_sync(db_obj, month, update_links=True):
         called["month"] = month
 
     monkeypatch.setattr("main.create_source_page", fake_create)

--- a/tests/test_db_ics_fields.py
+++ b/tests/test_db_ics_fields.py
@@ -62,6 +62,7 @@ async def test_ics_fields_persist_and_update(tmp_path, monkeypatch):
     monkeypatch.setattr(main, "update_source_page_ics", fake_update)
     monkeypatch.setattr(main, "update_source_post_keyboard", lambda *a, **k: None)
     await main.ics_publish(1, db, bot)
+    await main.tg_ics_post(1, db, bot)
     async with db.get_session() as session:
         ev = await session.get(Event, 1)
         h1, u1, f1, t1 = ev.ics_hash, ev.ics_url, ev.ics_file_id, ev.ics_updated_at
@@ -70,6 +71,7 @@ async def test_ics_fields_persist_and_update(tmp_path, monkeypatch):
         ev.time = "20:00"
         await session.commit()
     await main.ics_publish(1, db, bot)
+    await main.tg_ics_post(1, db, bot)
     async with db.get_session() as session:
         ev = await session.get(Event, 1)
         assert ev.ics_hash != h1

--- a/tests/test_notifications.py
+++ b/tests/test_notifications.py
@@ -404,14 +404,22 @@ async def test_publish_event_progress_ics(tmp_path, monkeypatch):
         await session.commit()
         await session.refresh(ev)
         session.add(JobOutbox(event_id=ev.id, task=JobTask.ics_publish))
+        session.add(JobOutbox(event_id=ev.id, task=JobTask.tg_ics_post))
         await session.commit()
 
     async def ics_handler(eid, db_obj, bot_obj, progress):
         progress.mark("ics_supabase", "done", "https://sup")
+        return True
+
+    async def tg_handler(eid, db_obj, bot_obj, progress):
         progress.mark("ics_telegram", "done", "https://tg")
         return True
 
-    monkeypatch.setattr(main, "JOB_HANDLERS", {"ics_publish": ics_handler})
+    monkeypatch.setattr(
+        main,
+        "JOB_HANDLERS",
+        {"ics_publish": ics_handler, "tg_ics_post": tg_handler},
+    )
 
     async def fake_link(task, eid, db_obj):
         return None


### PR DESCRIPTION
## Summary
- split ICS generation and Telegram posting with new `tg_ics_post` job
- delay month/weekend page builds until ICS and Telegraph tasks finish
- post VK source messages with the group token to avoid captcha

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bc500a42708332b41ec091832ffca1