### PR TITLE
VK import flow improvements and requeue command

### DIFF
--- a/tests/test_vk_persist_source_post_url.py
+++ b/tests/test_vk_persist_source_post_url.py
@@ -1,0 +1,29 @@
+import pytest
+import main
+import vk_intake
+from main import Database
+from models import Event, JobTask
+
+
+@pytest.mark.asyncio
+async def test_persist_event_and_pages_sets_source_post_url_and_skips_vk_sync(tmp_path, monkeypatch):
+    db = Database(str(tmp_path / "db.sqlite"))
+    await db.init()
+
+    tasks = []
+
+    async def fake_enqueue_job(db_, eid, task, depends_on=None, coalesce_key=None):
+        tasks.append(task)
+        return "job"
+
+    monkeypatch.setattr(main, "enqueue_job", fake_enqueue_job)
+
+    draft = vk_intake.EventDraft(title="T", date="2025-09-02", time="10:00", source_text="T")
+    res = await vk_intake.persist_event_and_pages(
+        draft, [], db, source_post_url="https://vk.com/wall-1_2"
+    )
+
+    async with db.get_session() as session:
+        ev = await session.get(Event, res.event_id)
+    assert ev.source_post_url == "https://vk.com/wall-1_2"
+    assert JobTask.vk_sync not in tasks

--- a/tests/test_vk_requeue_imported_command.py
+++ b/tests/test_vk_requeue_imported_command.py
@@ -1,0 +1,72 @@
+import os
+import sys
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+
+import pytest
+from aiogram import types
+from types import SimpleNamespace
+
+import main
+from main import Database, User
+
+
+class DummyBot:
+    def __init__(self):
+        self.messages = []
+
+    async def send_message(self, chat_id, text, **kwargs):
+        msg = SimpleNamespace(
+            message_id=len(self.messages) + 1,
+            date=0,
+            chat=SimpleNamespace(id=chat_id, type="private"),
+            from_user=SimpleNamespace(id=0, is_bot=True, first_name="B"),
+            text=text,
+            reply_markup=kwargs.get("reply_markup"),
+        )
+        self.messages.append(msg)
+        return msg
+
+
+@pytest.mark.asyncio
+async def test_vk_requeue_imported_returns_items(tmp_path):
+    db = Database(str(tmp_path / "db.sqlite"))
+    await db.init()
+    async with db.get_session() as session:
+        session.add(User(user_id=1))
+        await session.commit()
+    async with db.raw_conn() as conn:
+        await conn.execute(
+            "INSERT INTO vk_review_batch(batch_id, operator_id, months_csv) VALUES(?,?,?)",
+            ("b1", 1, "2025-09"),
+        )
+        rows = [
+            (1, 1, 0, "t", None, 1, None, "imported", "b1"),
+            (1, 2, 0, "t", None, 1, None, "imported", "b1"),
+            (1, 3, 0, "t", None, 1, None, "imported", "b1"),
+            (1, 4, 0, "t", None, 1, None, "imported", "b2"),
+        ]
+        await conn.executemany(
+            "INSERT INTO vk_inbox(group_id, post_id, date, text, matched_kw, has_date, event_ts_hint, status, review_batch) VALUES(?,?,?,?,?,?,?,?,?)",
+            rows,
+        )
+        await conn.commit()
+    msg = types.Message.model_validate(
+        {
+            "message_id": 1,
+            "date": 0,
+            "chat": {"id": 1, "type": "private"},
+            "from": {"id": 1, "is_bot": False, "first_name": "U"},
+            "text": "/vk_requeue_imported 2",
+        }
+    )
+    bot = DummyBot()
+    await main.handle_vk_requeue_imported(msg, db, bot)
+    assert bot.messages, "no message sent"
+    async with db.raw_conn() as conn:
+        cur = await conn.execute("SELECT id, status, review_batch FROM vk_inbox ORDER BY id")
+        rows = await cur.fetchall()
+    statuses = {r[0]: (r[1], r[2]) for r in rows}
+    assert statuses[3][0] == "pending"
+    assert statuses[2][0] == "pending"
+    assert statuses[1][0] == "imported"
+    assert statuses[4][0] == "imported"

--- a/vk_intake.py
+++ b/vk_intake.py
@@ -318,7 +318,7 @@ async def build_event_payload_from_vk(
 
 
 async def persist_event_and_pages(
-    draft: EventDraft, photos: list[str], db: Database
+    draft: EventDraft, photos: list[str], db: Database, source_post_url: str | None = None
 ) -> PersistResult:
     """Store a drafted event and produce all public artefacts.
 
@@ -348,6 +348,7 @@ async def persist_event_and_pages(
         ticket_link=(draft.links[0] if draft.links else None),
         photo_urls=photos,
         photo_count=len(photos),
+        source_post_url=source_post_url,
     )
 
     async with db.get_session() as session:


### PR DESCRIPTION
## Summary
- avoid auto `vk_sync` by saving VK source URL during import
- show Telegraph and ICS links to operators after VK import
- add `/vk_requeue_imported` command to return imported posts back to queue

## Testing
- `pytest tests/test_vk_persist_source_post_url.py tests/test_vk_requeue_imported_command.py tests/test_vk_queue_command.py tests/test_vk_intake_metrics.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68c6ba4b5c4c8332bef21d5e84e23907