### PR TITLE
Add festival link under month navigation on telegraph pages

### DIFF
--- a/main.py
+++ b/main.py
@@ -3547,7 +3547,14 @@ async def build_month_nav_html(db: Database, current_month: str | None = None) -
             links.append(" ")
     if not links:
         return ""
-    return "<br/><h4>" + "".join(links) + "</h4>"
+    result = "<br/><h4>" + "".join(links) + "</h4>"
+    fest_index_url = await get_setting_value(db, "fest_index_url")
+    if fest_index_url:
+        result += (
+            f'<br/><h3><a href="{html.escape(fest_index_url)}">'
+            f"Фестивали</a></h3>"
+        )
+    return result
 
 
 async def build_month_nav_block(


### PR DESCRIPTION
## Summary
- add "Фестивали" link below month navigation using h3 heading
- test that month navigation includes festival link

## Testing
- `pytest tests/test_month_nav.py::test_month_nav_includes_festival_link -q`

------
https://chatgpt.com/codex/tasks/task_e_68c1452763c0833280e1359dbda3ca59