### PR TITLE
Add VK crawling command and scheduling

### DIFF
--- a/db.py
+++ b/db.py
@@ -342,20 +342,6 @@ class Database:
             )
 
             await conn.execute(
-                """
-                CREATE TABLE IF NOT EXISTS vk_publish_queue (
-                    id           INTEGER PRIMARY KEY AUTOINCREMENT,
-                    event_id     INTEGER NOT NULL,
-                    payload      JSON NOT NULL,
-                    status       TEXT NOT NULL DEFAULT 'queued',
-                    last_error   TEXT,
-                    created_at   TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
-                    sent_at      TIMESTAMP
-                )
-                """
-            )
-
-            await conn.execute(
                 "CREATE INDEX IF NOT EXISTS idx_festival_name ON festival(name)"
             )
             await conn.execute(


### PR DESCRIPTION
## Summary
- add superadmin /vk_crawl_now command with queue summary helper
- schedule automatic VK crawling via `VK_CRAWL_TIMES_LOCAL`
- implement VK event draft and persistence helpers and refine crawl logging

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c17402db18833289954129c7317b02