### PR TITLE
Show event illustrations and Telegraph links on festival pages

### DIFF
--- a/main.py
+++ b/main.py
@@ -9958,10 +9958,13 @@ def event_title_nodes(e: Event) -> list:
     if e.emoji and not e.title.strip().startswith(e.emoji):
         nodes.append(f"{e.emoji} ")
     title_text = e.title
-    if e.source_post_url:
-        nodes.append(
-            {"tag": "a", "attrs": {"href": e.source_post_url}, "children": [title_text]}
-        )
+    url = e.telegraph_url
+    if not url and e.telegraph_path:
+        url = f"https://telegra.ph/{e.telegraph_path.lstrip('/')}"
+    if not url and e.source_post_url:
+        url = e.source_post_url
+    if url:
+        nodes.append({"tag": "a", "attrs": {"href": url}, "children": [title_text]})
     else:
         nodes.append(title_text)
     return nodes
@@ -11396,6 +11399,9 @@ async def build_festival_page_content(db: Database, fest: Festival) -> tuple[str
         nodes.extend(telegraph_br())
         nodes.append({"tag": "h3", "children": ["Мероприятия фестиваля"]})
         for e in events:
+            if e.photo_urls:
+                nodes.append({"tag": "img", "attrs": {"src": e.photo_urls[0]}})
+                nodes.append({"tag": "p", "children": ["\u00a0"]})
             nodes.extend(event_to_nodes(e, festival=fest, show_festival=False))
     else:
         nodes.extend(telegraph_br())

--- a/tests/test_festival_day_program_link.py
+++ b/tests/test_festival_day_program_link.py
@@ -1,4 +1,5 @@
 from pathlib import Path
+from datetime import datetime
 
 import pytest
 
@@ -62,6 +63,43 @@ def test_event_to_nodes_autoday_program_link():
     assert _p_has_content(nodes[2])
 
 
+def test_event_title_prefers_telegraph_link():
+    fest = Festival(name="Fest")
+    e = Event(
+        title="Day 1",
+        description="",
+        source_text="s",
+        date="2030-01-01",
+        time="10:00",
+        location_name="Loc",
+        festival="Fest",
+        telegraph_path="ev",
+        source_post_url="https://t.me/post",
+        added_at=datetime(2000, 1, 1),
+    )
+    nodes = main.event_to_nodes(e, festival=fest, show_festival=False)
+    link = nodes[0]["children"][0]
+    assert link["attrs"]["href"] == "https://telegra.ph/ev"
+
+
+def test_event_title_uses_source_post_without_telegraph():
+    fest = Festival(name="Fest")
+    e = Event(
+        title="Day 1",
+        description="",
+        source_text="s",
+        date="2030-01-01",
+        time="10:00",
+        location_name="Loc",
+        festival="Fest",
+        source_post_url="https://t.me/post",
+        added_at=datetime(2000, 1, 1),
+    )
+    nodes = main.event_to_nodes(e, festival=fest, show_festival=False)
+    link = nodes[0]["children"][0]
+    assert link["attrs"]["href"] == "https://t.me/post"
+
+
 @pytest.mark.asyncio
 async def test_build_festival_page_content_autoday(tmp_path: Path):
     db = Database(str(tmp_path / "db.sqlite"))
@@ -108,3 +146,29 @@ async def test_build_festival_page_content_autoday_no_program(tmp_path: Path):
     html = nodes_to_html(nodes)
     assert '<a href="https://prog">программа</a>' not in html
     assert '<p></p>' not in html
+
+
+@pytest.mark.asyncio
+async def test_build_festival_page_content_event_image_and_link(tmp_path: Path):
+    db = Database(str(tmp_path / "db.sqlite"))
+    await db.init()
+    async with db.get_session() as session:
+        fest = Festival(name="Fest", description="d")
+        ev = Event(
+            title="Day 1",
+            description="",
+            source_text="s",
+            date="2030-01-01",
+            time="10:00",
+            location_name="Loc",
+            festival="Fest",
+            telegraph_path="ev",
+            photo_urls=["https://example.com/img.jpg"],
+        )
+        session.add(fest)
+        session.add(ev)
+        await session.commit()
+    _, nodes = await main.build_festival_page_content(db, fest)
+    html = nodes_to_html(nodes)
+    assert '<img src="https://example.com/img.jpg"' in html
+    assert '<a href="https://telegra.ph/ev">Day 1</a>' in html


### PR DESCRIPTION
## Summary
- Prefer Telegraph URLs over Telegram posts for event titles
- Display an event's first image above its entry on festival pages
- Cover new behavior with tests

## Testing
- `pytest tests/test_festival_day_program_link.py -q`
- `pytest tests/test_festival_day_program_link.py::test_event_title_prefers_telegraph_link -q`
- `pytest tests/test_festival_day_program_link.py::test_event_title_uses_source_post_without_telegraph -q`
- `pytest tests/test_festival_day_program_link.py::test_build_festival_page_content_event_image_and_link -q`
- ⚠️ `pytest` *(interrupted: KeyboardInterrupt)*

------
https://chatgpt.com/codex/tasks/task_e_68c82d2c1ad08332a676696696f060a8