### PR TITLE
Add /ocrtest command for OCR diagnostics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## Unreleased
+- Added `/ocrtest` diagnostic command to compare OCR output from `gpt-4o-mini` and `gpt-4o` with token usage details.
+
 ## v0.1.0 – Deploy + US-02 + /tz
 - Initial Fly.io deployment config.
 - Moderator registration queue with approve/reject.

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 Telegram bot for publishing event announcements. Daily announcements can also be posted to a VK group.
 Use `/regdailychannels` and `/daily` to manage both Telegram channels and the VK group including posting times.
 
-Superadmins can use `/vk` to manage VK Intake: add or list sources, check or review events, and open the queue summary.
+Superadmins can use `/vk` to manage VK Intake: add or list sources, check or review events, and open the queue summary. The `/ocrtest` command compares OCR quality between `gpt-4o-mini` and `gpt-4o` on uploaded posters.
 
 ## VK Intake & Review v1.1
 

--- a/docs/COMMANDS.md
+++ b/docs/COMMANDS.md
@@ -16,6 +16,7 @@
 | `↪️ Репостнуть в Vk` | - | Safe repost via `wall.post` with photo IDs. |
 | `✂️ Сокращённый рерайт` | - | LLM-сжатый текст без фото, предпросмотр и правка перед публикацией. |
 | `/ask4o <text>` | any text | Send query to model 4o and show plain response (superadmin only). |
+| `/ocrtest` | - | Compare OCR results across gpt-4o-mini and gpt-4o (superadmin only). |
 | `/events [DATE]` | optional date `YYYY-MM-DD`, `DD.MM.YYYY` or `D месяц [YYYY]` | List events for the day with delete and edit buttons. Dates are shown as `DD.MM.YYYY`. Choosing **Edit** lists all fields with inline buttons including a toggle for "Бесплатно". |
 | `/setchannel` | - | Choose an admin channel and register it as an announcement or calendar asset source. |
 | `/channels` | - | List admin channels showing registered and asset ones with disable buttons. |

--- a/main.py
+++ b/main.py
@@ -131,6 +131,7 @@ from io import BytesIO
 import aiosqlite
 import gc
 import atexit
+import vision_test
 from markup import (
     simple_md_to_html,
     telegraph_br,
@@ -1131,6 +1132,11 @@ HELP_COMMANDS = [
     {
         "usage": "/ask4o <text>",
         "desc": "Send query to model 4o",
+        "roles": {"superadmin"},
+    },
+    {
+        "usage": "/ocrtest",
+        "desc": "Compare OCR results across gpt-4o-mini and gpt-4o",
         "roles": {"superadmin"},
     },
     {
@@ -4717,6 +4723,22 @@ async def handle_help(message: types.Message, db: Database, bot: Bot) -> None:
         if role in item["roles"]
     ]
     await bot.send_message(message.chat.id, "\n".join(lines) or "No commands available")
+
+
+async def handle_ocrtest(message: types.Message, db: Database, bot: Bot) -> None:
+    async with db.get_session() as session:
+        user = await session.get(User, message.from_user.id)
+        if not user or not user.is_superadmin:
+            await bot.send_message(message.chat.id, "Not authorized")
+            return
+
+    session = get_http_session()
+    await vision_test.start(
+        message,
+        bot,
+        http_session=session,
+        http_semaphore=HTTP_SEMAPHORE,
+    )
 
 
 async def handle_events_menu(message: types.Message, db: Database, bot: Bot):
@@ -17773,6 +17795,16 @@ def create_app() -> web.Application:
     async def help_wrapper(message: types.Message):
         await handle_help(message, db, bot)
 
+    async def ocrtest_wrapper(message: types.Message):
+        await handle_ocrtest(message, db, bot)
+
+    async def ocr_detail_wrapper(callback: types.CallbackQuery):
+        await vision_test.select_detail(callback, bot)
+
+    async def ocr_photo_wrapper(message: types.Message):
+        images = await extract_images(message, bot)
+        await vision_test.handle_photo(message, bot, images)
+
     async def requests_wrapper(message: types.Message):
         await handle_requests(message, db, bot)
 
@@ -18027,6 +18059,7 @@ def create_app() -> web.Application:
         await handle_ics_fix_nav(message, db, bot)
 
     dp.message.register(help_wrapper, Command("help"))
+    dp.message.register(ocrtest_wrapper, Command("ocrtest"))
     dp.message.register(start_wrapper, Command("start"))
     dp.message.register(register_wrapper, Command("register"))
     dp.message.register(requests_wrapper, Command("requests"))
@@ -18072,6 +18105,10 @@ def create_app() -> web.Application:
         or c.data.startswith("requeue:")
     ,
     )
+    dp.callback_query.register(
+        ocr_detail_wrapper,
+        lambda c: c.data and c.data.startswith("ocr:detail:"),
+    )
     dp.callback_query.register(askloc_wrapper, lambda c: c.data == "askloc")
     dp.callback_query.register(askcity_wrapper, lambda c: c.data == "askcity")
     dp.callback_query.register(
@@ -18083,6 +18120,9 @@ def create_app() -> web.Application:
     dp.message.register(tz_wrapper, Command("tz"))
     dp.message.register(
         add_event_session_wrapper, lambda m: m.from_user.id in add_event_sessions
+    )
+    dp.message.register(
+        ocr_photo_wrapper, lambda m: vision_test.is_waiting(m.from_user.id)
     )
     dp.message.register(add_event_wrapper, Command("addevent"))
     dp.message.register(add_event_raw_wrapper, Command("addevent_raw"))

--- a/tests/test_ocrtest.py
+++ b/tests/test_ocrtest.py
@@ -1,0 +1,212 @@
+import os
+import sys
+from types import SimpleNamespace
+
+import pytest
+from aiogram import types
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+
+import main
+import vision_test
+from main import Database, User
+
+
+class DummyBot:
+    def __init__(self):
+        self.messages: list[SimpleNamespace] = []
+
+    async def send_message(self, chat_id, text, **kwargs):
+        msg = SimpleNamespace(
+            message_id=len(self.messages) + 1,
+            date=0,
+            chat=SimpleNamespace(id=chat_id, type="private"),
+            from_user=SimpleNamespace(id=0, is_bot=True, first_name="B"),
+            text=text,
+            reply_markup=kwargs.get("reply_markup"),
+            parse_mode=kwargs.get("parse_mode"),
+        )
+        self.messages.append(msg)
+        return msg
+
+
+class DummySession:
+    async def post(self, *args, **kwargs):  # pragma: no cover - start only stores reference
+        raise AssertionError("run_ocr should be stubbed in tests")
+
+
+class DummyMessage:
+    def __init__(self):
+        self.calls: list = []
+
+    async def edit_reply_markup(self, reply_markup=None):
+        self.calls.append(reply_markup)
+
+
+class DummyCallback:
+    def __init__(self, user_id: int, data: str, message):
+        self.from_user = SimpleNamespace(id=user_id)
+        self.data = data
+        self.message = message
+        self.answers: list[tuple[str | None, bool]] = []
+
+    async def answer(self, text: str | None = None, show_alert: bool = False):
+        self.answers.append((text, show_alert))
+
+
+@pytest.mark.asyncio
+async def test_ocrtest_start_superadmin(tmp_path, monkeypatch):
+    vision_test._SESSIONS.clear()
+    db = Database(str(tmp_path / "db.sqlite"))
+    await db.init()
+    async with db.get_session() as session:
+        session.add(User(user_id=1, is_superadmin=True))
+        await session.commit()
+
+    msg = types.Message.model_validate(
+        {
+            "message_id": 1,
+            "date": 0,
+            "chat": {"id": 1, "type": "private"},
+            "from": {"id": 1, "is_bot": False, "first_name": "U"},
+            "text": "/ocrtest",
+        }
+    )
+
+    bot = DummyBot()
+    monkeypatch.setattr(main, "get_http_session", lambda: DummySession())
+
+    await main.handle_ocrtest(msg, db, bot)
+    assert bot.messages, "no message sent"
+    markup = bot.messages[0].reply_markup
+    assert markup is not None
+    buttons = [btn.text for row in markup.inline_keyboard for btn in row]
+    assert any(text.startswith("Сменить детализацию") for text in buttons)
+    assert "Завершить" in buttons
+
+
+@pytest.mark.asyncio
+async def test_ocrtest_denies_non_admin(tmp_path, monkeypatch):
+    vision_test._SESSIONS.clear()
+    db = Database(str(tmp_path / "db.sqlite"))
+    await db.init()
+    async with db.get_session() as session:
+        session.add(User(user_id=2, is_superadmin=False))
+        await session.commit()
+
+    msg = types.Message.model_validate(
+        {
+            "message_id": 1,
+            "date": 0,
+            "chat": {"id": 2, "type": "private"},
+            "from": {"id": 2, "is_bot": False, "first_name": "U"},
+            "text": "/ocrtest",
+        }
+    )
+
+    bot = DummyBot()
+    monkeypatch.setattr(main, "get_http_session", lambda: DummySession())
+
+    await main.handle_ocrtest(msg, db, bot)
+    assert bot.messages
+    assert bot.messages[0].text == "Not authorized"
+
+
+@pytest.mark.asyncio
+async def test_select_detail_updates_state(tmp_path, monkeypatch):
+    vision_test._SESSIONS.clear()
+    db = Database(str(tmp_path / "db.sqlite"))
+    await db.init()
+    async with db.get_session() as session:
+        session.add(User(user_id=3, is_superadmin=True))
+        await session.commit()
+
+    msg = types.Message.model_validate(
+        {
+            "message_id": 1,
+            "date": 0,
+            "chat": {"id": 3, "type": "private"},
+            "from": {"id": 3, "is_bot": False, "first_name": "U"},
+            "text": "/ocrtest",
+        }
+    )
+
+    bot = DummyBot()
+    monkeypatch.setattr(main, "get_http_session", lambda: DummySession())
+    await main.handle_ocrtest(msg, db, bot)
+
+    dummy_message = DummyMessage()
+    callback = DummyCallback(3, "ocr:detail:low", dummy_message)
+    await vision_test.select_detail(callback, bot)
+
+    session = vision_test._SESSIONS.get(3)
+    assert session is not None
+    assert session.detail == "low"
+    assert callback.answers
+    assert session.waiting_for_photo
+
+
+@pytest.mark.asyncio
+async def test_handle_photo_uses_both_models(tmp_path, monkeypatch):
+    vision_test._SESSIONS.clear()
+    db = Database(str(tmp_path / "db.sqlite"))
+    await db.init()
+    async with db.get_session() as session:
+        session.add(User(user_id=4, is_superadmin=True))
+        await session.commit()
+
+    msg = types.Message.model_validate(
+        {
+            "message_id": 1,
+            "date": 0,
+            "chat": {"id": 4, "type": "private"},
+            "from": {"id": 4, "is_bot": False, "first_name": "U"},
+            "text": "/ocrtest",
+        }
+    )
+
+    bot = DummyBot()
+    monkeypatch.setattr(main, "get_http_session", lambda: DummySession())
+    await main.handle_ocrtest(msg, db, bot)
+
+    calls: list[tuple[str, str]] = []
+
+    async def fake_run_ocr(image: bytes, *, model: str, detail: str):
+        calls.append((model, detail))
+        if model == "gpt-4o-mini":
+            return (
+                "строка одна\nобщая",
+                {"prompt_tokens": 10, "completion_tokens": 5, "total_tokens": 15},
+            )
+        return (
+            "строка одна\nдругая",
+            {"prompt_tokens": 20, "completion_tokens": 7, "total_tokens": 27},
+        )
+
+    monkeypatch.setattr(vision_test, "run_ocr", fake_run_ocr)
+
+    photo_msg = types.Message.model_validate(
+        {
+            "message_id": 2,
+            "date": 0,
+            "chat": {"id": 4, "type": "private"},
+            "from": {"id": 4, "is_bot": False, "first_name": "U"},
+        }
+    )
+
+    await vision_test.handle_photo(photo_msg, bot, [(b"jpegdata", "poster.jpg")])
+
+    assert calls == [
+        ("gpt-4o-mini", "auto"),
+        ("gpt-4o", "auto"),
+    ]
+    assert bot.messages
+    text = bot.messages[-1].text
+    assert "gpt-4o-mini" in text
+    assert "prompt" in text
+    assert "Схожесть:" in text
+    assert "Различия" in text
+    session = vision_test._SESSIONS.get(4)
+    assert session is not None
+    assert session.last_texts.get("gpt-4o")
+    assert session.waiting_for_photo

--- a/vision_test.py
+++ b/vision_test.py
@@ -1,0 +1,326 @@
+from __future__ import annotations
+
+import asyncio
+import base64
+import html
+import logging
+import os
+from dataclasses import dataclass, field
+from difflib import SequenceMatcher, ndiff
+from typing import Literal
+
+from aiohttp import ClientError, ClientSession
+from aiogram import Bot, types
+from aiogram.types import InlineKeyboardButton, InlineKeyboardMarkup
+from cachetools import TTLCache
+
+
+DetailLevel = Literal["auto", "low", "high"]
+
+
+@dataclass
+class VisionSession:
+    detail: DetailLevel = "auto"
+    waiting_for_photo: bool = True
+    last_texts: dict[str, str] = field(default_factory=dict)
+
+
+_SESSIONS: TTLCache[int, VisionSession] = TTLCache(maxsize=128, ttl=30 * 60)
+_HTTP_SESSION: ClientSession | None = None
+_HTTP_SEMAPHORE: asyncio.Semaphore | None = None
+
+DETAIL_LABELS = {
+    "auto": "Авто",
+    "low": "Низкая",
+    "high": "Высокая",
+}
+
+DETAIL_ORDER: tuple[DetailLevel, ...] = ("auto", "low", "high")
+FOUR_O_TIMEOUT = float(os.getenv("FOUR_O_TIMEOUT", "60"))
+
+
+def _ensure_session(user_id: int) -> VisionSession | None:
+    session = _SESSIONS.get(user_id)
+    if session:
+        _SESSIONS[user_id] = session  # refresh TTL
+    return session
+
+
+def _main_keyboard(detail: DetailLevel) -> InlineKeyboardMarkup:
+    return InlineKeyboardMarkup(
+        inline_keyboard=[
+            [
+                InlineKeyboardButton(
+                    text=f"Сменить детализацию ({DETAIL_LABELS.get(detail, detail)})",
+                    callback_data="ocr:detail:menu",
+                )
+            ],
+            [InlineKeyboardButton(text="Завершить", callback_data="ocr:detail:cancel")],
+        ]
+    )
+
+
+def _detail_keyboard(current: DetailLevel) -> InlineKeyboardMarkup:
+    rows = [
+        [
+            InlineKeyboardButton(
+                text=("✅ " if lvl == current else "▫️ ") + DETAIL_LABELS.get(lvl, lvl),
+                callback_data=f"ocr:detail:{lvl}",
+            )
+        ]
+        for lvl in DETAIL_ORDER
+    ]
+    rows.append([InlineKeyboardButton(text="← Назад", callback_data="ocr:detail:back")])
+    return InlineKeyboardMarkup(inline_keyboard=rows)
+
+
+async def start(
+    message: types.Message,
+    bot: Bot,
+    *,
+    http_session: ClientSession,
+    http_semaphore: asyncio.Semaphore,
+) -> None:
+    """Start OCR comparison session for the user."""
+
+    global _HTTP_SESSION, _HTTP_SEMAPHORE
+    _HTTP_SESSION = http_session
+    _HTTP_SEMAPHORE = http_semaphore
+
+    session = _ensure_session(message.from_user.id)
+    if not session:
+        session = VisionSession()
+        _SESSIONS[message.from_user.id] = session
+    session.waiting_for_photo = True
+    session.last_texts.clear()
+
+    text = (
+        "Отправьте афишу или фото для распознавания.\n"
+        f"Текущая детализация: {DETAIL_LABELS.get(session.detail, session.detail)}."
+    )
+    await bot.send_message(
+        message.chat.id,
+        text,
+        reply_markup=_main_keyboard(session.detail),
+    )
+
+
+async def select_detail(callback: types.CallbackQuery, bot: Bot) -> None:
+    """Handle detail selection callbacks."""
+
+    session = _ensure_session(callback.from_user.id)
+    if not session:
+        await callback.answer("Сессия не найдена", show_alert=True)
+        return
+
+    data = callback.data or ""
+    _, _, value = data.partition("ocr:detail:")
+    if not value:
+        await callback.answer("Неизвестная команда", show_alert=True)
+        return
+
+    if value == "menu":
+        await callback.message.edit_reply_markup(_detail_keyboard(session.detail))
+        await callback.answer("Выберите детализацию")
+        return
+
+    if value == "back":
+        await callback.message.edit_reply_markup(_main_keyboard(session.detail))
+        await callback.answer()
+        return
+
+    if value == "cancel":
+        cancel(callback.from_user.id)
+        await callback.message.edit_reply_markup(None)
+        await callback.answer("Сессия завершена")
+        return
+
+    if value in DETAIL_ORDER:
+        session.detail = value  # type: ignore[assignment]
+        session.waiting_for_photo = True
+        await callback.message.edit_reply_markup(_main_keyboard(session.detail))
+        await callback.answer(f"Детализация: {DETAIL_LABELS.get(value, value)}")
+        return
+
+    await callback.answer("Неизвестная команда", show_alert=True)
+
+
+def cancel(user_id: int) -> None:
+    """Stop OCR session for the user."""
+
+    if user_id in _SESSIONS:
+        del _SESSIONS[user_id]
+
+
+def is_waiting(user_id: int) -> bool:
+    session = _ensure_session(user_id)
+    return bool(session and session.waiting_for_photo)
+
+
+async def run_ocr(image: bytes, *, model: str, detail: str) -> tuple[str, dict[str, int]]:
+    """Send OCR request to OpenAI vision model."""
+
+    if _HTTP_SESSION is None or _HTTP_SEMAPHORE is None:
+        raise RuntimeError("HTTP resources are not configured for OCR")
+
+    token = os.getenv("FOUR_O_TOKEN")
+    if not token:
+        raise RuntimeError("FOUR_O_TOKEN is missing")
+
+    url = os.getenv("FOUR_O_URL", "https://api.openai.com/v1/chat/completions")
+    encoded = base64.b64encode(image).decode("ascii")
+    payload = {
+        "model": model,
+        "messages": [
+            {"role": "system", "content": "верни только распознанный текст"},
+            {
+                "role": "user",
+                "content": [
+                    {"type": "input_text", "text": "Распознай текст на изображении."},
+                    {
+                        "type": "image_url",
+                        "image_url": {
+                            "url": f"data:image/jpeg;base64,{encoded}",
+                            "detail": detail,
+                        },
+                    },
+                ],
+            },
+        ],
+        "temperature": 0,
+    }
+    headers = {
+        "Authorization": f"Bearer {token}",
+        "Content-Type": "application/json",
+    }
+
+    async def _call() -> dict:
+        async with _HTTP_SEMAPHORE:
+            async with _HTTP_SESSION.post(url, json=payload, headers=headers) as resp:
+                resp.raise_for_status()
+                return await resp.json()
+
+    try:
+        data = await asyncio.wait_for(_call(), FOUR_O_TIMEOUT)
+    except (asyncio.TimeoutError, ClientError) as e:  # pragma: no cover - network errors
+        logging.error("OCR request failed: model=%s detail=%s error=%s", model, detail, e)
+        raise RuntimeError(f"OCR request failed: {e}") from e
+
+    try:
+        choice = data.get("choices", [{}])[0]
+        message = choice.get("message", {})
+        text = (message.get("content") or "").strip()
+        usage = data.get("usage", {}) or {}
+    except (AttributeError, IndexError, TypeError) as e:  # pragma: no cover - unexpected
+        logging.error("Invalid OCR response: data=%s", data)
+        raise RuntimeError("Incomplete OCR response") from e
+
+    if not text:
+        raise RuntimeError("Empty OCR response")
+
+    tokens = {
+        "prompt_tokens": int(usage.get("prompt_tokens", 0) or 0),
+        "completion_tokens": int(usage.get("completion_tokens", 0) or 0),
+        "total_tokens": int(usage.get("total_tokens", 0) or 0),
+    }
+    return text, tokens
+
+
+async def handle_photo(
+    message: types.Message,
+    bot: Bot,
+    images: list[tuple[bytes, str]],
+) -> None:
+    """Process incoming photo for OCR comparison."""
+
+    session = _ensure_session(message.from_user.id)
+    if not session:
+        await bot.send_message(message.chat.id, "Сессия не найдена")
+        return
+
+    if not images:
+        await bot.send_message(
+            message.chat.id,
+            "Не удалось получить изображение.",
+            reply_markup=_main_keyboard(session.detail),
+        )
+        return
+
+    session.waiting_for_photo = False
+    image_bytes, name = images[0]
+    models = ("gpt-4o-mini", "gpt-4o")
+    results: list[dict[str, object]] = []
+    for model in models:
+        try:
+            text, tokens = await run_ocr(image_bytes, model=model, detail=session.detail)
+            session.last_texts[model] = text
+            results.append({"model": model, "text": text, "tokens": tokens, "error": None})
+        except Exception as exc:  # pragma: no cover - depends on network
+            logging.warning("OCR model failed: model=%s error=%s", model, exc)
+            results.append({"model": model, "text": "", "tokens": {}, "error": str(exc)})
+
+    lines = [f"Файл: {name}", f"Детализация: {DETAIL_LABELS.get(session.detail, session.detail)}"]
+    for item in results:
+        model = item["model"]
+        text = html.escape(str(item["text"] or ""))
+        error = item.get("error")
+        lines.append("")
+        lines.append(f"<b>{model}</b>:")
+        if error:
+            lines.append(f"<i>Ошибка: {html.escape(str(error))}</i>")
+        else:
+            lines.append(f"<pre>{text}</pre>")
+
+    lines.append("")
+    lines.append("<b>Токены</b>:")
+    header = f"{'Модель':<12} {'prompt':>7} {'completion':>10} {'total':>7}"
+    lines.append(f"<pre>{html.escape(header)}")
+    for item in results:
+        tokens = item.get("tokens") or {}
+        if tokens:
+            row = (
+                f"{item['model']:<12} "
+                f"{tokens.get('prompt_tokens', 0):>7} "
+                f"{tokens.get('completion_tokens', 0):>10} "
+                f"{tokens.get('total_tokens', 0):>7}"
+            )
+        else:
+            row = f"{item['model']:<12} {'-':>7} {'-':>10} {'-':>7}"
+        lines.append(html.escape(row))
+    lines.append("</pre>")
+
+    success = [item for item in results if not item.get("error")]
+    if len(success) == 2:
+        text_a = success[0]["text"] or ""
+        text_b = success[1]["text"] or ""
+        ratio = SequenceMatcher(None, text_a, text_b).ratio()
+        lines.append("")
+        lines.append(f"Схожесть: {ratio:.3f}")
+        diff_lines = [line for line in ndiff(str(text_a).splitlines(), str(text_b).splitlines()) if line[:1] in {"-", "+"}]
+        if diff_lines:
+            lines.append("Различия (первые 10 строк):")
+            for line in diff_lines[:10]:
+                lines.append(html.escape(line))
+    else:
+        errors = ", ".join(str(item.get("error")) for item in results if item.get("error"))
+        lines.append("")
+        lines.append(f"Сравнение недоступно: {html.escape(errors)}")
+
+    session.waiting_for_photo = True
+    text = "\n".join(lines)
+    await bot.send_message(
+        message.chat.id,
+        text,
+        parse_mode="HTML",
+        reply_markup=_main_keyboard(session.detail),
+    )
+
+
+__all__ = [
+    "start",
+    "select_detail",
+    "cancel",
+    "is_waiting",
+    "handle_photo",
+    "run_ocr",
+]


### PR DESCRIPTION
## Summary
- add a dedicated `vision_test` helper to manage OCR comparison sessions and call OpenAI vision models
- register the new `/ocrtest` superadmin command, callback handlers, and keep the session active while posters are processed
- document the diagnostic command and cover the flow with focused async tests

## Testing
- `pytest` *(terminated after extended runtime)*
- `pytest tests/test_ocrtest.py::test_ocrtest_start_superadmin`
- `pytest tests/test_ocrtest.py::test_ocrtest_denies_non_admin`
- `pytest tests/test_ocrtest.py::test_select_detail_updates_state`
- `pytest tests/test_ocrtest.py::test_handle_photo_uses_both_models`

------
https://chatgpt.com/codex/tasks/task_e_68ca8795cf408332a3752033826ade8c