### PR TITLE
Add actor/token context to VK API errors

### DIFF
--- a/tests/test_vk_captcha.py
+++ b/tests/test_vk_captcha.py
@@ -38,11 +38,15 @@ async def test_vk_api_captcha_cached(monkeypatch):
     assert e1.value.code == 14
     assert e1.value.captcha_sid == "sid"
     assert e1.value.captcha_img == "img"
+    assert e1.value.actor == "group"
+    assert e1.value.token == "<redacted>"
     assert calls == 1
     with pytest.raises(main.VKAPIError) as e2:
         await main._vk_api("wall.get", {}, token="t")
     assert e2.value.captcha_sid == "sid"
     assert e2.value.captcha_img == "img"
+    assert e2.value.actor is None
+    assert e2.value.token is None
     assert calls == 1
 
 


### PR DESCRIPTION
## Summary
- extend `VKAPIError` to capture the actor type and redacted token, and propagate them through vk API helpers
- log actor/token details when handling VKAPIError failures and update tests to assert the new metadata

## Testing
- pytest tests/test_vk_actor.py tests/test_vk_captcha.py tests/test_vkrev_fetch_photos.py

------
https://chatgpt.com/codex/tasks/task_e_68c989ca39cc83328e6aae3da8b2069a