### PR TITLE
Adjust VK shortpost date for ongoing exhibitions

### DIFF
--- a/main.py
+++ b/main.py
@@ -16401,15 +16401,56 @@ async def _vkrev_build_shortpost(
     else:
         max_sent = 4
     summary = await build_short_vk_text(ev, ev.source_text or "", max_sent)
-    day = int(ev.date.split("-")[2])
-    month = int(ev.date.split("-")[1])
-    month_name = MONTHS[month - 1]
+
+    start_date: date | None = None
+    try:
+        start_date = date.fromisoformat(ev.date)
+    except (TypeError, ValueError):
+        start_date = None
+
+    end_date_obj: date | None = None
+    if ev.end_date:
+        try:
+            end_date_obj = date.fromisoformat(ev.end_date)
+        except (TypeError, ValueError):
+            end_date_obj = None
+
+    if start_date:
+        default_date_str = f"{start_date.day} {MONTHS[start_date.month - 1]}"
+    else:
+        try:
+            parts = ev.date.split("-")
+            day = int(parts[2])
+            month = int(parts[1])
+        except (AttributeError, IndexError, ValueError):
+            default_date_str = ev.date
+        else:
+            default_date_str = f"{day} {MONTHS[month - 1]}"
+
+    today = date.today()
+
+    ongoing_exhibition = (
+        ev.event_type == "выставка"
+        and start_date is not None
+        and end_date_obj is not None
+        and start_date <= today <= end_date_obj
+    )
+
+    if ongoing_exhibition:
+        end_month_name = MONTHS[end_date_obj.month - 1]
+        year_suffix = ""
+        if start_date.year != end_date_obj.year:
+            year_suffix = f" {end_date_obj.year}"
+        date_line = f"🗓 по {end_date_obj.day} {end_month_name}{year_suffix}"
+    else:
+        time_part = f" ⏰ {ev.time}" if ev.time and ev.time != "00:00" else ""
+        date_line = f"🗓 {default_date_str}{time_part}"
+
     tags = await build_short_vk_tags(ev, summary)
-    time_part = f" ⏰ {ev.time}" if ev.time and ev.time != "00:00" else ""
     lines = [
         ev.title.upper(),
         "",
-        f"🗓 {day} {month_name}{time_part}",
+        date_line,
     ]
     if ev.ticket_link:
         lines.append(f"🎟 Билеты: {ev.ticket_link}")

--- a/tests/test_vk_shortpost.py
+++ b/tests/test_vk_shortpost.py
@@ -2,6 +2,7 @@ import os, sys
 import pytest
 import os, sys
 from types import SimpleNamespace
+from datetime import date as real_date
 
 sys.path.append(os.path.dirname(os.path.dirname(__file__)))
 
@@ -339,6 +340,41 @@ async def test_shortpost_midnight_time_hidden(monkeypatch):
     )
 
     msg, _ = await main._vkrev_build_shortpost(ev, "https://vk.com/wall-1_1")
+    assert "⏰" not in msg
+
+
+@pytest.mark.asyncio
+async def test_shortpost_ongoing_exhibition(monkeypatch):
+    async def fake_build_text(event, src, max_sent):
+        return "short summary"
+
+    async def fake_tags(event, summary):
+        return ["#a", "#b", "#c", "#d", "#e"]
+
+    monkeypatch.setattr(main, "build_short_vk_text", fake_build_text)
+    monkeypatch.setattr(main, "build_short_vk_tags", fake_tags)
+
+    class FakeDate(real_date):
+        @classmethod
+        def today(cls):
+            return cls(2025, 9, 28)
+
+    monkeypatch.setattr(main, "date", FakeDate)
+
+    ev = Event(
+        id=1,
+        title="T",
+        description="d",
+        date="2025-09-20",
+        end_date="2025-10-05",
+        time="18:00",
+        location_name="Place",
+        source_text="src",
+        event_type="выставка",
+    )
+
+    msg, _ = await main._vkrev_build_shortpost(ev, "https://vk.com/wall-1_1")
+    assert "🗓 по 5 октября" in msg
     assert "⏰" not in msg
 
 


### PR DESCRIPTION
## Summary
- parse VK shortpost dates into date objects so ongoing exhibitions use the "по <day> <month>" wording without a time suffix
- keep the existing formatting for other events while preserving ticket and location information
- cover the ongoing exhibition case with a dedicated vk shortpost test

## Testing
- pytest tests/test_vk_shortpost.py::test_shortpost_ongoing_exhibition


------
https://chatgpt.com/codex/tasks/task_e_68c9a17b26fc83328f5a5cac8aa67247