### PR TITLE
feat: add manual vk monitoring

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,6 +79,11 @@
 - Daily announcements can be posted to a VK group. Set the group with `/vkgroup` and adjust
   times via `/vktime`. Use the `VK_TOKEN` secret for API access.
 
+## v0.3.11 - VK monitoring MVP
+
+- Added `/vk` command for manual monitoring of VK communities: add/list/delete groups and review posts from the last three days.
+- New `VK_API_VERSION` environment variable to override VK API version.
+
 ## v0.3.10 - Unified daily management
 
 - `/regdailychannels` and `/daily` now show the VK group alongside Telegram channels.

--- a/README.md
+++ b/README.md
@@ -3,6 +3,8 @@
 Telegram bot for publishing event announcements. Daily announcements can also be posted to a VK group.
 Use `/regdailychannels` and `/daily` to manage both Telegram channels and the VK group including posting times.
 
+Superadmins can use `/vk` to monitor VK communities: add or remove groups and manually fetch posts from the last three days.
+
 This is an MVP using **aiogram 3** and SQLite. It is designed for deployment on
 Fly.io with a webhook.
 
@@ -47,6 +49,8 @@ browse upcoming announcements. The command accepts dates like `2025-07-10`,
   # Group tokens
   export VK_TOKEN=vk_group_token
   export VK_TOKEN_AFISHA=vk_afisha_group_token
+  # Optional: override VK API version (default 5.199)
+  export VK_API_VERSION=5.199
   # Optional: max photos per VK post (default 10)
   export VK_MAX_ATTACHMENTS=10
   # Sending images to VK is disabled by default. Use /vkphotos to enable it.

--- a/db.py
+++ b/db.py
@@ -244,6 +244,42 @@ class Database:
 
             await conn.execute(
                 """
+                CREATE TABLE IF NOT EXISTS vk_source(
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    group_id INTEGER NOT NULL,
+                    screen_name TEXT,
+                    name TEXT,
+                    location TEXT,
+                    default_time TEXT,
+                    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+                )
+                """
+            )
+            await conn.execute(
+                "CREATE UNIQUE INDEX IF NOT EXISTS ux_vk_source_group ON vk_source(group_id)"
+            )
+
+            await conn.execute(
+                """
+                CREATE TABLE IF NOT EXISTS vk_tmp_post(
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    batch TEXT NOT NULL,
+                    user_id INTEGER NOT NULL,
+                    group_id INTEGER NOT NULL,
+                    post_id INTEGER NOT NULL,
+                    date INTEGER NOT NULL,
+                    text TEXT,
+                    photos JSON,
+                    url TEXT
+                )
+                """
+            )
+            await conn.execute(
+                "CREATE INDEX IF NOT EXISTS ix_vk_tmp_post_batch ON vk_tmp_post(batch, id)"
+            )
+
+            await conn.execute(
+                """
                 CREATE TABLE IF NOT EXISTS page_section_cache(
                     page_key TEXT NOT NULL,
                     section_key TEXT NOT NULL,


### PR DESCRIPTION
## Summary
- add vk_source and vk_tmp_post tables for manual VK monitoring
- implement VK API utilities and /vk command for admins to add, list and inspect VK communities
- document VK_API_VERSION and new /vk workflow

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c11fa1dac48332aaf61d31769fac94