### PR TITLE
Update source post keyboard even when ICS unchanged

### DIFF
--- a/main.py
+++ b/main.py
@@ -4234,6 +4234,12 @@ async def tg_ics_post(event_id: int, db: Database, bot: Bot, progress=None) -> b
         if ev.ics_hash == ics_hash and ev.ics_file_id and ev.ics_post_url:
             if progress:
                 progress.mark("ics_telegram", "skipped_nochange", "no change")
+            try:
+                await update_source_post_keyboard(event_id, db, bot)
+            except Exception as e:  # pragma: no cover - logging inside
+                logging.warning(
+                    "update_source_post_keyboard failed for %s: %s", event_id, e
+                )
             return False
 
         channel = await get_asset_channel(db)


### PR DESCRIPTION
## Summary
- call `update_source_post_keyboard` even when Telegram ICS post is skipped because content didn't change
- add regression test verifying keyboard update on skipped ICS post

## Testing
- `pytest tests/test_ics_pipeline.py::test_tg_ics_post_updates_source_keyboard_on_skip -q`


------
https://chatgpt.com/codex/tasks/task_e_68c6c977f938833292b5d50c75e6d512