### PR TITLE
feat: select vk actor per owner

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,8 +41,12 @@ browse upcoming announcements. The command accepts dates like `2025-07-10`,
   export TELEGRAPH_TOKEN=your_telegraph_token
   # User access token for VK posts (scopes: wall,groups,offline)
   export VK_USER_TOKEN=vk_user_token
-  # Optional: group token used as a fallback
+  # IDs of VK groups (without @)
+  export VK_MAIN_GROUP_ID=123
+  export VK_AFISHA_GROUP_ID=231828790
+  # Group tokens
   export VK_TOKEN=vk_group_token
+  export VK_TOKEN_AFISHA=vk_afisha_group_token
   # Sending images to VK is disabled by default. Use /vkphotos to enable it.
   # Optional behaviour tuning
   export VK_ACTOR_MODE=auto  # group|user|auto
@@ -88,8 +92,12 @@ browse upcoming announcements. The command accepts dates like `2025-07-10`,
    fly secrets set TELEGRAPH_TOKEN=<token>
    # User access token for VK posts (scopes: wall,groups,offline)
    fly secrets set VK_USER_TOKEN=<token>
-   # Optional: group token used as a fallback
+   # IDs of VK groups (without @)
+   fly secrets set VK_MAIN_GROUP_ID=<id>
+   fly secrets set VK_AFISHA_GROUP_ID=<id>
+   # Group tokens
    fly secrets set VK_TOKEN=<token>
+   fly secrets set VK_TOKEN_AFISHA=<token>
    # Sending images to VK is disabled by default. Toggle with /vkphotos.
    ```
 3. Deploy:

--- a/tests/test_vk_actor.py
+++ b/tests/test_vk_actor.py
@@ -79,3 +79,19 @@ async def test_vk_actor_auto_no_fallback(monkeypatch):
     assert calls == ["g"]
     assert main.vk_fallback_group_to_user_total["wall.post"] == 0
 
+
+def test_choose_vk_actor(monkeypatch):
+    monkeypatch.setattr(main, "VK_MAIN_GROUP_ID", "1")
+    monkeypatch.setattr(main, "VK_AFISHA_GROUP_ID", "2")
+    monkeypatch.setattr(main, "VK_TOKEN", "gm")
+    monkeypatch.setattr(main, "VK_TOKEN_AFISHA", "ga")
+    monkeypatch.setattr(main, "VK_USER_TOKEN", "u")
+
+    actors_main = main.choose_vk_actor(-1, "wall.post")
+    assert [a.label for a in actors_main] == ["group:main", "user"]
+    assert actors_main[0].token == "gm"
+
+    actors_afisha = main.choose_vk_actor(-2, "wall.post")
+    assert [a.label for a in actors_afisha] == ["group:afisha", "user"]
+    assert actors_afisha[0].token == "ga"
+

--- a/tests/test_vk_source.py
+++ b/tests/test_vk_source.py
@@ -29,7 +29,7 @@ async def test_sync_vk_source_post_includes_calendar_link(monkeypatch):
     captured_message = {}
 
     async def fake_post_to_vk(
-        group_id, message, db=None, bot=None, attachments=None, token=None
+        group_id, message, db=None, bot=None, attachments=None
     ):
         captured_message["text"] = message
         return "https://vk.com/wall-1_2"

--- a/tests/test_vk_weekend.py
+++ b/tests/test_vk_weekend.py
@@ -90,7 +90,7 @@ async def test_sync_weekend_page_posts_vk(tmp_path: Path, monkeypatch):
     posted: list[str] = []
 
     async def fake_post_to_vk(
-        group_id, message, db=None, bot=None, attachments=None, token=None
+        group_id, message, db=None, bot=None, attachments=None
     ):
         posted.append(message)
         return 'https://vk.com/wall-1_111'
@@ -156,7 +156,7 @@ async def test_sync_vk_weekend_post_recreates_deleted(tmp_path: Path, monkeypatc
 
     created: list[str] = []
 
-    async def fake_post_to_vk(group_id, message, db=None, bot=None, attachments=None, token=None):
+    async def fake_post_to_vk(group_id, message, db=None, bot=None, attachments=None):
         created.append(message)
         return 'https://vk.com/wall-1_2'
 


### PR DESCRIPTION
## Summary
- add `choose_vk_actor` utility and configuration logging
- route VK wall posts and photo uploads through actor selection with retry logging
- document new VK group tokens and ids

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c040977aec833287264ebcd3f5b902