### PR TITLE
feat: add VK shortpost preview and edit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -277,3 +277,9 @@
 
 - VK review reposts now use safe `wall.post` with photo IDs.
 - Added "✂️ Сокращённый рерайт" button that publishes LLM‑compressed text.
+
+## v0.3.45 - VK shortpost preview
+
+- "✂️ Сокращённый рерайт" отправляет черновик в админ-чат с кнопками
+  публикации и правки.
+- Посты больше не прикрепляют фотографии, только ссылку с превью.

--- a/docs/COMMANDS.md
+++ b/docs/COMMANDS.md
@@ -14,7 +14,7 @@
 | `/vktime today|added <HH:MM>` | required type and time | Change VK posting times (default 08:00/20:00). |
 | `/vkphotos` | - | Toggle sending images to VK posts. |
 | `↪️ Репостнуть в Vk` | - | Safe repost via `wall.post` with photo IDs. |
-| `✂️ Сокращённый рерайт` | - | Short LLM rewrite and photo IDs. |
+| `✂️ Сокращённый рерайт` | - | LLM-сжатый текст без фото, предпросмотр и правка перед публикацией. |
 | `/ask4o <text>` | any text | Send query to model 4o and show plain response (superadmin only). |
 | `/events [DATE]` | optional date `YYYY-MM-DD`, `DD.MM.YYYY` or `D месяц [YYYY]` | List events for the day with delete and edit buttons. Dates are shown as `DD.MM.YYYY`. Choosing **Edit** lists all fields with inline buttons including a toggle for "Бесплатно". |
 | `/setchannel` | - | Choose an admin channel and register it as an announcement or calendar asset source. |


### PR DESCRIPTION
## Summary
- send shortpost drafts to the admin chat with publish/edit options
- drop photo attachments from shortposts and keep only a link preview
- allow manual shortpost text edits before publishing

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c70b6cdce8833285690df940432517