### PR TITLE
Broadcast VK crawl summary to admin chat

### DIFF
--- a/main.py
+++ b/main.py
@@ -12760,7 +12760,7 @@ async def vk_crawl_cron(db: Database, bot: Bot, run_id: str | None = None) -> No
     now = datetime.now(LOCAL_TZ).strftime("%H:%M")
     logging.info("vk.crawl.cron.fire time=%s", now)
     try:
-        await vk_intake.crawl_once(db)
+        await vk_intake.crawl_once(db, broadcast=True, bot=bot)
     except Exception:
         logging.exception("vk.crawl.cron.error")
 
@@ -15386,7 +15386,7 @@ async def handle_vk_crawl_now(message: types.Message, db: Database, bot: Bot) ->
         if not user or not user.is_superadmin:
             await bot.send_message(message.chat.id, "Not authorized")
             return
-    stats = await vk_intake.crawl_once(db)
+    stats = await vk_intake.crawl_once(db, broadcast=True, bot=bot)
     q = stats.get("queue", {})
     msg = (
         f"Проверено {stats['groups_checked']} сообществ, "


### PR DESCRIPTION
## Summary
- allow `vk_intake.crawl_once` to optionally broadcast a crawl summary to ADMIN_CHAT_ID
- send crawl summary in scheduled and manual VK crawl handlers

## Testing
- `pytest tests/test_auto_program_url.py tests/test_vk_captcha.py tests/test_bot.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68c1a8be4b8c833298302b2ffbe8598c