### PR TITLE
Skip automatic VK repost for VK-origin events

### DIFF
--- a/main.py
+++ b/main.py
@@ -6274,7 +6274,9 @@ async def schedule_event_update_tasks(
         results[JobTask.festival_pages] = await enqueue_job(
             db, eid, JobTask.festival_pages
         )
-    if not is_vk_wall_url(ev.source_post_url):
+    if is_vk_wall_url(ev.source_post_url) or ev.source_vk_post_url:
+        pass
+    else:
         results[JobTask.vk_sync] = await enqueue_job(db, eid, JobTask.vk_sync)
     logging.info("scheduled event tasks for %s", eid)
     if drain_nav:
@@ -9025,6 +9027,12 @@ async def job_sync_vk_source_post(event_id: int, db: Database, bot: Bot | None) 
         raise VKPermissionError(None, "permission error")
     async with db.get_session() as session:
         ev = await session.get(Event, event_id)
+    logging.info(
+        "job_sync_vk_source_post: event_id=%s source_post_url=%s is_wall=%s",
+        event_id,
+        ev.source_post_url if ev else None,
+        is_vk_wall_url(ev.source_post_url) if ev else None,
+    )
     if not ev or is_vk_wall_url(ev.source_post_url):
         return
     new_hash = content_hash(ev.source_text or "")

--- a/tests/test_vk_persist_source_post_url.py
+++ b/tests/test_vk_persist_source_post_url.py
@@ -27,3 +27,45 @@ async def test_persist_event_and_pages_sets_source_post_url_and_skips_vk_sync(tm
         ev = await session.get(Event, res.event_id)
     assert ev.source_post_url == "https://vk.com/wall-1_2"
     assert JobTask.vk_sync not in tasks
+
+
+@pytest.mark.asyncio
+async def test_schedule_event_update_tasks_enqueues_and_runs_vk_sync(tmp_path, monkeypatch):
+    db = Database(str(tmp_path / "db.sqlite"))
+    await db.init()
+
+    tasks = []
+
+    async def fake_enqueue_job(db_, eid, task, depends_on=None, coalesce_key=None):
+        tasks.append(task)
+        return "job"
+
+    async def fake_sync_vk_source_post(ev, text, db_, bot, ics_url=None):
+        return "https://vk.com/wall-1_1"
+
+    monkeypatch.setattr(main, "enqueue_job", fake_enqueue_job)
+    monkeypatch.setattr(main, "sync_vk_source_post", fake_sync_vk_source_post)
+
+    ev = Event(
+        title="T",
+        description="",
+        festival=None,
+        date="2025-09-02",
+        time="10:00",
+        location_name="",
+        source_text="T",
+        source_post_url="http://example.com",
+    )
+
+    async with db.get_session() as session:
+        saved, _ = await main.upsert_event(session, ev)
+
+    await main.schedule_event_update_tasks(db, saved)
+
+    assert JobTask.vk_sync in tasks
+
+    await main.job_sync_vk_source_post(saved.id, db, None)
+
+    async with db.get_session() as session:
+        updated = await session.get(Event, saved.id)
+    assert updated.source_vk_post_url == "https://vk.com/wall-1_1"

--- a/tests/test_vkrev_import_flow.py
+++ b/tests/test_vkrev_import_flow.py
@@ -1,0 +1,72 @@
+import os, sys
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+
+import pytest
+from types import SimpleNamespace
+
+import main
+import vk_intake
+import vk_review
+from main import Database
+from models import Event, JobTask
+
+
+class DummyBot:
+    def __init__(self):
+        self.messages = []
+
+    async def send_message(self, chat_id, text, **kwargs):
+        self.messages.append(SimpleNamespace(chat_id=chat_id, text=text))
+        return SimpleNamespace(message_id=1)
+
+    async def send_media_group(self, chat_id, media):
+        pass
+
+
+@pytest.mark.asyncio
+async def test_vkrev_import_flow_persists_url_and_skips_vk_sync(tmp_path, monkeypatch):
+    db = Database(str(tmp_path / "db.sqlite"))
+    await db.init()
+
+    async with db.raw_conn() as conn:
+        await conn.execute(
+            "INSERT INTO vk_source(group_id, screen_name, name, location, default_time) VALUES(?,?,?,?,?)",
+            (1, "club1", "Test Community", "", None),
+        )
+        await conn.execute(
+            "INSERT INTO vk_inbox(id, group_id, post_id, date, text, matched_kw, has_date, event_ts_hint, status) VALUES(?,?,?,?,?,?,?,?,?)",
+            (1, 1, 2, 0, "text", None, 1, 0, "pending"),
+        )
+        await conn.commit()
+
+    async def fake_fetch(*args, **kwargs):
+        return []
+
+    draft = vk_intake.EventDraft(title="T", date="2025-09-02", time="10:00", source_text="T")
+
+    async def fake_build(text, source_name=None, location_hint=None, default_time=None, operator_extra=None):
+        return draft
+
+    captured = {}
+
+    async def fake_mark_imported(db_, inbox_id, batch_id, event_id, event_date):
+        captured["event_id"] = event_id
+
+    tasks = []
+
+    async def fake_enqueue_job(db_, eid, task, depends_on=None, coalesce_key=None):
+        tasks.append(task)
+        return "job"
+
+    monkeypatch.setattr(main, "_vkrev_fetch_photos", fake_fetch)
+    monkeypatch.setattr(vk_intake, "build_event_payload_from_vk", fake_build)
+    monkeypatch.setattr(vk_review, "mark_imported", fake_mark_imported)
+    monkeypatch.setattr(main, "enqueue_job", fake_enqueue_job)
+
+    bot = DummyBot()
+    await main._vkrev_import_flow(1, 1, 1, "batch1", db, bot)
+
+    async with db.get_session() as session:
+        ev = await session.get(Event, captured["event_id"])
+    assert ev.source_post_url == "https://vk.com/wall-1_2"
+    assert JobTask.vk_sync not in tasks

--- a/vk_intake.py
+++ b/vk_intake.py
@@ -353,7 +353,11 @@ async def persist_event_and_pages(
 
     async with db.get_session() as session:
         saved, _ = await upsert_event(session, event)
-
+    async with db.get_session() as session:
+        saved = await session.get(Event, saved.id)
+    logging.info(
+        "persist_event_and_pages: source_post_url=%s", saved.source_post_url
+    )
     await schedule_event_update_tasks(db, saved)
 
     async with db.get_session() as session:


### PR DESCRIPTION
## Summary
- log and persist source_post_url before scheduling event tasks
- skip vk_sync scheduling for events from or already posted to VK
- add logging and regression tests for vk review import flow

## Testing
- `pytest tests/test_vk_persist_source_post_url.py tests/test_vkrev_import_flow.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68c6da08fa248332b8b78e6cfeb48fff