### PR TITLE
Show festivals landing page stats in /stats

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -268,3 +268,7 @@
 
 ## v0.3.42 - VK review media
 - VK review: поддержаны фото из репостов (copy_history), link-preview, doc-preview; для video берём только превью-картинки, видео не загружаем
+
+## v0.3.43 - Festival landing stats
+
+- `/stats` now shows view counts for the festivals landing page.

--- a/docs/COMMANDS.md
+++ b/docs/COMMANDS.md
@@ -26,7 +26,7 @@
 
 
 
-| `/stats [events]` | optional `events` | Superadmin only. Show Telegraph view counts starting from the past month and weekend pages up to all current and future ones. Festival stats include only upcoming or recently ended (within a week) festivals. Use `events` to list event page stats. |
+| `/stats [events]` | optional `events` | Superadmin only. Show Telegraph view counts starting from the past month and weekend pages up to all current and future ones. Includes the festivals landing page and stats for upcoming or recently ended (within a week) festivals. Use `events` to list event page stats. |
 | `/dumpdb` | - | Superadmin only. Download a SQL dump and `telegraph_token.txt` plus restore instructions. |
 | `/restore` | attach file | Superadmin only. Replace current database with the uploaded dump. |
 


### PR DESCRIPTION
## Summary
- track Telegraph views for the aggregated festivals landing page
- display landing page stats alongside festival and VK stats in `/stats`
- document `/stats` updates and add regression test

## Testing
- `pytest tests/test_bot.py::test_stats_pages tests/test_bot.py::test_stats_events tests/test_bot.py::test_stats_festivals -q`


------
https://chatgpt.com/codex/tasks/task_e_68c6afe253c08332922af1381552e576