### PR TITLE
Allow exhibitions without explicit start date

### DIFF
--- a/main.py
+++ b/main.py
@@ -6677,6 +6677,10 @@ async def add_events_from_text(
 
         addr = data.get("location_address")
         city = data.get("city")
+        event_type_raw = data.get("event_type")
+        event_type_name = (
+            event_type_raw.casefold() if isinstance(event_type_raw, str) else ""
+        )
         title = (data.get("title") or "").strip()
         time_str = (data.get("time") or "").strip()
         location_name = (data.get("location_name") or "").strip()
@@ -6688,6 +6692,9 @@ async def add_events_from_text(
         if not city:
             city = "Калининград"
         addr = strip_city_from_address(addr, city)
+        allow_missing_date = bool(end_date and event_type_name == "выставка")
+        if allow_missing_date and not date_str:
+            date_str = datetime.now(LOCAL_TZ).date().isoformat()
         missing = missing_fields(
             {
                 "title": title,


### PR DESCRIPTION
## Summary
- allow exhibitions parsed with only an end date to default their start date to the current day during import
- keep the missing-field validation from rejecting such exhibitions and persist them normally
- add a regression test covering adding and displaying an exhibition defined only by its end date

## Testing
- pytest -q tests/test_bot.py::test_add_events_from_text_adds_exhibition_with_end_only


------
https://chatgpt.com/codex/tasks/task_e_68c93e8b7d2c8332b5cce2e2118dfa20