### PR TITLE
Move digest select handlers above app runner

### DIFF
--- a/main.py
+++ b/main.py
@@ -18188,12 +18188,6 @@ def create_app() -> web.Application:
     return app
 
 
-if __name__ == "__main__":
-    import sys
-    if len(sys.argv) > 1 and sys.argv[1] == "test_telegraph":
-        asyncio.run(telegraph_test())
-    else:
-        web.run_app(create_app(), port=int(os.getenv("PORT", 8080)))
 async def _handle_digest_select(
     callback: types.CallbackQuery,
     db: Database,
@@ -18335,3 +18329,11 @@ async def handle_digest_select_masterclasses(
         items_noun="мастер-классов",
         panel_text="Управление дайджестом мастер-классов\nВыключите лишнее и нажмите «Обновить превью».",
     )
+
+
+if __name__ == "__main__":
+    import sys
+    if len(sys.argv) > 1 and sys.argv[1] == "test_telegraph":
+        asyncio.run(telegraph_test())
+    else:
+        web.run_app(create_app(), port=int(os.getenv("PORT", 8080)))


### PR DESCRIPTION
## Summary
- move the digest select handler definitions before the `__main__` guard so they load before the app starts

## Testing
- pytest tests/test_digest_panel.py tests/test_digest_command.py

------
https://chatgpt.com/codex/tasks/task_e_68c9debd602c8332a985a74cfb049e7c