### PR TITLE
Add 05:15 to default VK crawl schedule

### DIFF
--- a/scheduling.py
+++ b/scheduling.py
@@ -513,7 +513,7 @@ def startup(db, bot) -> AsyncIOScheduler:
         "SCHED registered job id=%s next_run=%s", job.id, _job_next_run(job)
     )
 
-    times_raw = os.getenv("VK_CRAWL_TIMES_LOCAL", "09:15,13:15,17:15,21:15")
+    times_raw = os.getenv("VK_CRAWL_TIMES_LOCAL", "05:15,09:15,13:15,17:15,21:15")
     tz_name = os.getenv("VK_CRAWL_TZ", "Europe/Kaliningrad")
     tz = ZoneInfo(tz_name)
     for idx, t in enumerate(times_raw.split(",")):


### PR DESCRIPTION
## Summary
- update the default `VK_CRAWL_TIMES_LOCAL` to include a 05:15 run for the VK crawl cron jobs

## Testing
- pytest *(stopped after ~8 minutes because the suite is very long, but 10 tests had already passed)*

------
https://chatgpt.com/codex/tasks/task_e_68ca5b45db1c8332ad7f2294f349fe0c