### PR TITLE
Add city hashtag to VK short post tags

### DIFF
--- a/main.py
+++ b/main.py
@@ -15966,6 +15966,11 @@ async def build_short_vk_tags(event: Event, summary: str) -> list[str]:
 
     add_tag(f"#{day}_{month_name}")
     add_tag(f"#{day}{month_name}")
+    city = (event.city or "").strip()
+    if city:
+        normalized_city = re.sub(r"[^0-9a-zа-яё]+", "", city.lower())
+        if normalized_city:
+            add_tag(f"#{normalized_city}")
     if event.event_type:
         normalized_event_type = re.sub(
             r"[^0-9a-zа-яё]+", "_", event.event_type.lower()

--- a/tests/test_vk_shortpost.py
+++ b/tests/test_vk_shortpost.py
@@ -368,3 +368,28 @@ async def test_shortpost_preview_link(monkeypatch):
     )
     assert "[https://vk.com/wall-1_1|Источник]" not in msg
     assert "Источник\nhttps://vk.com/wall-1_1" in msg
+
+
+@pytest.mark.asyncio
+async def test_build_short_vk_tags_adds_city_hashtag(monkeypatch):
+    async def fake_ask(prompt, **kwargs):
+        return "#доптег1 #доптег2"
+
+    monkeypatch.setattr(main, "ask_4o", fake_ask)
+
+    ev = Event(
+        id=1,
+        title="T",
+        description="d",
+        date="2025-09-27",
+        time="19:00",
+        location_name="Place",
+        city="Санкт-Петербург",
+        event_type="Лекция",
+        source_text="src",
+    )
+
+    tags = await main.build_short_vk_tags(ev, "summary")
+
+    assert "#санктпетербург" in tags
+    assert tags.index("#санктпетербург") <= 2


### PR DESCRIPTION
## Summary
- sanitize the event city name into a hashtag and insert it near the top of the VK short post tag list
- add coverage to ensure non-Kaliningrad events receive the derived city hashtag

## Testing
- pytest tests/test_vk_shortpost.py::test_build_short_vk_tags_adds_city_hashtag


------
https://chatgpt.com/codex/tasks/task_e_68c9a25134b88332bb4ae67ee2c15c22