### PR TITLE
Reject stale events during VK review

### DIFF
--- a/vk_review.py
+++ b/vk_review.py
@@ -39,17 +39,17 @@ async def pick_next(db: Database, operator_id: int, batch_id: str) -> Optional[I
     cutoff = int(_time.time()) + 2 * 3600
     async with db.raw_conn() as conn:
         await conn.execute(
-            "UPDATE vk_inbox SET status='rejected', locked_by=NULL, locked_at=NULL WHERE status IN ('pending','skipped') AND (event_ts_hint IS NULL OR event_ts_hint < ?)",
+            "UPDATE vk_inbox SET status='rejected', locked_by=NULL, locked_at=NULL WHERE status IN ('pending','skipped') AND event_ts_hint IS NOT NULL AND event_ts_hint < ?",
             (cutoff,),
         )
         cur = await conn.execute(
-            "SELECT 1 FROM vk_inbox WHERE status='pending' AND event_ts_hint >= ? LIMIT 1",
+            "SELECT 1 FROM vk_inbox WHERE status='pending' AND (event_ts_hint IS NULL OR event_ts_hint >= ?) LIMIT 1",
             (cutoff,),
         )
         has_pending = await cur.fetchone() is not None
         if not has_pending:
             await conn.execute(
-                "UPDATE vk_inbox SET status='pending' WHERE status='skipped' AND event_ts_hint >= ?",
+                "UPDATE vk_inbox SET status='pending' WHERE status='skipped' AND (event_ts_hint IS NULL OR event_ts_hint >= ?)",
                 (cutoff,),
             )
 
@@ -57,8 +57,9 @@ async def pick_next(db: Database, operator_id: int, batch_id: str) -> Optional[I
             """
             WITH next AS (
                 SELECT id FROM vk_inbox
-                WHERE status='pending' AND event_ts_hint >= ?
-                ORDER BY event_ts_hint ASC, date DESC, id DESC
+                WHERE status='pending' AND (event_ts_hint IS NULL OR event_ts_hint >= ?)
+                ORDER BY CASE WHEN event_ts_hint IS NULL THEN 1 ELSE 0 END,
+                         event_ts_hint ASC, date DESC, id DESC
                 LIMIT 1
             )
             UPDATE vk_inbox


### PR DESCRIPTION
## Summary
- Automatically reject VK inbox posts scheduled to start within two hours when checking the queue
- Keep undated posts in the queue and review them after dated ones
- Test VK review flow to ensure stale posts are rejected and undated posts remain

## Testing
- `pytest tests/test_vk_review.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68c66d45388c8332942af6679e670d6a