### PR TITLE
Show event illustrations and Telegraph links on festival pages

### DIFF
--- a/main.py
+++ b/main.py
@@ -9958,10 +9958,13 @@ def event_title_nodes(e: Event) -> list:
     if e.emoji and not e.title.strip().startswith(e.emoji):
         nodes.append(f"{e.emoji} ")
     title_text = e.title
-    if e.source_post_url:
-        nodes.append(
-            {"tag": "a", "attrs": {"href": e.source_post_url}, "children": [title_text]}
-        )
+    url = e.telegraph_url
+    if not url and e.telegraph_path:
+        url = f"https://telegra.ph/{e.telegraph_path.lstrip('/')}"
+    if not url and e.source_post_url:
+        url = e.source_post_url
+    if url:
+        nodes.append({"tag": "a", "attrs": {"href": url}, "children": [title_text]})
     else:
         nodes.append(title_text)
     return nodes
@@ -11287,7 +11290,9 @@ async def build_festival_page_content(db: Database, fest: Festival) -> tuple[str
                 await session.commit()
 
     nodes: list[dict] = []
-    cover = fest.photo_url or (fest.photo_urls[0] if fest.photo_urls else None)
+    photo_urls = list(fest.photo_urls or [])
+    cover = fest.photo_url or (photo_urls[0] if photo_urls else None)
+    gallery_photos = [url for url in photo_urls if url != cover]
     if cover:
         nodes.append(
             {
@@ -11325,11 +11330,6 @@ async def build_festival_page_content(db: Database, fest: Festival) -> tuple[str
             )
         nodes.extend(links)
         nodes.extend(telegraph_br())
-    for url in fest.photo_urls:
-        if url == cover:
-            continue
-        nodes.append({"tag": "img", "attrs": {"src": url}})
-        nodes.append({"tag": "p", "children": ["\u00a0"]})
     start, end = festival_dates(fest, events)
     if start:
         date_text = format_day_pretty(start)
@@ -11401,6 +11401,11 @@ async def build_festival_page_content(db: Database, fest: Festival) -> tuple[str
         nodes.extend(telegraph_br())
         nodes.extend(telegraph_br())
         nodes.append({"tag": "p", "children": ["Расписание скоро обновим"]})
+    if gallery_photos:
+        nodes.extend(telegraph_br())
+        for url in gallery_photos:
+            nodes.append({"tag": "img", "attrs": {"src": url}})
+            nodes.append({"tag": "p", "children": ["\u00a0"]})
     nav_nodes, _ = await _build_festival_nav_block(db, exclude=fest.name)
     if nav_nodes:
         from telegraph.utils import nodes_to_html, html_to_nodes

--- a/tests/test_festival_day_program_link.py
+++ b/tests/test_festival_day_program_link.py
@@ -1,4 +1,5 @@
 from pathlib import Path
+from datetime import datetime
 
 import pytest
 
@@ -62,6 +63,43 @@ def test_event_to_nodes_autoday_program_link():
     assert _p_has_content(nodes[2])
 
 
+def test_event_title_prefers_telegraph_link():
+    fest = Festival(name="Fest")
+    e = Event(
+        title="Day 1",
+        description="",
+        source_text="s",
+        date="2030-01-01",
+        time="10:00",
+        location_name="Loc",
+        festival="Fest",
+        telegraph_path="ev",
+        source_post_url="https://t.me/post",
+        added_at=datetime(2000, 1, 1),
+    )
+    nodes = main.event_to_nodes(e, festival=fest, show_festival=False)
+    link = nodes[0]["children"][0]
+    assert link["attrs"]["href"] == "https://telegra.ph/ev"
+
+
+def test_event_title_uses_source_post_without_telegraph():
+    fest = Festival(name="Fest")
+    e = Event(
+        title="Day 1",
+        description="",
+        source_text="s",
+        date="2030-01-01",
+        time="10:00",
+        location_name="Loc",
+        festival="Fest",
+        source_post_url="https://t.me/post",
+        added_at=datetime(2000, 1, 1),
+    )
+    nodes = main.event_to_nodes(e, festival=fest, show_festival=False)
+    link = nodes[0]["children"][0]
+    assert link["attrs"]["href"] == "https://t.me/post"
+
+
 @pytest.mark.asyncio
 async def test_build_festival_page_content_autoday(tmp_path: Path):
     db = Database(str(tmp_path / "db.sqlite"))
@@ -108,3 +146,48 @@ async def test_build_festival_page_content_autoday_no_program(tmp_path: Path):
     html = nodes_to_html(nodes)
     assert '<a href="https://prog">программа</a>' not in html
     assert '<p></p>' not in html
+
+
+@pytest.mark.asyncio
+async def test_build_festival_page_content_event_gallery_order(tmp_path: Path):
+    db = Database(str(tmp_path / "db.sqlite"))
+    await db.init()
+    async with db.get_session() as session:
+        fest = Festival(
+            name="Fest",
+            description="d",
+            photo_urls=[
+                "https://example.com/cover.jpg",
+                "https://example.com/gallery.jpg",
+            ],
+        )
+        ev = Event(
+            title="Day 1",
+            description="",
+            source_text="s",
+            date="2030-01-01",
+            time="10:00",
+            location_name="Loc",
+            festival="Fest",
+            telegraph_path="ev",
+            photo_urls=["https://example.com/img.jpg"],
+        )
+        other = Festival(
+            name="Other",
+            description="o",
+            start_date="2030-01-05",
+            end_date="2030-01-06",
+        )
+        session.add(fest)
+        session.add(ev)
+        session.add(other)
+        await session.commit()
+    _, nodes = await main.build_festival_page_content(db, fest)
+    html = nodes_to_html(nodes)
+    assert '<img src="https://example.com/img.jpg"' not in html
+    assert '<a href="https://telegra.ph/ev">Day 1</a>' in html
+    cover_idx = html.index("https://example.com/cover.jpg")
+    events_idx = html.index("Мероприятия фестиваля")
+    gallery_idx = html.index("https://example.com/gallery.jpg")
+    nav_idx = html.index("Ближайшие фестивали")
+    assert cover_idx < events_idx < gallery_idx < nav_idx


### PR DESCRIPTION
## Summary
- Prefer Telegraph URLs over Telegram posts for event titles
- Restore festival event lists without inline images and move festival galleries below the schedule
- Cover layout updates with tests

## Testing
- `pytest tests/test_festival_day_program_link.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68c82d2c1ad08332a676696696f060a8