### PR TITLE
Use hr anchor for month navigation

### DIFF
--- a/markup.py
+++ b/markup.py
@@ -97,10 +97,6 @@ WEND_START = lambda key: Marker(f"<!--WEEKEND:{key} START-->")
 WEND_END = lambda key: Marker(f"<!--WEEKEND:{key} END-->")
 PERM_START: Marker = Marker("<!--PERMANENT_EXHIBITIONS START-->")
 PERM_END: Marker = Marker("<!--PERMANENT_EXHIBITIONS END-->")
-# Month navigation markers for month pages
-NAV_MONTHS_START: Marker = Marker("<!-- nav-months:start -->")
-NAV_MONTHS_END: Marker = Marker("<!-- nav-months:end -->")
-
 # Canonical festival navigation markers used across the project
 # ``FEST_NAV_*`` names are kept for backwards compatibility but map to the
 # new ``near-festivals`` markers required by the idempotent block logic.

--- a/tests/test_bot.py
+++ b/tests/test_bot.py
@@ -2967,9 +2967,7 @@ async def test_month_nav_and_exhibitions(tmp_path: Path, monkeypatch):
     _, content, _ = await main.build_month_page_content(db, "2025-07")
     html = main.unescape_html_comments(nodes_to_html(content))
     nav_block = await main.build_month_nav_block(db, "2025-07")
-    html = main.replace_between_markers(
-        html, main.NAV_MONTHS_START, main.NAV_MONTHS_END, nav_block
-    )
+    html = main.ensure_footer_nav_with_hr(html, nav_block, month="2025-07", page=1)
     assert 'href="m2"' in html
 
     idx_exh = next(

--- a/tests/test_footer_hr.py
+++ b/tests/test_footer_hr.py
@@ -1,0 +1,39 @@
+from sections import ensure_footer_nav_with_hr
+from telegraph.utils import html_to_nodes, nodes_to_html
+
+
+def test_html_without_hr_adds_nav():
+    html = "<p>text</p>"
+    nav = "<h4>nav</h4>"
+    res = ensure_footer_nav_with_hr(html, nav, month="2025-01", page=1)
+    assert res == "<p>text</p><hr>\n<h4>nav</h4>"
+
+
+def test_html_with_duplicates():
+    html = "<p>text</p><hr><h4>old</h4><p>junk</p>"
+    nav = "<h4>new</h4>"
+    res = ensure_footer_nav_with_hr(html, nav, month="2025-01", page=1)
+    assert res == "<p>text</p><hr>\n<h4>new</h4>"
+
+
+def test_nodes_without_hr():
+    nodes = html_to_nodes("<p>text</p>")
+    nav_nodes = html_to_nodes("<h4>nav</h4>")
+    res = ensure_footer_nav_with_hr(nodes, nav_nodes, month="2025-01", page=1)
+    assert nodes_to_html(res) == "<p>text</p><hr><h4>nav</h4>"
+
+
+def test_nodes_with_duplicates():
+    nodes = html_to_nodes("<p>text</p><hr><h4>old</h4><p>junk</p>")
+    nav_nodes = html_to_nodes("<h4>nav</h4>")
+    res = ensure_footer_nav_with_hr(nodes, nav_nodes, month="2025-01", page=1)
+    assert nodes_to_html(res) == "<p>text</p><hr><h4>nav</h4>"
+
+
+def test_idempotent_html():
+    html = "<p>text</p><hr><h4>nav</h4>"
+    nav = "<h4>nav</h4>"
+    res1 = ensure_footer_nav_with_hr(html, nav, month="2025-01", page=1)
+    res2 = ensure_footer_nav_with_hr(res1, nav, month="2025-01", page=1)
+    assert res1 == res2
+

--- a/tests/test_month_nav.py
+++ b/tests/test_month_nav.py
@@ -61,9 +61,7 @@ async def test_footer_links_propagate_across_all_month_pages(tmp_path: Path, mon
         nav_block = await main.build_month_nav_block(db, m)
         _, content, _ = await main.build_month_page_content(db, m)
         html = main.unescape_html_comments(nodes_to_html(content))
-        html = main.replace_between_markers(
-            html, main.NAV_MONTHS_START, main.NAV_MONTHS_END, nav_block
-        )
+        html = main.ensure_footer_nav_with_hr(html, nav_block, month=m, page=1)
         for other in months:
             name = main.month_name_nominative(other)
             if other == m:
@@ -114,11 +112,9 @@ async def test_month_nav_skips_past_and_empty(tmp_path: Path, monkeypatch):
 
     _, content_aug, _ = await main.build_month_page_content(db, "2025-08")
     html_aug = main.unescape_html_comments(nodes_to_html(content_aug))
-    assert html_aug.count(main.NAV_MONTHS_START) == 1
-    assert html_aug.count(main.NAV_MONTHS_END) == 1
     nav_block_aug = await main.build_month_nav_block(db, "2025-08")
-    html_aug = main.replace_between_markers(
-        html_aug, main.NAV_MONTHS_START, main.NAV_MONTHS_END, nav_block_aug
+    html_aug = main.ensure_footer_nav_with_hr(
+        html_aug, nav_block_aug, month="2025-08", page=1
     )
     assert '<h4>август <a href="https://t.me/2025-09">сентябрь</a> <a href="https://t.me/2025-11">ноябрь</a></h4>' in html_aug
     assert "июль" not in html_aug
@@ -127,8 +123,8 @@ async def test_month_nav_skips_past_and_empty(tmp_path: Path, monkeypatch):
     _, content_sep, _ = await main.build_month_page_content(db, "2025-09")
     html_sep = main.unescape_html_comments(nodes_to_html(content_sep))
     nav_block_sep = await main.build_month_nav_block(db, "2025-09")
-    html_sep = main.replace_between_markers(
-        html_sep, main.NAV_MONTHS_START, main.NAV_MONTHS_END, nav_block_sep
+    html_sep = main.ensure_footer_nav_with_hr(
+        html_sep, nav_block_sep, month="2025-09", page=1
     )
     assert '<h4><a href="https://t.me/2025-08">август</a> сентябрь <a href="https://t.me/2025-11">ноябрь</a></h4>' in html_sep
     assert "октябрь" not in html_sep
@@ -149,8 +145,8 @@ async def test_month_nav_skips_past_and_empty(tmp_path: Path, monkeypatch):
     nav_block2 = await main.build_month_nav_block(db, "2025-08")
     _, content_aug2, _ = await main.build_month_page_content(db, "2025-08")
     html_aug2 = main.unescape_html_comments(nodes_to_html(content_aug2))
-    html_aug2 = main.replace_between_markers(
-        html_aug2, main.NAV_MONTHS_START, main.NAV_MONTHS_END, nav_block2
+    html_aug2 = main.ensure_footer_nav_with_hr(
+        html_aug2, nav_block2, month="2025-08", page=1
     )
     assert '<a href="https://t.me/2025-08">' not in html_aug2
     assert '<h4><a href="https://t.me/2025-09">сентябрь</a> <a href="https://t.me/2025-11">ноябрь</a></h4>' in html_aug2


### PR DESCRIPTION
## Summary
- ensure monthly pages keep a single navigation block after an `<hr>` marker
- replace fragile HTML comment markers with `<hr>` anchoring
- add regression tests for footer nav handling

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68bc7595464c83328e7e40c467b8d778