### PR TITLE
Handle repost media in VK review

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,7 +58,6 @@
 
 - `/stats events` lists stats for event source pages sorted by views.
 
-
 ## v0.3.7 - Large month pages
 
 - Month pages are split in two when the content exceeds ~64&nbsp;kB. The first
@@ -266,3 +265,6 @@
 
 - VK event imports now send the group title to 4o so venues can be inferred from
   `docs/LOCATIONS.md` when posts omit them.
+
+## v0.3.42 - VK review media
+- VK review: поддержаны фото из репостов (copy_history), link-preview, doc-preview; для video берём только превью-картинки, видео не загружаем

--- a/README.md
+++ b/README.md
@@ -24,6 +24,10 @@ batch can be finished with "🧹 Завершить…" which sequentially rebui
 affected month pages. Operators can run `/vk_queue` to see current inbox counts
 and get a button to start reviewing candidates.
 
+Reposts use images from the original post, link and doc attachments rely on their
+previews, and only preview frames from videos are shown—video files are never
+downloaded.
+
 This is an MVP using **aiogram 3** and SQLite. It is designed for deployment on
 Fly.io with a webhook.
 

--- a/tests/test_vkrev_fetch_photos.py
+++ b/tests/test_vkrev_fetch_photos.py
@@ -1,0 +1,160 @@
+import os, sys
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+
+import pytest
+
+import main
+
+
+@pytest.mark.asyncio
+async def test_copy_history_photo(monkeypatch):
+    async def fake_vk_api(method, params, db, bot):
+        assert method == "wall.getById"
+        return {
+            "response": [
+                {
+                    "copy_history": [
+                        {
+                            "attachments": [
+                                {
+                                    "type": "photo",
+                                    "photo": {
+                                        "sizes": [
+                                            {"width": 100, "height": 100, "url": "http://p"}
+                                        ]
+                                    },
+                                }
+                            ]
+                        }
+                    ],
+                    "attachments": [],
+                }
+            ]
+        }
+
+    monkeypatch.setattr(main, "_vk_api", fake_vk_api)
+    photos = await main._vkrev_fetch_photos(1, 1, None, None)
+    assert photos == ["http://p"]
+
+
+@pytest.mark.asyncio
+async def test_link_preview(monkeypatch):
+    async def fake_vk_api(method, params, db, bot):
+        return {
+            "response": [
+                {
+                    "attachments": [
+                        {
+                            "type": "link",
+                            "link": {
+                                "photo": {
+                                    "sizes": [
+                                        {
+                                            "width": 10,
+                                            "height": 10,
+                                            "url": "http://l",
+                                        }
+                                    ]
+                                }
+                            },
+                        }
+                    ]
+                }
+            ]
+        }
+
+    monkeypatch.setattr(main, "_vk_api", fake_vk_api)
+    photos = await main._vkrev_fetch_photos(1, 2, None, None)
+    assert photos == ["http://l"]
+
+
+@pytest.mark.asyncio
+async def test_video_preview(monkeypatch):
+    calls = []
+
+    async def fake_vk_api(method, params, db, bot):
+        calls.append(method)
+        return {
+            "response": [
+                {
+                    "attachments": [
+                        {
+                            "type": "video",
+                            "video": {
+                                "image": [
+                                    {"width": 10, "height": 10, "url": "http://v"}
+                                ]
+                            },
+                        }
+                    ]
+                }
+            ]
+        }
+
+    monkeypatch.setattr(main, "_vk_api", fake_vk_api)
+    photos = await main._vkrev_fetch_photos(1, 3, None, None)
+    assert photos == ["http://v"]
+    assert calls == ["wall.getById"]
+
+
+@pytest.mark.asyncio
+async def test_doc_preview(monkeypatch):
+    async def fake_vk_api(method, params, db, bot):
+        return {
+            "response": [
+                {
+                    "attachments": [
+                        {
+                            "type": "doc",
+                            "doc": {
+                                "preview": {
+                                    "photo": {
+                                        "sizes": [
+                                            {
+                                                "width": 10,
+                                                "height": 10,
+                                                "url": "http://d",
+                                            }
+                                        ]
+                                    }
+                                }
+                            },
+                        }
+                    ]
+                }
+            ]
+        }
+
+    monkeypatch.setattr(main, "_vk_api", fake_vk_api)
+    photos = await main._vkrev_fetch_photos(1, 4, None, None)
+    assert photos == ["http://d"]
+
+
+@pytest.mark.asyncio
+async def test_dedup_and_limit(monkeypatch):
+    urls = [f"http://{i}" for i in range(12)]
+
+    def make_photo(url):
+        return {
+            "type": "photo",
+            "photo": {"sizes": [{"width": 1, "height": 1, "url": url}]},
+        }
+
+    copy_atts = [make_photo(u) for u in urls[:6]]
+    atts = [make_photo(u) for u in urls[5:]]  # overlap at url[5]
+
+    async def fake_vk_api(method, params, db, bot):
+        return {
+            "response": [
+                {
+                    "copy_history": [{"attachments": copy_atts}],
+                    "attachments": atts,
+                }
+            ]
+        }
+
+    monkeypatch.setattr(main, "_vk_api", fake_vk_api)
+    photos = await main._vkrev_fetch_photos(1, 5, None, None)
+    assert len(photos) == 10
+    assert len(set(photos)) == 10
+    assert photos[:6] == urls[:6]


### PR DESCRIPTION
## Summary
- Fetch images from reposted content, link and doc previews, and video thumbnails
- Show a short note about preview handling in VK intake docs
- Log media parsing details and tests for new attachment types

## Testing
- `pytest tests/test_vkrev_fetch_photos.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68c6a4d05b348332a9a45a65899ecb37