### PR TITLE
Remove Polubit 39 folder snippet from VK posts

### DIFF
--- a/markup.py
+++ b/markup.py
@@ -82,6 +82,42 @@ def sanitize_for_vk(text_or_html: str) -> str:
     s = re.sub(r"<\s*/?(?:p|ul|ol)\s*>", "", s, flags=re.I)
     s = re.sub(r"</?[^>]+>", "", s)
     s = re.sub(r"[ \t]{2,}", " ", s)
+
+    lines = s.splitlines()
+    cleaned: list[str] = []
+    i = 0
+    while i < len(lines):
+        line = lines[i]
+        stripped = line.strip()
+        norm = stripped.casefold()
+        has_folder_icon = "📂" in stripped
+        has_addlist = "addlist" in norm
+        if "полюбить 39" in norm:
+            if not has_addlist:
+                j = i + 1
+                while j < len(lines):
+                    next_stripped = lines[j].strip()
+                    if not next_stripped:
+                        j += 1
+                        continue
+                    if "t.me/addlist" in next_stripped.casefold():
+                        has_addlist = True
+                    break
+            if has_folder_icon or has_addlist:
+                i += 1
+                while i < len(lines):
+                    next_stripped = lines[i].strip()
+                    if not next_stripped:
+                        i += 1
+                        continue
+                    if "t.me/addlist" in next_stripped.casefold():
+                        i += 1
+                    break
+                continue
+        cleaned.append(line)
+        i += 1
+
+    s = "\n".join(cleaned)
     s = re.sub(r"\n{3,}", "\n\n", s).strip()
     return s
 

--- a/tests/test_sanitize_for_vk.py
+++ b/tests/test_sanitize_for_vk.py
@@ -14,3 +14,13 @@ def test_sanitize_for_vk_strips_html_and_tg_emoji():
     )
     assert sanitize_for_vk(src) == expected
 
+
+def test_sanitize_for_vk_removes_polubit_39_block():
+    src = '📂 Полюбить 39\nhttps://t.me/addlist/foo\n\nОсновной текст'
+    assert sanitize_for_vk(src) == 'Основной текст'
+
+
+def test_sanitize_for_vk_removes_polubit_39_inline_link():
+    src = "📂 Полюбить 39 (<a href='https://t.me/addlist/foo'>https://t.me/addlist/foo</a>)\nТекст"
+    assert sanitize_for_vk(src) == 'Текст'
+


### PR DESCRIPTION
## Summary
- strip the recurring "📂 Полюбить 39" block from text before publishing VK posts
- ensure the associated Telegram folder link is dropped together with the label
- cover the sanitiser behaviour with regression tests

## Testing
- pytest tests/test_sanitize_for_vk.py

------
https://chatgpt.com/codex/tasks/task_e_68c9480b8ca08332a0638bd8d7770731