### PR TITLE
Show VK shortpost drafts in operator chat

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,9 @@ them by event keywords and date patterns. Matching posts land in the persistent
 skip a candidate. Accepted items go through the standard import pipeline to
 create a Telegraph page and calendar links. After each import the admin chat
 receives links to the generated Telegraph and ICS pages, and the operator can
-manually repost the source to the Afisha VK group via a dedicated button. The
+manually repost the source to the Afisha VK group via a dedicated button. Choosing
+the ✂️ "Short post" action shows the draft with Publish/Edit buttons in the same
+chat where the operator clicked. The
 batch can be finished with "🧹 Завершить…" which sequentially rebuilds all
 affected month pages. Operators can run `/vk_queue` to see current inbox counts
 and get a button to start reviewing candidates.

--- a/tests/test_vk_shortpost.py
+++ b/tests/test_vk_shortpost.py
@@ -58,7 +58,6 @@ async def test_shortpost_wall_post(tmp_path, monkeypatch):
         await conn.commit()
     monkeypatch.setenv("VK_AFISHA_GROUP_ID", "-5")
     main.VK_AFISHA_GROUP_ID = "-5"
-    monkeypatch.setenv("ADMIN_CHAT_ID", "100")
     calls = []
     async def fake_api(method, params, db=None, bot=None, token=None, **kwargs):
         calls.append((method, params))
@@ -88,14 +87,14 @@ async def test_shortpost_wall_post(tmp_path, monkeypatch):
     )
     cb._bot = bot
     await main.handle_vk_review_cb(cb, db, bot)
-    # now simulate publish from admin chat
+    # now simulate publish from the same chat
     cb_pub = types.CallbackQuery.model_validate(
         {
             "id": "2",
             "from": {"id": 10, "is_bot": False, "first_name": "A"},
             "chat_instance": "1",
             "data": "vkrev:shortpost_pub:77",
-            "message": {"message_id": 2, "date": 0, "chat": {"id": 100, "type": "private"}},
+            "message": {"message_id": 2, "date": 0, "chat": {"id": 1, "type": "private"}},
         }
     )
     cb_pub._bot = bot
@@ -123,7 +122,6 @@ async def test_shortpost_captcha(tmp_path, monkeypatch):
         await conn.commit()
     monkeypatch.setenv("VK_AFISHA_GROUP_ID", "-5")
     main.VK_AFISHA_GROUP_ID = "-5"
-    monkeypatch.setenv("ADMIN_CHAT_ID", "100")
     async def fake_api(method, params, db=None, bot=None, token=None, **kwargs):
         raise main.VKAPIError(14, "captcha")
     monkeypatch.setattr(main, "_vk_api", fake_api)
@@ -151,7 +149,7 @@ async def test_shortpost_captcha(tmp_path, monkeypatch):
             "from": {"id": 10, "is_bot": False, "first_name": "A"},
             "chat_instance": "1",
             "data": "vkrev:shortpost_pub:77",
-            "message": {"message_id": 2, "date": 0, "chat": {"id": 100, "type": "private"}},
+            "message": {"message_id": 2, "date": 0, "chat": {"id": 1, "type": "private"}},
         }
     )
     cb_pub._bot = bot


### PR DESCRIPTION
## Summary
- send shortpost preview and controls to the operator's chat, removing ADMIN_CHAT_ID dependency
- avoid duplicate publish notifications when operator and actor chats match
- document that shortpost previews appear in the chat where the action was triggered

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68c7b87e14dc83329448245227d2bc2b