### PR TITLE
Handle captcha for VK short posts

### DIFF
--- a/main.py
+++ b/main.py
@@ -15608,6 +15608,9 @@ async def _vkrev_fetch_photos(group_id: int, post_id: int, db: Database, bot: Bo
             {"posts": f"-{group_id}_{post_id}"},
             db,
             bot,
+            token=VK_TOKEN_AFISHA,
+            token_kind="group",
+            skip_captcha=True,
         )
     except Exception as e:  # pragma: no cover
         logging.error("wall.getById failed gid=%s post=%s: %s", group_id, post_id, e)
@@ -16042,7 +16045,7 @@ async def _vkrev_handle_repost(callback: types.CallbackQuery, event_id: int, db:
     attachments = ",".join(photos) if photos else vk_url
     message = f"Репост: {ev.title}\n\nИсточник: {vk_url}"
     params = {
-        "owner_id": int(VK_AFISHA_GROUP_ID),
+        "owner_id": f"-{VK_AFISHA_GROUP_ID.lstrip('-')}",
         "from_group": 1,
         "message": message,
         "attachments": attachments,
@@ -16050,7 +16053,14 @@ async def _vkrev_handle_repost(callback: types.CallbackQuery, event_id: int, db:
         "signed": 0,
     }
     try:
-        data = await _vk_api("wall.post", params, db, bot, token=VK_TOKEN_AFISHA)
+        data = await _vk_api(
+            "wall.post",
+            params,
+            db,
+            bot,
+            token=VK_TOKEN_AFISHA,
+            skip_captcha=True,
+        )
         post = data.get("response", {}).get("post_id")
         if not post:
             raise RuntimeError("no post_id")
@@ -16186,7 +16196,7 @@ async def _vkrev_publish_shortpost(
         message = text
         attachments = ev.telegraph_url or vk_url
     params = {
-        "owner_id": int(VK_AFISHA_GROUP_ID),
+        "owner_id": f"-{VK_AFISHA_GROUP_ID.lstrip('-')}",
         "from_group": 1,
         "message": message,
         "attachments": attachments,
@@ -16195,7 +16205,14 @@ async def _vkrev_publish_shortpost(
     }
     operator_chat = vk_shortpost_ops.get(event_id)
     try:
-        data = await _vk_api("wall.post", params, db, bot, token=VK_TOKEN_AFISHA)
+        data = await _vk_api(
+            "wall.post",
+            params,
+            db,
+            bot,
+            token=VK_TOKEN_AFISHA,
+            skip_captcha=True,
+        )
         post = data.get("response", {}).get("post_id")
         if not post:
             raise RuntimeError("no post_id")

--- a/tests/test_vkrev_fetch_photos.py
+++ b/tests/test_vkrev_fetch_photos.py
@@ -5,11 +5,16 @@ import pytest
 
 import main
 
+main.VK_TOKEN_AFISHA = "ga"
+
 
 @pytest.mark.asyncio
 async def test_copy_history_photo(monkeypatch):
-    async def fake_vk_api(method, params, db, bot):
+    async def fake_vk_api(method, params, db, bot, **kwargs):
         assert method == "wall.getById"
+        assert kwargs.get("token_kind") == "group"
+        assert kwargs.get("token") == main.VK_TOKEN_AFISHA
+        assert kwargs.get("skip_captcha") is True
         return {
             "response": [
                 {
@@ -39,7 +44,7 @@ async def test_copy_history_photo(monkeypatch):
 
 @pytest.mark.asyncio
 async def test_link_preview(monkeypatch):
-    async def fake_vk_api(method, params, db, bot):
+    async def fake_vk_api(method, params, db, bot, **kwargs):
         return {
             "response": [
                 {
@@ -72,7 +77,7 @@ async def test_link_preview(monkeypatch):
 async def test_video_preview(monkeypatch):
     calls = []
 
-    async def fake_vk_api(method, params, db, bot):
+    async def fake_vk_api(method, params, db, bot, **kwargs):
         calls.append(method)
         return {
             "response": [
@@ -99,7 +104,7 @@ async def test_video_preview(monkeypatch):
 
 @pytest.mark.asyncio
 async def test_doc_preview(monkeypatch):
-    async def fake_vk_api(method, params, db, bot):
+    async def fake_vk_api(method, params, db, bot, **kwargs):
         return {
             "response": [
                 {
@@ -143,7 +148,7 @@ async def test_dedup_and_limit(monkeypatch):
     copy_atts = [make_photo(u) for u in urls[:6]]
     atts = [make_photo(u) for u in urls[5:]]  # overlap at url[5]
 
-    async def fake_vk_api(method, params, db, bot):
+    async def fake_vk_api(method, params, db, bot, **kwargs):
         return {
             "response": [
                 {


### PR DESCRIPTION
## Summary
- ignore existing captcha when publishing short posts and reposts
- fetch VK posts for review with group auth to avoid triggering captcha
- test coverage for captcha-skipping photo fetch

## Testing
- `pytest tests/test_vkrev_fetch_photos.py tests/test_vk_shortpost.py`

------
https://chatgpt.com/codex/tasks/task_e_68c81577d8048332830b6f4ca324d876