### PR TITLE
Integrate poster OCR processing and reuse media uploads

### DIFF
--- a/poster_media.py
+++ b/poster_media.py
@@ -1,0 +1,129 @@
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+from dataclasses import dataclass, field
+from importlib import import_module
+from typing import Iterable, Sequence
+
+from vision_test.ocr import OcrResult, configure_http as _configure_ocr_http, run_ocr
+
+__all__ = [
+    "PosterMedia",
+    "process_media",
+    "collect_poster_texts",
+    "build_poster_summary",
+]
+
+
+@dataclass(slots=True)
+class PosterMedia:
+    """Container for processed poster information."""
+
+    data: bytes = field(repr=False)
+    name: str
+    catbox_url: str | None = None
+    ocr_text: str | None = None
+    prompt_tokens: int | None = None
+    completion_tokens: int | None = None
+    total_tokens: int | None = None
+
+    def clear_payload(self) -> None:
+        """Release in-memory payload after processing."""
+
+        if self.data:
+            self.data = b""
+
+
+_OCR_CONFIGURED = False
+
+
+def _ensure_ocr_http() -> None:
+    global _OCR_CONFIGURED
+    if _OCR_CONFIGURED:
+        return
+    main_mod = import_module("main")
+    session = main_mod.get_http_session()
+    semaphore = main_mod.HTTP_SEMAPHORE
+    _configure_ocr_http(session=session, semaphore=semaphore)
+    _OCR_CONFIGURED = True
+
+
+async def _run_ocr(poster: PosterMedia, model: str, detail: str) -> None:
+    try:
+        result: OcrResult = await run_ocr(poster.data, model=model, detail=detail)
+    except Exception as exc:  # pragma: no cover - network/remote failures
+        logging.warning("poster ocr failed name=%s error=%s", poster.name, exc)
+        return
+    poster.ocr_text = result.text
+    usage = result.usage
+    poster.prompt_tokens = usage.prompt_tokens
+    poster.completion_tokens = usage.completion_tokens
+    poster.total_tokens = usage.total_tokens
+
+
+async def process_media(
+    images: Iterable[tuple[bytes, str]] | None,
+    *,
+    need_catbox: bool,
+    need_ocr: bool,
+) -> tuple[list[PosterMedia], str]:
+    """Upload media to Catbox and optionally run OCR over them."""
+
+    raw = list(images or [])
+    if not raw:
+        return [], ""
+
+    posters = [PosterMedia(data=data, name=name) for data, name in raw]
+    catbox_msg = ""
+
+    if need_catbox:
+        main_mod = import_module("main")
+        upload_images = main_mod.upload_images
+        catbox_urls, catbox_msg = await upload_images(raw)
+        for poster, url in zip(posters, catbox_urls):
+            poster.catbox_url = url
+
+    if need_ocr:
+        _ensure_ocr_http()
+        model = os.getenv("POSTER_OCR_MODEL", "gpt-4o-mini")
+        detail = os.getenv("POSTER_OCR_DETAIL", "auto")
+        for poster in posters:
+            await _run_ocr(poster, model=model, detail=detail)
+
+    for poster in posters:
+        poster.clear_payload()
+
+    return posters, catbox_msg
+
+
+def collect_poster_texts(poster_media: Sequence[PosterMedia]) -> list[str]:
+    """Return cleaned OCR texts from processed posters."""
+
+    texts: list[str] = []
+    for poster in poster_media:
+        if poster.ocr_text:
+            text = poster.ocr_text.strip()
+            if text:
+                texts.append(text)
+    return texts
+
+
+def build_poster_summary(poster_media: Sequence[PosterMedia]) -> str | None:
+    """Return a short summary describing OCR token usage."""
+
+    if not poster_media:
+        return None
+
+    prompt = sum(p.prompt_tokens or 0 for p in poster_media)
+    completion = sum(p.completion_tokens or 0 for p in poster_media)
+    total = sum(p.total_tokens or 0 for p in poster_media)
+
+    if prompt == completion == total == 0:
+        return f"Posters processed: {len(poster_media)}."
+
+    return (
+        f"Posters processed: {len(poster_media)}. "
+        f"Tokens — prompt: {prompt}, completion: {completion}, total: {total}."
+    )

--- a/tests/test_vk_intake_metrics.py
+++ b/tests/test_vk_intake_metrics.py
@@ -28,7 +28,7 @@ async def test_vk_intake_processing_time_metric(tmp_path, monkeypatch):
             is_free=False,
         )
 
-    monkeypatch.setattr(vk_intake, "build_event_payload_from_vk", fake_build)
+    monkeypatch.setattr(vk_intake, "build_event_draft", fake_build)
     monkeypatch.setattr(vk_intake, "persist_event_and_pages", fake_persist)
 
     times = iter([1.0, 2.0])

--- a/tests/test_vkrev_import_flow.py
+++ b/tests/test_vkrev_import_flow.py
@@ -46,6 +46,8 @@ async def test_vkrev_import_flow_persists_url_and_skips_vk_sync(tmp_path, monkey
 
     async def fake_build(
         text,
+        *,
+        photos=None,
         source_name=None,
         location_hint=None,
         default_time=None,
@@ -73,7 +75,7 @@ async def test_vkrev_import_flow_persists_url_and_skips_vk_sync(tmp_path, monkey
         await session.commit()
 
     monkeypatch.setattr(main, "_vkrev_fetch_photos", fake_fetch)
-    monkeypatch.setattr(vk_intake, "build_event_payload_from_vk", fake_build)
+    monkeypatch.setattr(vk_intake, "build_event_draft", fake_build)
     monkeypatch.setattr(vk_review, "mark_imported", fake_mark_imported)
     monkeypatch.setattr(main, "enqueue_job", fake_enqueue_job)
 


### PR DESCRIPTION
## Summary
- add a reusable `poster_media` module to upload poster images to Catbox, run OCR, and summarise token usage
- extend `parse_event_via_4o`, add-event handlers, and album/forward flows to reuse processed media, pass poster OCR context, and avoid duplicate downloads
- update the VK intake pipeline and related tests to process poster media once, retain Catbox URLs, and expose poster metadata on event drafts

## Testing
- pytest tests/test_auto_program_url.py tests/test_vkrev_import_flow.py tests/test_vk_intake_metrics.py

------
https://chatgpt.com/codex/tasks/task_e_68cb0b8fe1408332970934825b7030d0