### PR TITLE
Avoid duplicating hyphenated type tags in short posts

### DIFF
--- a/tests/test_vk_shortpost.py
+++ b/tests/test_vk_shortpost.py
@@ -407,8 +407,9 @@ async def test_shortpost_type_line_for_hyphenated_type(monkeypatch):
     assert lines[date_idx - 1] == "#мастеркласс"
 
     hashtags_line = lines[-1]
-    assert "#мастеркласс" in hashtags_line
-    assert "#мастер_класс" in hashtags_line
+    hashtags = hashtags_line.split()
+    assert "#мастер_класс" in hashtags
+    assert "#мастеркласс" not in hashtags
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- track the type-line hashtag even for hyphenated event types so it can be shared with tag generation
- skip emitting the hyphen-free variant when the type line already uses it, keeping only the underscored form in hashtags
- update the shortpost hyphenated type test to assert the cleaned hashtag list

## Testing
- pytest tests/test_vk_shortpost.py


------
https://chatgpt.com/codex/tasks/task_e_68c9d19339b88332a47b0ed55872e441