### PR TITLE
Propagate VK intake metadata to persisted events

### DIFF
--- a/main.py
+++ b/main.py
@@ -16177,7 +16177,19 @@ async def _vkrev_import_flow(
             ]
         ]
     )
-    await bot.send_message(chat_id, "Импортировано", reply_markup=markup)
+    def _display(value: str | None) -> str:
+        return value if value else "—"
+
+    info_lines = [
+        "Импортировано",
+        f"Тип: {_display(res.event_type)}",
+        f"Дата начала: {_display(res.event_date)}",
+        f"Дата окончания: {_display(res.event_end_date)}",
+        f"Время: {_display(res.event_time)}",
+        f"Бесплатное: {'да' if res.is_free else 'нет'}",
+    ]
+
+    await bot.send_message(chat_id, "\n".join(info_lines), reply_markup=markup)
 
 
 async def handle_vk_review_cb(callback: types.CallbackQuery, db: Database, bot: Bot) -> None:

--- a/tests/test_vk_intake_metrics.py
+++ b/tests/test_vk_intake_metrics.py
@@ -20,6 +20,10 @@ async def test_vk_intake_processing_time_metric(monkeypatch):
             ics_supabase_url="s",
             ics_tg_url="tg",
             event_date="2025-01-01",
+            event_end_date=None,
+            event_time="10:00",
+            event_type=None,
+            is_free=False,
         )
 
     monkeypatch.setattr(vk_intake, "build_event_payload_from_vk", fake_build)

--- a/tests/test_vkrev_import_flow.py
+++ b/tests/test_vkrev_import_flow.py
@@ -72,6 +72,14 @@ async def test_vkrev_import_flow_persists_url_and_skips_vk_sync(tmp_path, monkey
         ev = await session.get(Event, captured["event_id"])
     assert ev.source_post_url == "https://vk.com/wall-1_2"
     assert JobTask.vk_sync not in tasks
+    assert bot.messages[-1].text == (
+        "Импортировано\n"
+        "Тип: —\n"
+        "Дата начала: 2025-09-02\n"
+        "Дата окончания: —\n"
+        "Время: 10:00\n"
+        "Бесплатное: нет"
+    )
 
 
 @pytest.mark.asyncio

--- a/vk_intake.py
+++ b/vk_intake.py
@@ -243,7 +243,17 @@ class EventDraft:
     date: str | None = None
     time: str | None = None
     venue: str | None = None
-    price: str | None = None
+    description: str | None = None
+    festival: str | None = None
+    location_address: str | None = None
+    city: str | None = None
+    ticket_price_min: int | None = None
+    ticket_price_max: int | None = None
+    event_type: str | None = None
+    emoji: str | None = None
+    end_date: str | None = None
+    is_free: bool = False
+    pushkin_card: bool = False
     links: List[str] | None = None
     source_text: str | None = None
 
@@ -255,6 +265,10 @@ class PersistResult:
     ics_supabase_url: str
     ics_tg_url: str
     event_date: str
+    event_end_date: str | None
+    event_time: str
+    event_type: str | None
+    is_free: bool
 
 
 async def build_event_payload_from_vk(
@@ -275,8 +289,9 @@ async def build_event_payload_from_vk(
     The extractor is also instructed to apply ``default_time`` when no time is
     present in the post.
 
-    The resulting :class:`EventDraft` contains basic event attributes such as
-    title, date, time, venue, price and relevant links.
+    The resulting :class:`EventDraft` contains normalised event attributes such
+    as title, schedule, venue, ticket details and other metadata needed by the
+    import pipeline.
     """
     from main import parse_event_via_4o
 
@@ -302,22 +317,71 @@ async def build_event_payload_from_vk(
         trimmed = combined_text.rstrip()
         combined_text = f"{trimmed}\n\n{extra_clean}" if trimmed else extra_clean
 
-    price: str | None = None
-    if data.get("ticket_price_min") or data.get("ticket_price_max"):
-        lo = data.get("ticket_price_min")
-        hi = data.get("ticket_price_max")
-        if lo and hi and lo != hi:
-            price = f"{lo}-{hi}"
-        else:
-            price = str(lo or hi)
+    def clean_int(value: Any) -> int | None:
+        if value in (None, ""):
+            return None
+        if isinstance(value, bool):
+            return None
+        if isinstance(value, (int, float)):
+            return int(value)
+        if isinstance(value, str):
+            value = value.strip()
+            if not value:
+                return None
+            try:
+                return int(float(value))
+            except ValueError:
+                return None
+        try:
+            return int(value)
+        except (TypeError, ValueError):
+            return None
 
+    def clean_str(value: Any) -> str | None:
+        if value is None:
+            return None
+        if isinstance(value, str):
+            value = value.strip()
+            return value or None
+        return str(value)
+
+    def clean_bool(value: Any) -> bool:
+        if isinstance(value, bool):
+            return value
+        if value is None:
+            return False
+        if isinstance(value, str):
+            val = value.strip().lower()
+            if not val:
+                return False
+            if val in {"true", "1", "yes", "да", "y"}:
+                return True
+            if val in {"false", "0", "no", "нет", "n"}:
+                return False
+        try:
+            return bool(int(value))
+        except (TypeError, ValueError):
+            return bool(value)
+
+    ticket_price_min = clean_int(data.get("ticket_price_min"))
+    ticket_price_max = clean_int(data.get("ticket_price_max"))
     links = [data["ticket_link"]] if data.get("ticket_link") else None
     return EventDraft(
         title=data.get("title", ""),
         date=data.get("date"),
         time=data.get("time") or default_time,
         venue=data.get("location_name"),
-        price=price,
+        description=data.get("short_description"),
+        festival=clean_str(data.get("festival")),
+        location_address=clean_str(data.get("location_address")),
+        city=clean_str(data.get("city")),
+        ticket_price_min=ticket_price_min,
+        ticket_price_max=ticket_price_max,
+        event_type=clean_str(data.get("event_type")),
+        emoji=clean_str(data.get("emoji")),
+        end_date=clean_str(data.get("end_date")),
+        is_free=clean_bool(data.get("is_free")),
+        pushkin_card=clean_bool(data.get("pushkin_card")),
         links=links,
         source_text=combined_text,
     )
@@ -345,13 +409,22 @@ async def persist_event_and_pages(
 
     event = Event(
         title=draft.title,
-        description="",
-        festival=None,
+        description=(draft.description or ""),
+        festival=(draft.festival or None),
         date=draft.date or datetime.utcnow().date().isoformat(),
         time=draft.time or "00:00",
         location_name=draft.venue or "",
-        source_text=draft.source_text or draft.title,
+        location_address=draft.location_address or None,
+        city=draft.city or None,
+        ticket_price_min=draft.ticket_price_min,
+        ticket_price_max=draft.ticket_price_max,
         ticket_link=(draft.links[0] if draft.links else None),
+        event_type=draft.event_type or None,
+        emoji=draft.emoji or None,
+        end_date=draft.end_date or None,
+        is_free=bool(draft.is_free),
+        pushkin_card=bool(draft.pushkin_card),
+        source_text=draft.source_text or draft.title,
         photo_urls=photos,
         photo_count=len(photos),
         source_post_url=source_post_url,
@@ -375,6 +448,10 @@ async def persist_event_and_pages(
         ics_supabase_url=saved.ics_url or "",
         ics_tg_url=saved.ics_post_url or "",
         event_date=saved.date,
+        event_end_date=saved.end_date,
+        event_time=saved.time,
+        event_type=saved.event_type,
+        is_free=bool(saved.is_free),
     )
 
 


### PR DESCRIPTION
## Summary
- expand the VK intake draft to carry description, location, pricing, type and flag metadata
- map the additional fields out of the LLM response and persist them on the saved Event
- add a regression test covering the newly persisted attributes
- show event type, schedule and free flag details in the VK import success message

## Testing
- pytest tests/test_vk_intake_metrics.py tests/test_vkrev_import_flow.py tests/test_vk_persist_source_post_url.py

------
https://chatgpt.com/codex/tasks/task_e_68c9971753bc83328e42d861c997d211