### PR TITLE
Handle VK short rewrite fallback when LLM requests text

### DIFF
--- a/tests/test_short_rewrite.py
+++ b/tests/test_short_rewrite.py
@@ -1,0 +1,58 @@
+import os, sys
+from types import SimpleNamespace
+
+import pytest
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+
+import main
+
+
+@pytest.mark.asyncio
+async def test_build_short_vk_text_uses_description_when_source_missing(monkeypatch):
+    calls = {}
+
+    async def fake_ask(prompt, **kwargs):
+        calls["prompt"] = prompt
+        return "Сжатый текст. Второе предложение."
+
+    monkeypatch.setattr(main, "ask_4o", fake_ask)
+
+    event = SimpleNamespace(
+        description="Длинное описание события. Подробности о программе и времени.",
+        title="Название события",
+    )
+
+    result = await main.build_short_vk_text(event, "", max_sentences=2)
+
+    assert "Длинное описание события" in calls["prompt"]
+    assert result == "Сжатый текст. Второе предложение."
+
+
+@pytest.mark.asyncio
+async def test_build_short_vk_text_falls_back_to_title(monkeypatch):
+    async def fake_ask(*args, **kwargs):  # pragma: no cover - should not be called
+        raise AssertionError("ask_4o should not be called when only title is available")
+
+    monkeypatch.setattr(main, "ask_4o", fake_ask)
+
+    event = SimpleNamespace(description="", title="Лаконичное событие")
+
+    result = await main.build_short_vk_text(event, "", max_sentences=3)
+
+    assert result == "Лаконичное событие"
+
+
+@pytest.mark.asyncio
+async def test_build_short_vk_text_handles_missing_text_reply(monkeypatch):
+    async def fake_ask(prompt, **kwargs):
+        return "Пожалуйста, предоставьте текст, который нужно сократить."
+
+    monkeypatch.setattr(main, "ask_4o", fake_ask)
+
+    event = SimpleNamespace(description="", title="Название события")
+    original = "Первое предложение. Второе предложение. Третье предложение."
+
+    result = await main.build_short_vk_text(event, original, max_sentences=3)
+
+    assert result == "Первое предложение. Второе предложение."

--- a/vk_intake.py
+++ b/vk_intake.py
@@ -296,6 +296,12 @@ async def build_event_payload_from_vk(
         raise RuntimeError("LLM returned no event")
     data = parsed[0]
 
+    combined_text = text or ""
+    extra_clean = (operator_extra or "").strip()
+    if extra_clean:
+        trimmed = combined_text.rstrip()
+        combined_text = f"{trimmed}\n\n{extra_clean}" if trimmed else extra_clean
+
     price: str | None = None
     if data.get("ticket_price_min") or data.get("ticket_price_max"):
         lo = data.get("ticket_price_min")
@@ -313,7 +319,7 @@ async def build_event_payload_from_vk(
         venue=data.get("location_name"),
         price=price,
         links=links,
-        source_text=text,
+        source_text=combined_text,
     )
 
 


### PR DESCRIPTION
## Summary
- add a local fallback helper for the VK short rewrite so we can recover when the LLM replies with a request for more text
- treat "please provide text" style answers as failures and fall back to the naive sentence truncation
- cover the regression with a unit test that simulates the empty LLM response

## Testing
- pytest tests/test_vkrev_import_flow.py tests/test_short_rewrite.py

------
https://chatgpt.com/codex/tasks/task_e_68c83fd28e948332a1e33ccc8a910ee7