### PR TITLE
Remove event illustrations from festival event list

### DIFF
--- a/main.py
+++ b/main.py
@@ -11396,9 +11396,6 @@ async def build_festival_page_content(db: Database, fest: Festival) -> tuple[str
         nodes.extend(telegraph_br())
         nodes.append({"tag": "h3", "children": ["Мероприятия фестиваля"]})
         for e in events:
-            if e.photo_urls:
-                nodes.append({"tag": "img", "attrs": {"src": e.photo_urls[0]}})
-                nodes.append({"tag": "p", "children": ["\u00a0"]})
             nodes.extend(event_to_nodes(e, festival=fest, show_festival=False))
     else:
         nodes.extend(telegraph_br())


### PR DESCRIPTION
## Summary
- stop adding the first event photo to the festival page event list so only the event content remains

## Testing
- pytest tests/test_festival_day_program_link.py

------
https://chatgpt.com/codex/tasks/task_e_68c83c02de10833298b4536cc91fb610