### PR TITLE
Place festival cover image before title

### DIFF
--- a/main.py
+++ b/main.py
@@ -11287,6 +11287,10 @@ async def build_festival_page_content(db: Database, fest: Festival) -> tuple[str
                 await session.commit()
 
     nodes: list[dict] = []
+    cover = fest.photo_url or (fest.photo_urls[0] if fest.photo_urls else None)
+    if cover:
+        nodes.append({"tag": "img", "attrs": {"src": cover}})
+        nodes.append({"tag": "p", "children": ["\u00a0"]})
     if fest.program_url:
         nodes.append({"tag": "h2", "children": ["ПРОГРАММА"]})
         links = [
@@ -11316,10 +11320,6 @@ async def build_festival_page_content(db: Database, fest: Festival) -> tuple[str
             )
         nodes.extend(links)
         nodes.extend(telegraph_br())
-    cover = fest.photo_url or (fest.photo_urls[0] if fest.photo_urls else None)
-    if cover:
-        nodes.append({"tag": "img", "attrs": {"src": cover}})
-        nodes.append({"tag": "p", "children": ["\u00a0"]})
     for url in fest.photo_urls:
         if url == cover:
             continue

--- a/tests/test_festival_cover_position.py
+++ b/tests/test_festival_cover_position.py
@@ -1,0 +1,34 @@
+from pathlib import Path
+
+import pytest
+
+import main
+from db import Database
+from models import Festival
+
+
+@pytest.mark.asyncio
+async def test_festival_cover_comes_first(tmp_path: Path):
+    db = Database(str(tmp_path / "db.sqlite"))
+    await db.init()
+
+    async with db.get_session() as session:
+        fest = Festival(
+            name="Fest",
+            photo_url="https://example.com/cover.jpg",
+            program_url="https://prog",
+        )
+        session.add(fest)
+        await session.commit()
+        fid = fest.id
+
+    async with db.get_session() as session:
+        fest = await session.get(Festival, fid)
+
+    _, nodes = await main.build_festival_page_content(db, fest)
+
+    assert nodes[0]["tag"] == "img"
+    assert nodes[0]["attrs"]["src"] == "https://example.com/cover.jpg"
+    h2_idx = next(i for i, n in enumerate(nodes) if n.get("tag") == "h2")
+    assert h2_idx > 0
+


### PR DESCRIPTION
## Summary
- show festival cover image as the first element on telegraph page so it appears above the title
- add test ensuring festival cover precedes other page content

## Testing
- `pytest tests/test_festival_program.py tests/test_festival_album.py tests/test_festival_cover_position.py tests/test_telegraph_cover.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68c802475c6c833298e750af6992aae7