### PR TITLE
Filter festival stats to upcoming events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,11 @@
 - Daily announcements no longer append a "подробнее" link to the event's
   Telegraph page.
 
+## v0.3.10 - Festival stats filter
+
+- `/stats` now lists festival statistics only for upcoming festivals or those
+  that ended within the last week.
+
 ## v0.3.9 - VK daily announcements
 
 - Daily announcements can be posted to a VK group. Set the group with `/vkgroup` and adjust

--- a/docs/COMMANDS.md
+++ b/docs/COMMANDS.md
@@ -25,7 +25,7 @@
 
 
 
-| `/stats [events]` | optional `events` | Superadmin only. Show Telegraph view counts starting from the past month and weekend pages up to all current and future ones. Use `events` to list event page stats. |
+| `/stats [events]` | optional `events` | Superadmin only. Show Telegraph view counts starting from the past month and weekend pages up to all current and future ones. Festival stats include only upcoming or recently ended (within a week) festivals. Use `events` to list event page stats. |
 | `/dumpdb` | - | Superadmin only. Download a SQL dump and `telegraph_token.txt` plus restore instructions. |
 | `/restore` | attach file | Superadmin only. Replace current database with the uploaded dump. |
 

--- a/main.py
+++ b/main.py
@@ -13195,7 +13195,9 @@ async def collect_event_stats(db: Database) -> list[str]:
 
 
 async def collect_festival_telegraph_stats(db: Database) -> list[str]:
-    """Return Telegraph view counts for all festivals."""
+    """Return Telegraph view counts for upcoming and recent festivals."""
+    today = datetime.now(LOCAL_TZ).date()
+    week_ago = today - timedelta(days=7)
     async with db.get_session() as session:
         result = await session.execute(
             select(Festival).where(Festival.telegraph_path.is_not(None))
@@ -13203,6 +13205,10 @@ async def collect_festival_telegraph_stats(db: Database) -> list[str]:
         fests = result.scalars().all()
     stats: list[tuple[str, int]] = []
     for f in fests:
+        start = parse_iso_date(f.start_date) if f.start_date else None
+        end = parse_iso_date(f.end_date) if f.end_date else start
+        if not ((start and start >= today) or (end and end >= week_ago)):
+            continue
         views = await fetch_views(f.telegraph_path, f.telegraph_url)
         if views is not None:
             stats.append((f.name, views))
@@ -13273,7 +13279,9 @@ async def fetch_vk_post_stats(
 
 
 async def collect_festival_vk_stats(db: Database) -> list[str]:
-    """Return VK view and reach counts for all festivals."""
+    """Return VK view and reach counts for upcoming and recent festivals."""
+    today = datetime.now(LOCAL_TZ).date()
+    week_ago = today - timedelta(days=7)
     async with db.get_session() as session:
         result = await session.execute(
             select(Festival).where(Festival.vk_post_url.is_not(None))
@@ -13281,6 +13289,10 @@ async def collect_festival_vk_stats(db: Database) -> list[str]:
         fests = result.scalars().all()
     stats: list[tuple[str, int, int]] = []
     for f in fests:
+        start = parse_iso_date(f.start_date) if f.start_date else None
+        end = parse_iso_date(f.end_date) if f.end_date else start
+        if not ((start and start >= today) or (end and end >= week_ago)):
+            continue
         views, reach = await fetch_vk_post_stats(f.vk_post_url, db)
         if views is not None or reach is not None:
             stats.append((f.name, views or 0, reach or 0))


### PR DESCRIPTION
## Summary
- show Telegraph and VK festival stats only for upcoming festivals or those that ended within a week
- document stats festival window
- test festival stats filtering

## Testing
- `pytest tests/test_bot.py::test_stats_festivals -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68bdf4ae8f8083328357b814403fa4fe