### PR TITLE
Track VK intake processing time

### DIFF
--- a/docs/VK_METRICS.md
+++ b/docs/VK_METRICS.md
@@ -1,0 +1,10 @@
+# VK metrics
+
+The application exposes a text endpoint `/metrics` suitable for scraping.
+
+## Metrics
+
+- `vk_fallback_group_to_user_total{method="<name>"}` – number of times a VK API
+  call had to fall back from a group token to a user token for a given method.
+- `vk_intake_processing_time_seconds_total` – cumulative time spent converting
+  VK posts into events.


### PR DESCRIPTION
## Summary
- add processing-time metric in `vk_intake.process_event`
- expose metrics via `/metrics` endpoint and document counters
- test metric collection and endpoint output

## Testing
- `pytest tests/test_vk_intake_metrics.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68c1646b0224833286da079ab3b1ad2b