### PR TITLE
Handle VK internal links in Telegraph markup

### DIFF
--- a/tests/test_markup.py
+++ b/tests/test_markup.py
@@ -39,6 +39,13 @@ def test_linkify_text_url():
 def test_linkify_markdown_link():
     assert linkify_for_telegraph("[site](https://example.com)") == '<a href="https://example.com">site</a>'
 
+
+def test_linkify_vk_internal_link():
+    assert (
+        linkify_for_telegraph("[club9118984|Калининградском музее]")
+        == '<a href="https://vk.com/club9118984">Калининградском музее</a>'
+    )
+
 def test_expose_links_from_html():
     assert expose_links_for_vk('see <a href="https://example.com">site</a>') == 'see site (https://example.com)'
 


### PR DESCRIPTION
## Summary
- convert VK [screen_name|label] links to HTML anchors when linkifying for Telegraph
- test VK-style internal link conversion in markup utilities

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c5147328b483328e96a49f2f8249f9