### PR TITLE
Handle VK location abbreviations

### DIFF
--- a/tests/test_vk_shortpost.py
+++ b/tests/test_vk_shortpost.py
@@ -559,3 +559,29 @@ async def test_build_short_vk_tags_adds_city_hashtag(monkeypatch):
 
     assert "#санктпетербург" in tags
     assert tags.index("#санктпетербург") <= 2
+
+
+@pytest.mark.asyncio
+async def test_build_short_vk_tags_location_abbreviations(monkeypatch):
+    async def fake_ask(prompt, **kwargs):
+        return "#доп1 #доп2 #доп3"
+
+    monkeypatch.setattr(main, "ask_4o", fake_ask)
+
+    ev = Event(
+        id=2,
+        title="T",
+        description="d",
+        date="2025-09-27",
+        time="19:00",
+        location_name="ИЦАЭ (в КГТУ)",
+        city="Калининград",
+        event_type="Лекция",
+        source_text="src",
+    )
+
+    tags = await main.build_short_vk_tags(ev, "summary")
+
+    assert "#ИЦАЭ" in tags
+    assert "#КГТУ" in tags
+    assert len(tags) <= 7


### PR DESCRIPTION
## Summary
- add explicit VK location hashtag overrides and generate tags from detected uppercase abbreviations in event locations before LLM fallback
- cover VK location abbreviation handling with a short post hashtag test

## Testing
- pytest tests/test_vk_shortpost.py

------
https://chatgpt.com/codex/tasks/task_e_68ca7492c3348332a51e5b54e9ad53a1