### PR TITLE
Wrap festival cover image in figure

### DIFF
--- a/main.py
+++ b/main.py
@@ -11289,7 +11289,12 @@ async def build_festival_page_content(db: Database, fest: Festival) -> tuple[str
     nodes: list[dict] = []
     cover = fest.photo_url or (fest.photo_urls[0] if fest.photo_urls else None)
     if cover:
-        nodes.append({"tag": "img", "attrs": {"src": cover}})
+        nodes.append(
+            {
+                "tag": "figure",
+                "children": [{"tag": "img", "attrs": {"src": cover}}],
+            }
+        )
         nodes.append({"tag": "p", "children": ["\u00a0"]})
     if fest.program_url:
         nodes.append({"tag": "h2", "children": ["ПРОГРАММА"]})

--- a/tests/test_festival_album.py
+++ b/tests/test_festival_album.py
@@ -76,5 +76,17 @@ async def test_build_festival_page_content_shows_album(tmp_path: Path):
     async with db.get_session() as session:
         fest = await session.get(Festival, fid)
     _, nodes = await main.build_festival_page_content(db, fest)
-    imgs = [n for n in nodes if n.get("tag") == "img"]
-    assert [img["attrs"]["src"] for img in imgs] == [urls[1], urls[0], urls[2]]
+
+    def _collect_img_srcs(nodes):
+        srcs = []
+        for n in nodes:
+            if n.get("tag") == "img":
+                srcs.append(n["attrs"]["src"])
+            elif n.get("tag") == "figure":
+                for ch in n.get("children", []):
+                    if isinstance(ch, dict) and ch.get("tag") == "img":
+                        srcs.append(ch["attrs"]["src"])
+        return srcs
+
+    srcs = _collect_img_srcs(nodes)
+    assert srcs == [urls[1], urls[0], urls[2]]

--- a/tests/test_festival_cover_position.py
+++ b/tests/test_festival_cover_position.py
@@ -27,8 +27,11 @@ async def test_festival_cover_comes_first(tmp_path: Path):
 
     _, nodes = await main.build_festival_page_content(db, fest)
 
-    assert nodes[0]["tag"] == "img"
-    assert nodes[0]["attrs"]["src"] == "https://example.com/cover.jpg"
+    assert nodes[0]["tag"] == "figure"
+    img = next(
+        ch for ch in nodes[0].get("children", []) if isinstance(ch, dict) and ch.get("tag") == "img"
+    )
+    assert img["attrs"]["src"] == "https://example.com/cover.jpg"
     h2_idx = next(i for i, n in enumerate(nodes) if n.get("tag") == "h2")
     assert h2_idx > 0
 


### PR DESCRIPTION
## Summary
- ensure festival page cover images are wrapped in `<figure>` so cover appears above the title on mobile
- adjust related tests to expect and handle `<figure>` wrapped covers

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c820a7c7188332a4ed42f34edf4b52