### PR TITLE
Improve short VK repost text and preview handling

### DIFF
--- a/tests/test_vk_shortpost.py
+++ b/tests/test_vk_shortpost.py
@@ -190,3 +190,56 @@ async def test_shortpost_no_time(monkeypatch):
     msg, _ = await main._vkrev_build_shortpost(ev, "https://vk.com/wall-1_1")
     assert "⏰" not in msg
     assert "[https://vk.com/wall-1_1|Источник]" in msg
+
+
+@pytest.mark.asyncio
+async def test_shortpost_midnight_time_hidden(monkeypatch):
+    async def fake_build_text(event, src, max_sent):
+        return "short summary"
+
+    async def fake_tags(event, summary):
+        return ["#a", "#b", "#c", "#d", "#e"]
+
+    monkeypatch.setattr(main, "build_short_vk_text", fake_build_text)
+    monkeypatch.setattr(main, "build_short_vk_tags", fake_tags)
+
+    ev = Event(
+        id=1,
+        title="T",
+        description="d",
+        date="2025-09-27",
+        time="00:00",
+        location_name="Place",
+        source_text="src",
+    )
+
+    msg, _ = await main._vkrev_build_shortpost(ev, "https://vk.com/wall-1_1")
+    assert "⏰" not in msg
+
+
+@pytest.mark.asyncio
+async def test_shortpost_preview_link(monkeypatch):
+    async def fake_build_text(event, src, max_sent):
+        return "short summary"
+
+    async def fake_tags(event, summary):
+        return ["#a", "#b", "#c", "#d", "#e"]
+
+    monkeypatch.setattr(main, "build_short_vk_text", fake_build_text)
+    monkeypatch.setattr(main, "build_short_vk_tags", fake_tags)
+
+    ev = Event(
+        id=1,
+        title="T",
+        description="d",
+        date="2025-09-27",
+        time="",
+        location_name="Place",
+        source_text="src",
+    )
+
+    msg, _ = await main._vkrev_build_shortpost(
+        ev, "https://vk.com/wall-1_1", for_preview=True
+    )
+    assert "[https://vk.com/wall-1_1|Источник]" not in msg
+    assert "Источник\nhttps://vk.com/wall-1_1" in msg


### PR DESCRIPTION
## Summary
- Hide default `00:00` time and show source link differently in short repost previews versus published posts
- Prompt LLM to produce paragraph-separated summaries for readability
- Show next VK queue item only after a short repost is published and add tests for midnight/preview handling

## Testing
- `pytest tests/test_vk_shortpost.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68c8260f3514833290e5122417d03bb9