### PR TITLE
Propagate festival source post to single-day events

### DIFF
--- a/alembic/versions/20250902_festival_source_post.py
+++ b/alembic/versions/20250902_festival_source_post.py
@@ -1,0 +1,20 @@
+"""add festival source post fields"""
+
+from typing import Sequence, Union
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = '20250902_festival_source_post'
+down_revision: Union[str, None] = '20250901_festday_city_fix'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.execute("ALTER TABLE festival ADD COLUMN source_post_url TEXT")
+    op.execute("ALTER TABLE festival ADD COLUMN source_chat_id INTEGER")
+    op.execute("ALTER TABLE festival ADD COLUMN source_message_id INTEGER")
+
+
+def downgrade() -> None:
+    pass

--- a/db.py
+++ b/db.py
@@ -201,7 +201,10 @@ class Database:
                     location_name TEXT,
                     location_address TEXT,
                     city TEXT,
-                    source_text TEXT
+                    source_text TEXT,
+                    source_post_url TEXT,
+                    source_chat_id INTEGER,
+                    source_message_id INTEGER
                 )
                 """
             )
@@ -212,6 +215,9 @@ class Database:
             await _add_column(conn, "festival", "ticket_url TEXT")
             await _add_column(conn, "festival", "nav_hash TEXT")
             await _add_column(conn, "festival", "photo_urls JSON")
+            await _add_column(conn, "festival", "source_post_url TEXT")
+            await _add_column(conn, "festival", "source_chat_id INTEGER")
+            await _add_column(conn, "festival", "source_message_id INTEGER")
 
             await conn.execute(
                 """

--- a/models.py
+++ b/models.py
@@ -151,6 +151,9 @@ class Festival(SQLModel, table=True):
     location_address: Optional[str] = None
     city: Optional[str] = None
     source_text: Optional[str] = None
+    source_post_url: Optional[str] = None
+    source_chat_id: Optional[int] = None
+    source_message_id: Optional[int] = None
     nav_hash: Optional[str] = None
 
 


### PR DESCRIPTION
## Summary
- track source Telegram post on festivals
- forward source info to single-day events so original announcement gains an ICS button
- add migration and tests

## Testing
- `pytest tests/test_bot.py::test_forward_add_festival -q`
- `pytest` *(fails: KeyboardInterrupt during suite, environment limitation)*

------
https://chatgpt.com/codex/tasks/task_e_68beca0040688332a420a5c24d99796f