### PR TITLE
docs: mention vk inbox review and update pipeline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -232,3 +232,9 @@
   matching posts.
 - Dropped the unused VK publish queue in favor of operator-triggered reposts;
   documentation updated.
+
+## v0.3.37 - VK inbox review
+
+- The review flow now reads candidates from the persistent `vk_inbox` table.
+- Operators can choose to repost accepted events to the Afisha VK group.
+- Removed remaining references to the deprecated publish queue from docs.

--- a/README.md
+++ b/README.md
@@ -5,13 +5,14 @@ Use `/regdailychannels` and `/daily` to manage both Telegram channels and the VK
 
 Superadmins can use `/vk` to monitor VK communities: add or remove groups and manually fetch posts from the last three days.
 
-## VK Intake & Review v1.1
+## VK Intake & Review
 
 Background crawling collects posts from configured VK communities and filters
-them by event keywords and date patterns. Matching posts land in an operator
-review queue where they can be accepted, enriched with extra info, rejected or
-skipped. Accepted items go through the existing pipeline to create a Telegraph
-page, calendar links and, if desired, a VK repost.
+them by event keywords and date patterns. Matching posts land in the persistent
+`vk_inbox` queue where an operator can accept, enrich with extra info, reject or
+skip a candidate. Accepted items go through the standard import pipeline to
+create a Telegraph page and calendar links. The operator may additionally
+trigger a repost to the Afisha VK group; there is no separate publish queue.
 
 This is an MVP using **aiogram 3** and SQLite. It is designed for deployment on
 Fly.io with a webhook.

--- a/vk_intake.py
+++ b/vk_intake.py
@@ -92,7 +92,17 @@ async def build_event_payload_from_vk(
     default_time: str | None = None,
     operator_extra: str | None = None,
 ) -> EventDraft:
-    """Parse VK post text into an :class:`EventDraft` using the existing LLM."""
+    """Return a normalised event draft extracted from a VK post.
+
+    The function delegates parsing to the same LLM helper used by ``/add`` and
+    forwarded posts.  When ``operator_extra`` is supplied it takes precedence
+    over conflicting fragments of the original text.  ``source_name`` and
+    ``location_hint`` are passed to the extractor for additional context and
+    ``default_time`` is used when the post does not mention a time explicitly.
+
+    The resulting :class:`EventDraft` contains basic event attributes such as
+    title, date, time, venue, price and relevant links.
+    """
     from main import parse_event_via_4o
 
     llm_text = text
@@ -133,7 +143,13 @@ async def build_event_payload_from_vk(
 async def persist_event_and_pages(
     draft: EventDraft, photos: list[str]
 ) -> PersistResult:
-    """Persist a drafted event and schedule page generation tasks."""
+    """Store a drafted event and produce all public artefacts.
+
+    The helper encapsulates the legacy import pipeline used by the bot.  It
+    persists the event to the database, uploads images to Catbox and creates the
+    Telegraph page, generates an ICS file and posts it to the asset channel.
+    Links to these artefacts are returned in :class:`PersistResult`.
+    """
     from datetime import datetime
     from main import (
         db,


### PR DESCRIPTION
## Summary
- clarify LLM extraction and persistence helpers for VK import
- document vk_inbox queue and optional VK repost
- note vk inbox review in changelog

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c18ab937e08332938f311ab0040708