### PR TITLE
feat: highlight festival index link

### DIFF
--- a/main.py
+++ b/main.py
@@ -10053,16 +10053,17 @@ def _build_month_page_content_sync(
         add_many(telegraph_br())
         add(
             {
-                "tag": "p",
+                "tag": "h3",
                 "children": [
                     {
                         "tag": "a",
                         "attrs": {"href": fest_index_url},
-                        "children": ["🎪 Все фестивали Калининградской области"],
+                        "children": ["Фестивали"],
                     }
                 ],
             }
         )
+        add_many(telegraph_br())
 
     title = (
         f"События Калининграда в {month_name_prepositional(month)}: полный анонс от Полюбить Калининград Анонсы"
@@ -10496,16 +10497,17 @@ async def build_weekend_page_content(
         add_many(telegraph_br())
         add(
             {
-                "tag": "p",
+                "tag": "h3",
                 "children": [
                     {
                         "tag": "a",
                         "attrs": {"href": fest_index_url},
-                        "children": ["Ближайшие фестивали Калининградской области"],
+                        "children": ["Фестивали"],
                     }
                 ],
             }
         )
+        add_many(telegraph_br())
 
     label = format_weekend_range(saturday)
     if saturday.month == sunday.month:
@@ -11132,18 +11134,17 @@ async def build_festival_page_content(db: Database, fest: Festival) -> tuple[str
         )
         nodes.append(
             {
-                "tag": "p",
+                "tag": "h3",
                 "children": [
                     {
                         "tag": "a",
                         "attrs": {"href": fest_index_url},
-                        "children": [
-                            "\U0001f3aa Все фестивали Калининградской области →"
-                        ],
+                        "children": ["Фестивали"],
                     }
                 ],
             }
         )
+        nodes.extend(telegraph_br())
     title = fest.full_name or fest.name
     return title, nodes
 

--- a/tests/test_festival_index_link.py
+++ b/tests/test_festival_index_link.py
@@ -22,10 +22,7 @@ async def test_festival_page_has_index_link(tmp_path: Path, caplog):
     with caplog.at_level(logging.INFO):
         _, nodes = await main.build_festival_page_content(db, fest)
     html = nodes_to_html(nodes)
-    assert (
-        '<a href="https://telegra.ph/fests">🎪 Все фестивали Калининградской области →</a>'
-        in html
-    )
+    assert '<h3><a href="https://telegra.ph/fests">Фестивали</a></h3>' in html
     rec = next(r for r in caplog.records if r.message == "festival_page_index_link")
     assert rec.festival == "Fest"
     assert rec.fest_index_url == "https://telegra.ph/fests"

--- a/tests/test_festivals_index_page.py
+++ b/tests/test_festivals_index_page.py
@@ -226,7 +226,7 @@ async def test_month_page_has_festivals_link(tmp_path: Path, monkeypatch):
 
     _, content, _ = await main.build_month_page_content(db, "2025-07")
     html = nodes_to_html(content)
-    assert '<a href="https://telegra.ph/fests">🎪 Все фестивали Калининградской области</a>' in html
+    assert '<h3><a href="https://telegra.ph/fests">Фестивали</a></h3>' in html
 
 
 @pytest.mark.asyncio
@@ -265,7 +265,7 @@ async def test_weekend_page_has_festivals_link(tmp_path: Path, monkeypatch):
 
     _, content, _ = await main.build_weekend_page_content(db, saturday.isoformat())
     html = nodes_to_html(content)
-    assert '<a href="https://telegra.ph/fests">Ближайшие фестивали Калининградской области</a>' in html
+    assert '<h3><a href="https://telegra.ph/fests">Фестивали</a></h3>' in html
 
 
 def test_sanitize_telegraph_html_rewrites_and_checks():


### PR DESCRIPTION
## Summary
- replace bottom "Все фестивали" links on Telegraph pages with prominent "Фестивали" heading
- add spacer line below the heading
- adjust tests for new festival link text

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c0689c5f588332b1f02d1fea67a1d8