### PR TITLE
Expose VK queue summary and review shortcut

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -238,3 +238,8 @@
 - The review flow now reads candidates from the persistent `vk_inbox` table.
 - Operators can choose to repost accepted events to the Afisha VK group.
 - Removed remaining references to the deprecated publish queue from docs.
+
+## v0.3.38 - VK queue summary
+
+- `/vk_queue` displays current inbox counts and offers a button to start the
+  review flow.

--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@ them by event keywords and date patterns. Matching posts land in the persistent
 skip a candidate. Accepted items go through the standard import pipeline to
 create a Telegraph page and calendar links. The operator may additionally
 trigger a repost to the Afisha VK group; there is no separate publish queue.
+Operators can run `/vk_queue` to see current inbox counts and get a button to
+start reviewing candidates.
 
 This is an MVP using **aiogram 3** and SQLite. It is designed for deployment on
 Fly.io with a webhook.

--- a/main.py
+++ b/main.py
@@ -15405,9 +15405,9 @@ async def handle_vk_crawl_now(message: types.Message, db: Database, bot: Bot) ->
 async def handle_vk_queue(message: types.Message, db: Database, bot: Bot) -> None:
     async with db.get_session() as session:
         user = await session.get(User, message.from_user.id)
-        if not user or not user.is_superadmin:
-            await bot.send_message(message.chat.id, "Not authorized")
-            return
+    if not user:
+        await bot.send_message(message.chat.id, "Not authorized")
+        return
     async with db.raw_conn() as conn:
         cur = await conn.execute(
             "SELECT status, COUNT(*) FROM vk_inbox GROUP BY status"
@@ -15421,7 +15421,11 @@ async def handle_vk_queue(message: types.Message, db: Database, bot: Bot) -> Non
         f"imported: {counts.get('imported', 0)}",
         f"rejected: {counts.get('rejected', 0)}",
     ]
-    await bot.send_message(message.chat.id, "\n".join(lines))
+    markup = types.ReplyKeyboardMarkup(
+        keyboard=[[types.KeyboardButton(text=VK_BTN_CHECK_EVENTS)]],
+        resize_keyboard=True,
+    )
+    await bot.send_message(message.chat.id, "\n".join(lines), reply_markup=markup)
 
 
 async def handle_vk_next_callback(callback: types.CallbackQuery, db: Database, bot: Bot) -> None:

--- a/tests/test_vk_queue_command.py
+++ b/tests/test_vk_queue_command.py
@@ -1,0 +1,65 @@
+import os, sys
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+
+import pytest
+from aiogram import types
+from types import SimpleNamespace
+
+import main
+from main import Database, User
+
+
+class DummyBot:
+    def __init__(self):
+        self.messages = []
+
+    async def send_message(self, chat_id, text, **kwargs):
+        msg = SimpleNamespace(
+            message_id=len(self.messages) + 1,
+            date=0,
+            chat=SimpleNamespace(id=chat_id, type="private"),
+            from_user=SimpleNamespace(id=0, is_bot=True, first_name="B"),
+            text=text,
+            reply_markup=kwargs.get("reply_markup"),
+        )
+        self.messages.append(msg)
+        return msg
+
+
+@pytest.mark.asyncio
+async def test_handle_vk_queue_shows_counts_and_button(tmp_path):
+    db = Database(str(tmp_path / "db.sqlite"))
+    await db.init()
+    async with db.get_session() as session:
+        session.add(User(user_id=1))
+        await session.commit()
+    async with db.raw_conn() as conn:
+        rows = [
+            (1, 1, 0, "t", None, 1, "pending"),
+            (1, 2, 0, "t", None, 1, "pending"),
+            (1, 3, 0, "t", None, 1, "locked"),
+            (1, 4, 0, "t", None, 1, "skipped"),
+            (1, 5, 0, "t", None, 1, "imported"),
+            (1, 6, 0, "t", None, 1, "rejected"),
+        ]
+        await conn.executemany(
+            "INSERT INTO vk_inbox(group_id, post_id, date, text, matched_kw, has_date, status) VALUES(?,?,?,?,?,?,?)",
+            rows,
+        )
+        await conn.commit()
+    msg = types.Message.model_validate(
+        {
+            "message_id": 1,
+            "date": 0,
+            "chat": {"id": 1, "type": "private"},
+            "from": {"id": 1, "is_bot": False, "first_name": "U"},
+            "text": "/vk_queue",
+        }
+    )
+    bot = DummyBot()
+    await main.handle_vk_queue(msg, db, bot)
+    assert bot.messages, "no message sent"
+    sent = bot.messages[0]
+    assert "pending: 2" in sent.text
+    assert "locked: 1" in sent.text
+    assert sent.reply_markup.keyboard[0][0].text == main.VK_BTN_CHECK_EVENTS


### PR DESCRIPTION
## Summary
- allow non-admins to view VK inbox counts via `/vk_queue`
- show a "🔎 Проверить события" button in the queue summary
- document the new command and changelog entry

## Testing
- `pytest tests/test_vk_queue_command.py -vv`
- `pytest` *(fails: KeyboardInterrupt during full suite)*

------
https://chatgpt.com/codex/tasks/task_e_68c1bec4fafc8332b4479d3440185567