### PR TITLE
Handle stale VK queue locks and add finish prompt

### DIFF
--- a/tests/test_vk_queue_command.py
+++ b/tests/test_vk_queue_command.py
@@ -46,6 +46,10 @@ async def test_handle_vk_queue_shows_counts_and_button(tmp_path):
             "INSERT INTO vk_inbox(group_id, post_id, date, text, matched_kw, has_date, event_ts_hint, status) VALUES(?,?,?,?,?,?,?,?)",
             rows,
         )
+        await conn.execute(
+            "UPDATE vk_inbox SET locked_by=?, locked_at=CURRENT_TIMESTAMP WHERE post_id=?",
+            (1, 3),
+        )
         await conn.commit()
     msg = types.Message.model_validate(
         {

--- a/tests/test_vk_review_show_next.py
+++ b/tests/test_vk_review_show_next.py
@@ -4,6 +4,8 @@ sys.path.append(os.path.dirname(os.path.dirname(__file__)))
 import pytest
 from types import SimpleNamespace
 
+from aiogram import types
+
 import main
 from main import Database, User
 
@@ -57,3 +59,106 @@ async def test_vkrev_show_next_adds_blank_line_and_group_name(tmp_path, monkeypa
     assert lines[1] == "Test Community"
     assert lines[2] == ""  # blank line before the link
     assert lines[3] == "https://vk.com/wall-1_10"
+
+
+@pytest.mark.asyncio
+async def test_vkrev_show_next_prompts_finish_on_empty_queue(tmp_path):
+    db = Database(str(tmp_path / "db.sqlite"))
+    await db.init()
+    async with db.get_session() as session:
+        session.add(User(user_id=1))
+        await session.commit()
+    async with db.raw_conn() as conn:
+        await conn.execute(
+            "INSERT INTO vk_review_batch(batch_id, operator_id, months_csv) VALUES(?,?,?)",
+            ("batch1", 1, "2025-09"),
+        )
+        await conn.commit()
+    bot = DummyBot()
+    await main._vkrev_show_next(1, "batch1", 1, db, bot)
+    assert len(bot.messages) == 2
+    empty_msg, finish_msg = bot.messages
+    assert empty_msg.text == "Очередь пуста"
+    assert isinstance(finish_msg.reply_markup, types.InlineKeyboardMarkup)
+    button = finish_msg.reply_markup.inline_keyboard[0][0]
+    assert button.callback_data == "vkrev:finish:batch1"
+    assert button.text.startswith("🧹 Завершить")
+    assert "обновления" in finish_msg.text.lower()
+
+
+@pytest.mark.asyncio
+async def test_handle_vk_check_creates_new_batch(tmp_path, monkeypatch):
+    db = Database(str(tmp_path / "db.sqlite"))
+    await db.init()
+    async with db.get_session() as session:
+        session.add(User(user_id=1))
+        await session.commit()
+
+    captured: dict[str, str] = {}
+
+    async def fake_show_next(chat_id, batch_id, operator_id, db_obj, bot_obj):
+        captured["batch_id"] = batch_id
+        captured["operator_id"] = operator_id
+
+    monkeypatch.setattr(main, "_vkrev_show_next", fake_show_next)
+
+    msg = types.Message.model_validate(
+        {
+            "message_id": 1,
+            "date": 0,
+            "chat": {"id": 1, "type": "private"},
+            "from": {"id": 1, "is_bot": False, "first_name": "U"},
+            "text": "🔎 Проверить события",
+        }
+    )
+
+    bot = DummyBot()
+    await main.handle_vk_check(msg, db, bot)
+    assert captured["operator_id"] == 1
+    assert captured["batch_id"].endswith(":1")
+    async with db.raw_conn() as conn:
+        cur = await conn.execute("SELECT batch_id FROM vk_review_batch")
+        rows = await cur.fetchall()
+    assert len(rows) == 1 and rows[0][0] == captured["batch_id"]
+
+
+@pytest.mark.asyncio
+async def test_handle_vk_check_reuses_existing_batch(tmp_path, monkeypatch):
+    db = Database(str(tmp_path / "db.sqlite"))
+    await db.init()
+    async with db.get_session() as session:
+        session.add(User(user_id=1))
+        await session.commit()
+    async with db.raw_conn() as conn:
+        await conn.execute(
+            "INSERT INTO vk_review_batch(batch_id, operator_id, months_csv) VALUES(?,?,?)",
+            ("existing", 1, "2025-09"),
+        )
+        await conn.commit()
+
+    captured: dict[str, str] = {}
+
+    async def fake_show_next(chat_id, batch_id, operator_id, db_obj, bot_obj):
+        captured["batch_id"] = batch_id
+        captured["operator_id"] = operator_id
+
+    monkeypatch.setattr(main, "_vkrev_show_next", fake_show_next)
+
+    msg = types.Message.model_validate(
+        {
+            "message_id": 1,
+            "date": 0,
+            "chat": {"id": 1, "type": "private"},
+            "from": {"id": 1, "is_bot": False, "first_name": "U"},
+            "text": "🔎 Проверить события",
+        }
+    )
+
+    bot = DummyBot()
+    await main.handle_vk_check(msg, db, bot)
+    assert captured["operator_id"] == 1
+    assert captured["batch_id"] == "existing"
+    async with db.raw_conn() as conn:
+        cur = await conn.execute("SELECT COUNT(*) FROM vk_review_batch")
+        (count,) = await cur.fetchone()
+    assert count == 1


### PR DESCRIPTION
## Summary
- automatically return stale VK inbox locks to the pending queue and resume locks held by the current operator so previously stuck posts can be reviewed
- reuse existing review batches when reopening the queue and show a finish button when the queue is empty but months still need to be rebuilt
- extend the VK queue tests to cover the new behaviours, including the finish prompt and lock handling helpers

## Testing
- pytest tests/test_vk_review.py tests/test_vk_review_show_next.py tests/test_vk_queue_command.py

------
https://chatgpt.com/codex/tasks/task_e_68c871f87294833287b9749b62f6cf8c