### PR TITLE
Add VK service token support and throttling

### DIFF
--- a/.env
+++ b/.env
@@ -1,2 +1,5 @@
 TELEGRAPH_AUTHOR_NAME="Полюбить Калининград Анонсы"
 TELEGRAPH_AUTHOR_URL="https://t.me/kenigevents"
+VK_SERVICE_TOKEN=
+VK_READ_VIA_SERVICE=true
+VK_MIN_INTERVAL_MS=350

--- a/README.md
+++ b/README.md
@@ -74,6 +74,12 @@ browse upcoming announcements. The command accepts dates like `2025-07-10`,
   # Group tokens
   export VK_TOKEN=vk_group_token
   export VK_TOKEN_AFISHA=vk_afisha_group_token
+  # Optional: server-side token for read-only VK calls
+  export VK_SERVICE_TOKEN=vk_service_token
+  # Optional: disable service token reads (default true)
+  export VK_READ_VIA_SERVICE=true
+  # Optional: throttle VK requests (ms between calls, default 350)
+  export VK_MIN_INTERVAL_MS=350
   # Optional: override VK API version (default 5.199)
   export VK_API_VERSION=5.199
   # Optional: max photos per VK post (default 10)
@@ -116,6 +122,14 @@ By default the crawler uses regular-expression stems to detect event keywords.
 Setting `VK_USE_PYMORPHY=true` (and installing `pymorphy3`) switches matching to
 lemmatised forms for better coverage of Russian morphology.
 
+## Service token
+
+A VK service (server) token helps keep read-only API traffic away from the user token.
+
+- **Why?** Crawling and preparing reposts rely on `wall.get*` and similar methods; using the service token reduces captcha prompts on these safe reads.
+- **How do I enable it?** Set the `VK_SERVICE_TOKEN` secret and keep `VK_READ_VIA_SERVICE=true` (the default). Without the secret the bot behaves as before.
+- **What does it cover?** Only public, read-only endpoints such as `utils.resolveScreenName`, `groups.getById`, `wall.get`, `wall.getById`, `photos.getById`, and `video.get*`. Publishing still uses user/group tokens.
+
 ## Deployment on Fly.io
 
 1. Initialize app (once):
@@ -144,6 +158,10 @@ lemmatised forms for better coverage of Russian morphology.
    # Group tokens
    fly secrets set VK_TOKEN=<token>
    fly secrets set VK_TOKEN_AFISHA=<token>
+   # Optional: server-side token for read-only VK calls
+   fly secrets set VK_SERVICE_TOKEN=<token>
+   fly secrets set VK_READ_VIA_SERVICE=true
+   fly secrets set VK_MIN_INTERVAL_MS=350
    # Optional: max photos per VK post
    fly secrets set VK_MAX_ATTACHMENTS=10
    # Sending images to VK is disabled by default. Toggle with /vkphotos.

--- a/main.py
+++ b/main.py
@@ -315,6 +315,30 @@ SUPABASE_BUCKET = os.getenv("SUPABASE_BUCKET", "events-ics")
 VK_TOKEN = os.getenv("VK_TOKEN")
 VK_TOKEN_AFISHA = os.getenv("VK_TOKEN_AFISHA")  # NEW
 VK_USER_TOKEN = os.getenv("VK_USER_TOKEN")
+VK_SERVICE_TOKEN = os.getenv("VK_SERVICE_TOKEN")
+VK_READ_VIA_SERVICE = os.getenv("VK_READ_VIA_SERVICE", "true").lower() == "true"
+VK_MIN_INTERVAL_MS = int(os.getenv("VK_MIN_INTERVAL_MS", "350"))
+_last_vk_call = 0.0
+
+
+async def _vk_throttle() -> None:
+    global _last_vk_call
+    now = _time.monotonic()
+    wait = (_last_vk_call + VK_MIN_INTERVAL_MS / 1000) - now
+    if wait > 0:
+        await asyncio.sleep(wait)
+    _last_vk_call = _time.monotonic()
+
+
+VK_SERVICE_READ_METHODS = {
+    "utils.resolveScreenName",
+    "groups.getById",
+    "wall.get",
+    "wall.getById",
+    "photos.getById",
+}
+VK_SERVICE_READ_PREFIXES = ("video.get",)
+
 VK_MAIN_GROUP_ID = os.getenv("VK_MAIN_GROUP_ID")
 VK_AFISHA_GROUP_ID = os.getenv("VK_AFISHA_GROUP_ID")
 VK_API_VERSION = os.getenv("VK_API_VERSION", "5.199")
@@ -360,12 +384,13 @@ VK_CAPTCHA_QUIET = os.getenv("VK_CAPTCHA_QUIET", "")
 VK_CRAWL_JITTER_SEC = int(os.getenv("VK_CRAWL_JITTER_SEC", "600"))
 
 logging.info(
-    "vk.config groups: main=-%s, afisha=-%s; user_token=%s, token_main=%s, token_afisha=%s",
+    "vk.config groups: main=-%s, afisha=-%s; user_token=%s, token_main=%s, token_afisha=%s, service_token=%s",
     VK_MAIN_GROUP_ID,
     VK_AFISHA_GROUP_ID,
     "present" if VK_USER_TOKEN else "missing",
     "present" if VK_TOKEN else "missing",
     "present" if VK_TOKEN_AFISHA else "missing",
+    "present" if VK_SERVICE_TOKEN else "missing",
 )
 
 
@@ -1453,13 +1478,22 @@ def _vk_user_token() -> str | None:
 
 async def vk_api(method: str, **params: Any) -> Any:
     """Simple VK API GET request with token and version."""
-    token = VK_USER_TOKEN or VK_TOKEN or VK_TOKEN_AFISHA
+    service_allowed = method in VK_SERVICE_READ_METHODS or any(
+        method.startswith(prefix) for prefix in VK_SERVICE_READ_PREFIXES
+    )
+    if VK_READ_VIA_SERVICE and VK_SERVICE_TOKEN and service_allowed:
+        token = VK_SERVICE_TOKEN
+        actor = "service"
+    else:
+        token = VK_USER_TOKEN or VK_TOKEN or VK_TOKEN_AFISHA
+        actor = "user/group"
     if not token:
         raise RuntimeError("VK token not set")
     call_params = params.copy()
     call_params["access_token"] = token
     call_params["v"] = VK_API_VERSION
     async with VK_SEMAPHORE:
+        await _vk_throttle()
         resp = await http_call(
             f"vk.{method}",
             "GET",
@@ -1467,6 +1501,7 @@ async def vk_api(method: str, **params: Any) -> Any:
             timeout=HTTP_TIMEOUT,
             params=call_params,
         )
+    logging.info("vk.actor=%s method=%s", actor, method)
     data = resp.json()
     if "error" in data:
         err = data["error"]
@@ -1682,6 +1717,7 @@ async def _vk_api(
         last_msg: str | None = None
         for attempt, delay in enumerate(BACKOFF_DELAYS, start=1):
             async with VK_SEMAPHORE:
+                await _vk_throttle()
                 async with span("vk-send"):
                     data = await asyncio.wait_for(_call(), HTTP_TIMEOUT)
             if "error" not in data:
@@ -15626,23 +15662,8 @@ async def _vkrev_queue_size(db: Database) -> int:
 
 
 async def _vkrev_fetch_photos(group_id: int, post_id: int, db: Database, bot: Bot) -> list[str]:
-    user_token = _vk_user_token()
-    if not user_token:
-        logging.error(
-            "VK_USER_TOKEN missing, cannot fetch photos gid=%s post=%s",
-            group_id,
-            post_id,
-        )
-        return []
     try:
-        data = await _vk_api(
-            "wall.getById",
-            {"posts": f"-{group_id}_{post_id}"},
-            db,
-            bot,
-            token=user_token,
-            token_kind="user",
-        )
+        response = await vk_api("wall.getById", posts=f"-{group_id}_{post_id}")
     except Exception as e:  # pragma: no cover
         logging.error("wall.getById failed gid=%s post=%s: %s", group_id, post_id, e)
         return []
@@ -15652,7 +15673,10 @@ async def _vkrev_fetch_photos(group_id: int, post_id: int, db: Database, bot: Bo
         best = max(sizes, key=lambda s: s.get("width", 0) * s.get("height", 0))
         return best.get("url") or best.get("src", "")
 
-    items = data.get("response") or []
+    if isinstance(response, dict):
+        items = response.get("items") or []
+    else:
+        items = response or []
     photos: list[str] = []
     seen: set[str] = set()
 

--- a/tests/test_vkrev_fetch_photos.py
+++ b/tests/test_vkrev_fetch_photos.py
@@ -10,66 +10,65 @@ main.VK_TOKEN_AFISHA = "ga"
 
 @pytest.mark.asyncio
 async def test_copy_history_photo(monkeypatch):
-    async def fake_vk_api(method, params, db, bot, **kwargs):
-        assert method == "wall.getById"
-        assert kwargs.get("token_kind") == "group"
-        assert kwargs.get("token") == main.VK_TOKEN_AFISHA
-        assert kwargs.get("skip_captcha") is True
-        return {
-            "response": [
-                {
-                    "copy_history": [
-                        {
-                            "attachments": [
-                                {
-                                    "type": "photo",
-                                    "photo": {
-                                        "sizes": [
-                                            {"width": 100, "height": 100, "url": "http://p"}
-                                        ]
-                                    },
-                                }
-                            ]
-                        }
-                    ],
-                    "attachments": [],
-                }
-            ]
-        }
+    post_id = 1
 
-    monkeypatch.setattr(main, "_vk_api", fake_vk_api)
-    photos = await main._vkrev_fetch_photos(1, 1, None, None)
+    async def fake_vk_api(method, **params):
+        assert method == "wall.getById"
+        assert params.get("posts") == f"-1_{post_id}"
+        return [
+            {
+                "copy_history": [
+                    {
+                        "attachments": [
+                            {
+                                "type": "photo",
+                                "photo": {
+                                    "sizes": [
+                                        {"width": 100, "height": 100, "url": "http://p"}
+                                    ]
+                                },
+                            }
+                        ],
+                    }
+                ],
+                "attachments": [],
+            }
+        ]
+
+    monkeypatch.setattr(main, "vk_api", fake_vk_api)
+    photos = await main._vkrev_fetch_photos(1, post_id, None, None)
     assert photos == ["http://p"]
 
 
 @pytest.mark.asyncio
 async def test_link_preview(monkeypatch):
-    async def fake_vk_api(method, params, db, bot, **kwargs):
-        return {
-            "response": [
-                {
-                    "attachments": [
-                        {
-                            "type": "link",
-                            "link": {
-                                "photo": {
-                                    "sizes": [
-                                        {
-                                            "width": 10,
-                                            "height": 10,
-                                            "url": "http://l",
-                                        }
-                                    ]
-                                }
-                            },
-                        }
-                    ]
-                }
-            ]
-        }
+    post_id = 2
 
-    monkeypatch.setattr(main, "_vk_api", fake_vk_api)
-    photos = await main._vkrev_fetch_photos(1, 2, None, None)
+    async def fake_vk_api(method, **params):
+        assert params.get("posts") == f"-1_{post_id}"
+        return [
+            {
+                "attachments": [
+                    {
+                        "type": "link",
+                        "link": {
+                            "photo": {
+                                "sizes": [
+                                    {
+                                        "width": 10,
+                                        "height": 10,
+                                        "url": "http://l",
+                                    }
+                                ]
+                            }
+                        },
+                    }
+                ]
+            }
+        ]
+
+    monkeypatch.setattr(main, "vk_api", fake_vk_api)
+    photos = await main._vkrev_fetch_photos(1, post_id, None, None)
     assert photos == ["http://l"]
 
 
@@ -77,61 +76,61 @@ async def test_link_preview(monkeypatch):
 async def test_video_preview(monkeypatch):
     calls = []
 
-    async def fake_vk_api(method, params, db, bot, **kwargs):
-        calls.append(method)
-        return {
-            "response": [
-                {
-                    "attachments": [
-                        {
-                            "type": "video",
-                            "video": {
-                                "image": [
-                                    {"width": 10, "height": 10, "url": "http://v"}
-                                ]
-                            },
-                        }
-                    ]
-                }
-            ]
-        }
+    post_id = 3
 
-    monkeypatch.setattr(main, "_vk_api", fake_vk_api)
-    photos = await main._vkrev_fetch_photos(1, 3, None, None)
+    async def fake_vk_api(method, **params):
+        calls.append((method, params.get("posts")))
+        return [
+            {
+                "attachments": [
+                    {
+                        "type": "video",
+                        "video": {
+                            "image": [
+                                {"width": 10, "height": 10, "url": "http://v"}
+                            ]
+                        },
+                    }
+                ]
+            }
+        ]
+
+    monkeypatch.setattr(main, "vk_api", fake_vk_api)
+    photos = await main._vkrev_fetch_photos(1, post_id, None, None)
     assert photos == ["http://v"]
-    assert calls == ["wall.getById"]
+    assert calls == [("wall.getById", "-1_3")]
 
 
 @pytest.mark.asyncio
 async def test_doc_preview(monkeypatch):
-    async def fake_vk_api(method, params, db, bot, **kwargs):
-        return {
-            "response": [
-                {
-                    "attachments": [
-                        {
-                            "type": "doc",
-                            "doc": {
-                                "preview": {
-                                    "photo": {
-                                        "sizes": [
-                                            {
-                                                "width": 10,
-                                                "height": 10,
-                                                "url": "http://d",
-                                            }
-                                        ]
-                                    }
-                                }
-                            },
-                        }
-                    ]
-                }
-            ]
-        }
+    post_id = 4
 
-    monkeypatch.setattr(main, "_vk_api", fake_vk_api)
-    photos = await main._vkrev_fetch_photos(1, 4, None, None)
+    async def fake_vk_api(method, **params):
+        return [
+            {
+                "attachments": [
+                    {
+                        "type": "doc",
+                        "doc": {
+                            "preview": {
+                                "photo": {
+                                    "sizes": [
+                                        {
+                                            "width": 10,
+                                            "height": 10,
+                                            "url": "http://d",
+                                        }
+                                    ]
+                                }
+                            }
+                        },
+                    }
+                ]
+            }
+        ]
+
+    monkeypatch.setattr(main, "vk_api", fake_vk_api)
+    photos = await main._vkrev_fetch_photos(1, post_id, None, None)
     assert photos == ["http://d"]
 
 
@@ -148,18 +147,18 @@ async def test_dedup_and_limit(monkeypatch):
     copy_atts = [make_photo(u) for u in urls[:6]]
     atts = [make_photo(u) for u in urls[5:]]  # overlap at url[5]
 
-    async def fake_vk_api(method, params, db, bot, **kwargs):
-        return {
-            "response": [
-                {
-                    "copy_history": [{"attachments": copy_atts}],
-                    "attachments": atts,
-                }
-            ]
-        }
+    post_id = 5
 
-    monkeypatch.setattr(main, "_vk_api", fake_vk_api)
-    photos = await main._vkrev_fetch_photos(1, 5, None, None)
+    async def fake_vk_api(method, **params):
+        return [
+            {
+                "copy_history": [{"attachments": copy_atts}],
+                "attachments": atts,
+            }
+        ]
+
+    monkeypatch.setattr(main, "vk_api", fake_vk_api)
+    photos = await main._vkrev_fetch_photos(1, post_id, None, None)
     assert len(photos) == 10
     assert len(set(photos)) == 10
     assert photos[:6] == urls[:6]


### PR DESCRIPTION
## Summary
- add configuration for VK service token reads and request throttling
- use the service token for safe read-only vk_api calls with logging and spacing between requests
- switch repost photo fetching to vk_api and update its tests

## Testing
- pytest tests/test_vkrev_fetch_photos.py

------
https://chatgpt.com/codex/tasks/task_e_68c93194b6d8833291362fd7d63ed338