### PR TITLE
Refactor source page content layout

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ If the original message contains photos (under 5&nbsp;MB), they are uploaded to 
 The project uses `telegraph>=2.2.0`. `create_page` returns the page `url` and `path`;
 only `edit_page(path=...)` accepts a `path` argument when updating existing pages.
 Editing an event lets you create or delete an ICS file for calendars. The file is uploaded to Supabase when `SUPABASE_URL` and `SUPABASE_KEY` are set. Files are named `Event-<id>-dd-mm-yyyy.ics` and include a link back to the event. Set `SUPABASE_BUCKET` if you use a bucket name other than `events-ics`.
-When a calendar file exists the Telegraph page shows a link right under the title image: "📅 Добавить в календарь на телефоне (ICS)".
+When a calendar file exists the Telegraph page shows a link right under the title image: "📅 Добавить в календарь".
 Events may note support for the Пушкинская карта, shown as a separate line in postings.
 Run `/exhibitions` to see all ongoing exhibitions (events with a start and end date).
 

--- a/main.py
+++ b/main.py
@@ -2939,7 +2939,7 @@ async def rebuild_fest_nav_if_changed(db: Database) -> bool:
     return True
 
 
-ICS_LABEL = "Добавить в календарь на телефоне (ICS)"
+ICS_LABEL = "Добавить в календарь"
 
 FOOTER_LINK_HTML = (
     '<p>&#8203;</p>'
@@ -14407,17 +14407,23 @@ async def build_source_page_content(
     else:
         catbox_urls, catbox_msg = await upload_images(images)
         urls = catbox_urls
+    # filter out video links and limit to first 12 images
+    urls = [
+        u for u in urls if not re.search(r"\.(?:mp4|webm|mkv|mov)(?:\?|$)", u, re.I)
+    ][:12]
     cover = urls[:1]
     tail = urls[1:]
-    if source_url and display_link:
-        html_content += (
-            f'<p><a href="{html.escape(source_url)}"><strong>{html.escape(title)}</strong></a></p>'
-        )
-    else:
-        html_content += f"<p><strong>{html.escape(title)}</strong></p>"
     if cover:
         html_content += f'<figure><img src="{html.escape(cover[0])}"/></figure>'
-    html_content = apply_ics_link(html_content, ics_url)
+        if ics_url:
+            html_content += (
+                f'<p>\U0001f4c5 <a href="{html.escape(ics_url)}">Добавить в календарь</a></p>'
+            )
+    else:
+        if ics_url:
+            html_content += (
+                f'<p>\U0001f4c5 <a href="{html.escape(ics_url)}">Добавить в календарь</a></p>'
+            )
     if html_text:
         html_text = strip_title(html_text)
         html_text = normalize_hashtag_dates(html_text)

--- a/tests/test_source_images.py
+++ b/tests/test_source_images.py
@@ -20,6 +20,8 @@ async def test_build_source_page_content_multi(monkeypatch):
     assert uploaded == 4
     assert html.count('<figure><img src="http://cat/0.jpg"/></figure>') == 1
     assert html.count('<img src="http://cat/') == 4
+    assert '<p><strong>T</strong></p>' not in html
+    assert 'Добавить в календарь' not in html
     # first nav before tail, second after tail
     assert html.count("<p>NAV</p>") == 2
     first_nav = html.index("<p>NAV</p>")
@@ -69,3 +71,41 @@ def test_apply_ics_link_after_figure():
     res = main.apply_ics_link(html, "http://i")
     assert main.ICS_LABEL in res
     assert res.index(main.ICS_LABEL) > res.index("</figure>")
+
+
+@pytest.mark.asyncio
+async def test_build_source_page_content_ics_with_cover():
+    html, _, _ = await main.build_source_page_content(
+        "T",
+        "text",
+        None,
+        None,
+        None,
+        "http://ics",
+        None,
+        catbox_urls=["http://cat/1.jpg"],
+    )
+    assert html.startswith('<figure><img src="http://cat/1.jpg"/></figure>')
+    assert '<p>📅 <a href="http://ics">Добавить в календарь</a></p>' in html
+    assert html.index('http://ics') > html.index('</figure>')
+    assert html.index('http://ics') < html.index('<p>text</p>')
+
+
+@pytest.mark.asyncio
+async def test_build_source_page_content_ics_no_cover():
+    html, _, _ = await main.build_source_page_content(
+        "T", "text", None, None, None, "http://ics", None
+    )
+    assert html.startswith('<p>📅 <a href="http://ics">Добавить в календарь</a></p>')
+    assert html.index('http://ics') < html.index('<p>text</p>')
+
+
+@pytest.mark.asyncio
+async def test_build_source_page_content_limit_and_no_video():
+    urls = [f"http://cat/{i}.jpg" for i in range(15)] + ["http://cat/vid.mp4"]
+    html, _, uploaded = await main.build_source_page_content(
+        "T", "text", None, None, None, None, None, catbox_urls=urls
+    )
+    assert uploaded == 12
+    assert html.count('<img src="http://cat/') == 12
+    assert 'vid.mp4' not in html


### PR DESCRIPTION
## Summary
- avoid repeating title in Telegraph source pages
- insert calendar link after cover or at top and cap images at 12
- document updated calendar link label

## Testing
- `pytest tests/test_source_images.py -q`
- `pytest tests/test_source_keyboard.py -q`
- `pytest` *(fails: KeyboardInterrupt after initial tests)*

------
https://chatgpt.com/codex/tasks/task_e_68bdd450f8048332bd846580a8c7bb6a