### PR TITLE
Add festival link to Telegraph source pages

### DIFF
--- a/tests/test_source_festival_link.py
+++ b/tests/test_source_festival_link.py
@@ -1,0 +1,38 @@
+import pytest
+from pathlib import Path
+
+import main
+from db import Database
+from models import Event, Festival
+
+
+@pytest.mark.asyncio
+async def test_source_page_has_festival_link(tmp_path: Path, monkeypatch):
+    db = Database(str(tmp_path / "db.sqlite"))
+    await db.init()
+
+    async with db.get_session() as session:
+        fest = Festival(name="Fest", telegraph_path="fest")
+        ev = Event(
+            title="T",
+            description="d",
+            source_text="src text",
+            date="2025-07-16",
+            time="18:00",
+            location_name="Hall",
+            festival=fest.name,
+        )
+        session.add_all([fest, ev])
+        await session.commit()
+
+    async def fake_nav(db):
+        return "<p>NAV</p>"
+
+    monkeypatch.setattr(main, "build_month_nav_html", fake_nav)
+
+    html, _, _ = await main.build_source_page_content(
+        "T", "src text", None, None, None, None, db
+    )
+    snippet = '<p>&#8203;</p><p>✨ <a href="https://telegra.ph/fest">Fest</a></p><p>&#8203;</p>'
+    assert snippet in html
+    assert html.index('✨') < html.index('<p>NAV</p>')


### PR DESCRIPTION
## Summary
- show ✨ link to festival page at end of Telegraph source text
- add regression test for festival link placement

## Testing
- `pytest tests/test_source_festival_link.py -q`
- `pytest tests/test_source_images.py -q`
- `pytest -q` *(failed: KeyboardInterrupt)*

------
https://chatgpt.com/codex/tasks/task_e_68c7d6b105c8833289fa942fd3db4179