### PR TITLE
Add VK repost URL field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -221,3 +221,7 @@
 
 - Added database tables and helpers for VK crawling and review queue.
 - Introduced `vk_intake` module with keyword and date detection utilities.
+
+## v0.3.35 - VK repost link storage
+
+- Event records now include an optional `vk_repost_url` to track reposts in the VK afisha.

--- a/db.py
+++ b/db.py
@@ -120,6 +120,7 @@ class Database:
                     ics_url TEXT,
                     source_post_url TEXT,
                     source_vk_post_url TEXT,
+                    vk_repost_url TEXT,
                     ics_hash TEXT,
                     ics_file_id TEXT,
                     ics_updated_at TIMESTAMP,
@@ -141,6 +142,7 @@ class Database:
             await _add_column(conn, "event", "ics_updated_at TIMESTAMP")
             await _add_column(conn, "event", "ics_post_url TEXT")
             await _add_column(conn, "event", "ics_post_id INTEGER")
+            await _add_column(conn, "event", "vk_repost_url TEXT")
 
             await conn.execute(
                 """

--- a/models.py
+++ b/models.py
@@ -87,6 +87,7 @@ class Event(SQLModel, table=True):
     ics_url: Optional[str] = None
     source_post_url: Optional[str] = None
     source_vk_post_url: Optional[str] = None
+    vk_repost_url: Optional[str] = None
     ics_hash: Optional[str] = None
     ics_file_id: Optional[str] = None
     ics_updated_at: Optional[datetime] = None


### PR DESCRIPTION
## Summary
- allow events to store a `vk_repost_url` linking to the afisha repost
- document VK repost link storage in changelog

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c168cb3f6083329f02aba11aaadc23