### PR TITLE
feat: notify partners about digest inclusion

### DIFF
--- a/tests/test_digest_notify_partners.py
+++ b/tests/test_digest_notify_partners.py
@@ -7,14 +7,16 @@ import main
 from main import Database, User, Event, Channel
 from test_digest_command import DummyBot
 
+
 @pytest.mark.asyncio
-async def test_digest_toggle_refresh_publish(tmp_path, monkeypatch):
+async def test_notify_partners(tmp_path, monkeypatch):
     db = Database(str(tmp_path / "db.sqlite"))
     await db.init()
     async with db.get_session() as session:
         session.add(User(user_id=1, is_superadmin=True))
+        session.add(User(user_id=2, username="p1", is_partner=True))
         dt = datetime.utcnow() + timedelta(days=1)
-        ev1 = Event(
+        ev = Event(
             title="L1",
             description="d",
             date=dt.strftime("%Y-%m-%d"),
@@ -23,18 +25,9 @@ async def test_digest_toggle_refresh_publish(tmp_path, monkeypatch):
             source_text="s",
             event_type="лекция",
             telegraph_url="https://telegra.ph/1",
+            creator_id=2,
         )
-        ev2 = Event(
-            title="L2",
-            description="d",
-            date=dt.strftime("%Y-%m-%d"),
-            time="13:00",
-            location_name="loc",
-            source_text="s",
-            event_type="лекция",
-            telegraph_url="https://telegra.ph/2",
-        )
-        session.add_all([ev1, ev2, Channel(channel_id=-100, title="Chan", daily_time="08:00")])
+        session.add_all([ev, Channel(channel_id=-100, title="Chan", daily_time="08:00")])
         await session.commit()
     bot = DummyBot()
 
@@ -57,8 +50,10 @@ async def test_digest_toggle_refresh_publish(tmp_path, monkeypatch):
     await main.show_digest_menu(msg, db, bot)
     menu_msg = bot.messages[0]
     digest_id = menu_msg.reply_markup.inline_keyboard[0][0].callback_data.split(":")[-1]
+
     async def ans(**kw):
         return None
+
     cb_select = SimpleNamespace(
         id="1",
         from_user=SimpleNamespace(id=1),
@@ -68,52 +63,32 @@ async def test_digest_toggle_refresh_publish(tmp_path, monkeypatch):
     )
     await main.handle_digest_select_lectures(cb_select, db, bot)
 
-    session_data = main.digest_preview_sessions[digest_id]
-    assert len(session_data["items"]) == 2
-    assert session_data["excluded"] == set()
-
     panel_msg = bot.messages[-1]
-    async def ans2(**kw):
+    async def ans2(*args, **kw):
         return None
-    cb_toggle = SimpleNamespace(
-        data=f"dg:t:{digest_id}:1",
+    cb_send = SimpleNamespace(
+        data=f"dg:s:{digest_id}:-100",
         from_user=SimpleNamespace(id=1),
         message=panel_msg,
         answer=ans2,
         id="2",
     )
-    prev_groups = len(bot.media_groups)
-    await main.handle_digest_toggle(cb_toggle, bot)
-    assert len(bot.media_groups) == prev_groups
-    updated_panel = next(m for m in bot.messages if m.message_id == panel_msg.message_id)
-    assert updated_panel.reply_markup.inline_keyboard[0][0].text.startswith("❌")
-    assert 0 in session_data["excluded"]
-
-    async def ans3(**kw):
-        return None
-    cb_refresh = SimpleNamespace(
-        data=f"dg:r:{digest_id}",
+    await main.handle_digest_send(cb_send, db, bot)
+    status_msg = bot.messages[-1]
+    assert status_msg.reply_markup is not None
+    cb_notify = SimpleNamespace(
+        data=f"dg:np:{digest_id}:-100",
         from_user=SimpleNamespace(id=1),
-        message=panel_msg,
-        answer=ans3,
+        message=status_msg,
+        answer=ans2,
         id="3",
     )
-    await main.handle_digest_refresh(cb_refresh, bot)
-    assert len(bot.media_groups) == prev_groups + 1
-    caption = bot.media_groups[-1][1][0].caption
-    assert "L2" in caption and "L1" not in caption
-
-    new_panel = bot.messages[-1]
-    async def ans4(*args, **kw):
-        return None
-    cb_send = SimpleNamespace(
-        data=f"dg:s:{digest_id}:-100",
-        from_user=SimpleNamespace(id=1),
-        message=new_panel,
-        answer=ans4,
-        id="4",
-    )
-    await main.handle_digest_send(cb_send, db, bot)
-    # check that link and status messages were sent
-    assert bot.messages[-2].text.startswith("https://")
-    assert "нет событий" in bot.messages[-1].text
+    await main.handle_digest_notify_partners(cb_notify, db, bot)
+    partner_msgs = [m for m in bot.messages if m.chat.id == 2]
+    assert len(partner_msgs) == 1
+    assert "Ваше событие попало в дайджест" in partner_msgs[0].text
+    assert bot.messages[-1].text.startswith("Уведомлено:")
+    prev = len(partner_msgs)
+    await main.handle_digest_notify_partners(cb_notify, db, bot)
+    partner_msgs = [m for m in bot.messages if m.chat.id == 2]
+    assert len(partner_msgs) == prev


### PR DESCRIPTION
## Summary
- track event and creator info in digest preview items
- save published digest info and prompt admins to notify partners
- add handler to DM partners whose events are featured
- cover partner notification flow with tests

## Testing
- `pytest tests/test_digest_panel.py tests/test_digest_notify_partners.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68c02a79c7308332a523695069333557