### PR TITLE
feat: add vk crawl helper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -225,3 +225,10 @@
 ## v0.3.35 - VK repost link storage
 
 - Event records now include an optional `vk_repost_url` to track reposts in the VK afisha.
+
+## v0.3.36 - VK crawl utility
+
+- Introduced `vk_intake.crawl_once` for cursor-based crawling and enqueueing of
+  matching posts.
+- Dropped the unused VK publish queue in favor of operator-triggered reposts;
+  documentation updated.

--- a/README.md
+++ b/README.md
@@ -10,8 +10,8 @@ Superadmins can use `/vk` to monitor VK communities: add or remove groups and ma
 Background crawling collects posts from configured VK communities and filters
 them by event keywords and date patterns. Matching posts land in an operator
 review queue where they can be accepted, enriched with extra info, rejected or
-skipped. Accepted items are processed through the existing pipeline to create a
-Telegraph page, calendar links and a VK publish queue item.
+skipped. Accepted items go through the existing pipeline to create a Telegraph
+page, calendar links and, if desired, a VK repost.
 
 This is an MVP using **aiogram 3** and SQLite. It is designed for deployment on
 Fly.io with a webhook.

--- a/vk_intake.py
+++ b/vk_intake.py
@@ -1,5 +1,8 @@
 from __future__ import annotations
 
+import asyncio
+import logging
+import random
 import re
 import time
 from dataclasses import dataclass
@@ -122,3 +125,118 @@ async def process_event(
     global processing_time_seconds_total
     processing_time_seconds_total += duration
     return result
+
+
+async def crawl_once(db, *, broadcast: bool = False) -> dict[str, int]:
+    """Crawl configured VK groups once and enqueue matching posts.
+
+    The function scans groups listed in ``vk_source`` and uses cursors from
+    ``vk_crawl_cursor`` to fetch only new posts. Posts containing event
+    keywords and a date mention are inserted into ``vk_inbox`` with status
+    ``pending``. Basic statistics are returned for reporting purposes.
+    ``broadcast`` is accepted for API parity but is not used directly here.
+    """
+
+    from main import vk_wall_since  # imported lazily to avoid circular import
+
+    start = time.perf_counter()
+    stats = {
+        "groups_checked": 0,
+        "posts_scanned": 0,
+        "posts_matched": 0,
+        "duplicates": 0,
+        "errors": 0,
+        "inbox_total": 0,
+    }
+
+    async with db.raw_conn() as conn:
+        cur = await conn.execute("SELECT group_id FROM vk_source")
+        groups = [row[0] for row in await cur.fetchall()]
+
+    logging.info("vk.crawl start groups=%d", len(groups))
+
+    for gid in groups:
+        stats["groups_checked"] += 1
+        # pause between groups
+        await asyncio.sleep(random.uniform(0.4, 0.6))
+        try:
+            async with db.raw_conn() as conn:
+                cur = await conn.execute(
+                    "SELECT last_seen_ts, last_post_id FROM vk_crawl_cursor WHERE group_id=?",
+                    (gid,),
+                )
+                row = await cur.fetchone()
+                last_seen_ts, last_post_id = row if row else (0, 0)
+
+            posts = await vk_wall_since(gid, last_seen_ts)
+            group_posts = 0
+            group_matched = 0
+            max_ts, max_pid = last_seen_ts, last_post_id
+
+            for post in posts:
+                ts = post["date"]
+                pid = post["post_id"]
+                if ts < last_seen_ts or (ts == last_seen_ts and pid <= last_post_id):
+                    continue
+                stats["posts_scanned"] += 1
+                group_posts += 1
+                kw_ok, kws = match_keywords(post["text"])
+                has_date = detect_date(post["text"])
+                if kw_ok and has_date:
+                    try:
+                        async with db.raw_conn() as conn:
+                            cur = await conn.execute(
+                                """
+                                INSERT OR IGNORE INTO vk_inbox(
+                                    group_id, post_id, date, text, matched_kw, has_date, status
+                                ) VALUES (?, ?, ?, ?, ?, ?, 'pending')
+                                """,
+                                (
+                                    gid,
+                                    pid,
+                                    ts,
+                                    post["text"],
+                                    ",".join(kws),
+                                    int(has_date),
+                                ),
+                            )
+                            await conn.commit()
+                        if cur.rowcount == 0:
+                            stats["duplicates"] += 1
+                        else:
+                            stats["posts_matched"] += 1
+                            group_matched += 1
+                    except Exception:
+                        stats["errors"] += 1
+
+                if ts > max_ts or (ts == max_ts and pid > max_pid):
+                    max_ts, max_pid = ts, pid
+
+            async with db.raw_conn() as conn:
+                await conn.execute(
+                    "INSERT OR REPLACE INTO vk_crawl_cursor(group_id, last_seen_ts, last_post_id) VALUES(?,?,?)",
+                    (gid, max_ts, max_pid),
+                )
+                await conn.commit()
+
+            logging.info(
+                "vk.crawl group=%s posts=%s matched=%s", gid, group_posts, group_matched
+            )
+        except Exception:
+            stats["errors"] += 1
+
+    async with db.raw_conn() as conn:
+        cur = await conn.execute(
+            "SELECT COUNT(*) FROM vk_inbox WHERE status='pending'"
+        )
+        stats["inbox_total"] = (await cur.fetchone())[0]
+
+    duration = time.perf_counter() - start
+    logging.info(
+        "vk.crawl done checked=%s matched=%s inbox_total=%s dur=%.2fs",
+        stats["posts_scanned"],
+        stats["posts_matched"],
+        stats["inbox_total"],
+        duration,
+    )
+    return stats


### PR DESCRIPTION
## Summary
- add `vk_intake.crawl_once` for cursor-based VK crawling and queueing
- document removal of VK publish queue and emphasize optional repost
- note change in changelog

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c16e1a66908332a0b661e3acc713c8