### PR TITLE
Fix VK review batch tracking and rebuild reporting

### DIFF
--- a/tests/test_vkrev_import_flow.py
+++ b/tests/test_vkrev_import_flow.py
@@ -49,7 +49,9 @@ async def test_vkrev_import_flow_persists_url_and_skips_vk_sync(tmp_path, monkey
 
     captured = {}
 
-    async def fake_mark_imported(db_, inbox_id, batch_id, event_id, event_date):
+    async def fake_mark_imported(
+        db_, inbox_id, batch_id, operator_id, event_id, event_date
+    ):
         captured["event_id"] = event_id
 
     tasks = []


### PR DESCRIPTION
## Summary
- ensure vk_review.mark_imported recreates missing batches, records months, and resets finished_at before rebuilds
- pass the operator id when recording imports and relay detailed month rebuild reports to the review chat
- cover the new flow with unit tests, including batch auto-creation and updated mocks

## Testing
- pytest tests/test_vk_review.py
- pytest tests/test_vkrev_import_flow.py::test_vkrev_import_flow_persists_url_and_skips_vk_sync
- pytest tests/test_pages_rebuild_report.py::test_pages_rebuild_report_errors

------
https://chatgpt.com/codex/tasks/task_e_68c87c43f95c8332bb924cf5bb601917