### PR TITLE
Allow shortpost publish without photos

### DIFF
--- a/tests/test_vk_shortpost.py
+++ b/tests/test_vk_shortpost.py
@@ -89,17 +89,27 @@ async def test_shortpost_wall_post(tmp_path, monkeypatch):
     monkeypatch.setenv("VK_AFISHA_GROUP_ID", "-5")
     main.VK_AFISHA_GROUP_ID = "-5"
     calls = []
+
     async def fake_api(method, params, db=None, bot=None, token=None, **kwargs):
         calls.append((method, params))
+        if method == "wall.getById":
+            return {
+                "response": [
+                    {
+                        "attachments": [
+                            {"type": "photo", "photo": {"owner_id": 1, "id": 2}},
+                        ]
+                    }
+                ]
+            }
         if method == "wall.post":
             assert params["from_group"] == 1
-            assert params["attachments"] == "https://t"
+            assert params["attachments"] == "photo1_2,https://t"
             assert len(params["message"]) <= 4096
             tags = [w for w in params["message"].split() if w.startswith("#")]
             assert 5 <= len(tags) <= 7
             return {"response": {"post_id": 42}}
-        else:
-            raise AssertionError
+        raise AssertionError
     monkeypatch.setattr(main, "_vk_api", fake_api)
     async def fake_build(event, src, max_sent):
         return "short"
@@ -142,6 +152,81 @@ async def test_shortpost_wall_post(tmp_path, monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_shortpost_publish_without_photo(tmp_path, monkeypatch):
+    db = Database(str(tmp_path / "db.sqlite"))
+    await db.init()
+    async with db.raw_conn() as conn:
+        await conn.execute(
+            "INSERT INTO vk_inbox(id, group_id, post_id, date, text, matched_kw, has_date, status, imported_event_id, review_batch) VALUES(?,?,?,?,?,?,?,?,?,?)",
+            (1, 1, 2, 0, "text", None, 1, "imported", 77, "b"),
+        )
+        await conn.execute(
+            "INSERT INTO event(id, title, description, date, time, location_name, city, source_text, telegraph_url) VALUES(?,?,?,?,?,?,?,?,?)",
+            (77, "Test", "d", "2025-09-27", "19:00", "Place", "City", "source", "https://t"),
+        )
+        await conn.commit()
+    monkeypatch.setenv("VK_AFISHA_GROUP_ID", "-5")
+    main.VK_AFISHA_GROUP_ID = "-5"
+
+    async def fake_api(method, params, db=None, bot=None, token=None, **kwargs):
+        if method == "wall.getById":
+            return {"response": []}
+        if method == "wall.post":
+            assert "attachments" not in params
+            return {"response": {"post_id": 43}}
+        raise AssertionError
+
+    monkeypatch.setattr(main, "_vk_api", fake_api)
+
+    async def fake_build(event, src, max_sent):
+        return "short"
+
+    monkeypatch.setattr(main, "build_short_vk_text", fake_build)
+
+    async def fake_ask(prompt, **kwargs):
+        return "#a #b #c #d #e"
+
+    monkeypatch.setattr(main, "ask_4o", fake_ask)
+
+    bot = DummyBot()
+
+    async def fake_answer(self, *args, **kwargs):
+        return None
+
+    monkeypatch.setattr(types.CallbackQuery, "answer", fake_answer)
+
+    cb = types.CallbackQuery.model_validate(
+        {
+            "id": "1",
+            "from": {"id": 1, "is_bot": False, "first_name": "U"},
+            "chat_instance": "1",
+            "data": "vkrev:shortpost:77",
+            "message": {"message_id": 1, "date": 0, "chat": {"id": 1, "type": "private"}},
+        }
+    )
+    cb._bot = bot
+    await main.handle_vk_review_cb(cb, db, bot)
+
+    cb_pub = types.CallbackQuery.model_validate(
+        {
+            "id": "2",
+            "from": {"id": 10, "is_bot": False, "first_name": "A"},
+            "chat_instance": "1",
+            "data": "vkrev:shortpost_pub:77",
+            "message": {"message_id": 2, "date": 0, "chat": {"id": 1, "type": "private"}},
+        }
+    )
+    cb_pub._bot = bot
+    await main.handle_vk_review_cb(cb_pub, db, bot)
+
+    assert any("✅ Опубликовано" in m.text for m in bot.messages)
+
+    async with db.get_session() as session:
+        ev = await session.get(Event, 77)
+        assert ev.vk_repost_url == "https://vk.com/wall-5_43"
+
+
+@pytest.mark.asyncio
 async def test_shortpost_captcha(tmp_path, monkeypatch):
     db = Database(str(tmp_path / "db.sqlite"))
     await db.init()
@@ -158,6 +243,16 @@ async def test_shortpost_captcha(tmp_path, monkeypatch):
     monkeypatch.setenv("VK_AFISHA_GROUP_ID", "-5")
     main.VK_AFISHA_GROUP_ID = "-5"
     async def fake_api(method, params, db=None, bot=None, token=None, **kwargs):
+        if method == "wall.getById":
+            return {
+                "response": [
+                    {
+                        "attachments": [
+                            {"type": "photo", "photo": {"owner_id": 1, "id": 2}}
+                        ]
+                    }
+                ]
+            }
         raise main.VKAPIError(14, "captcha")
     monkeypatch.setattr(main, "_vk_api", fake_api)
     async def fake_build(event, src, max_sent):


### PR DESCRIPTION
## Summary
- avoid adding link-only attachments to VK shortposts when no photos are available so the publish request succeeds without media
- keep attaching the source link alongside any collected photos to preserve previews when media is present
- add a regression test covering the photo-less publish fallback

## Testing
- pytest tests/test_vk_shortpost.py

------
https://chatgpt.com/codex/tasks/task_e_68c85ab861ec83329784643a0ea9956b