### PR TITLE
Add poster OCR cache and usage tracking

### DIFF
--- a/alembic/versions/20250903_poster_ocr_cache.py
+++ b/alembic/versions/20250903_poster_ocr_cache.py
@@ -1,0 +1,35 @@
+"""poster OCR cache tables"""
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+revision: str = "20250903_poster_ocr_cache"
+down_revision: Union[str, None] = "20250902_festival_photo_urls"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "posterocrcache",
+        sa.Column("hash", sa.String(), primary_key=True),
+        sa.Column("detail", sa.String(), nullable=False),
+        sa.Column("model", sa.String(), nullable=False),
+        sa.Column("text", sa.Text(), nullable=False),
+        sa.Column("prompt_tokens", sa.Integer(), nullable=False, server_default="0"),
+        sa.Column("completion_tokens", sa.Integer(), nullable=False, server_default="0"),
+        sa.Column("total_tokens", sa.Integer(), nullable=False, server_default="0"),
+        sa.Column("created_at", sa.DateTime(), nullable=False, server_default=sa.text("CURRENT_TIMESTAMP")),
+    )
+    op.create_table(
+        "ocrusage",
+        sa.Column("date", sa.String(), primary_key=True),
+        sa.Column("spent_tokens", sa.Integer(), nullable=False, server_default="0"),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("ocrusage")
+    op.drop_table("posterocrcache")

--- a/db.py
+++ b/db.py
@@ -345,6 +345,30 @@ class Database:
             )
 
             await conn.execute(
+                """
+                CREATE TABLE IF NOT EXISTS posterocrcache(
+                    hash TEXT PRIMARY KEY,
+                    detail TEXT NOT NULL,
+                    model TEXT NOT NULL,
+                    text TEXT NOT NULL,
+                    prompt_tokens INTEGER NOT NULL DEFAULT 0,
+                    completion_tokens INTEGER NOT NULL DEFAULT 0,
+                    total_tokens INTEGER NOT NULL DEFAULT 0,
+                    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+                )
+                """
+            )
+
+            await conn.execute(
+                """
+                CREATE TABLE IF NOT EXISTS ocrusage(
+                    date TEXT PRIMARY KEY,
+                    spent_tokens INTEGER NOT NULL DEFAULT 0
+                )
+                """
+            )
+
+            await conn.execute(
                 "CREATE INDEX IF NOT EXISTS idx_festival_name ON festival(name)"
             )
             await conn.execute(

--- a/models.py
+++ b/models.py
@@ -198,7 +198,22 @@ class JobOutbox(SQLModel, table=True):
     updated_at: datetime = Field(default_factory=datetime.utcnow)
     next_run_at: datetime = Field(default_factory=datetime.utcnow)
     coalesce_key: Optional[str] = None
-    depends_on: Optional[str] = None
+
+
+class PosterOcrCache(SQLModel, table=True):
+    hash: str = Field(primary_key=True)
+    detail: str
+    model: str
+    text: str
+    prompt_tokens: int = 0
+    completion_tokens: int = 0
+    total_tokens: int = 0
+    created_at: datetime = Field(default_factory=datetime.utcnow)
+
+
+class OcrUsage(SQLModel, table=True):
+    date: str = Field(primary_key=True)
+    spent_tokens: int = 0
 
 
 def create_all(engine) -> None:

--- a/poster_ocr.py
+++ b/poster_ocr.py
@@ -1,0 +1,105 @@
+from __future__ import annotations
+
+import hashlib
+import os
+from datetime import datetime, timezone
+from typing import Any, Iterable
+
+from sqlmodel import select
+
+from db import Database
+from models import OcrUsage as OcrUsageModel, PosterOcrCache
+from vision_test.ocr import run_ocr
+
+DAILY_TOKEN_LIMIT = 10_000_000
+
+
+def _today_key() -> str:
+    return datetime.now(timezone.utc).date().isoformat()
+
+
+def _ensure_bytes(item: Any) -> bytes:
+    if isinstance(item, (bytes, bytearray, memoryview)):
+        return bytes(item)
+    if isinstance(item, tuple) and item:
+        return bytes(item[0])
+    if isinstance(item, dict) and "data" in item:
+        return bytes(item["data"])
+    data = getattr(item, "data", None)
+    if data is None:
+        raise TypeError("poster OCR item must provide image bytes")
+    return bytes(data)
+
+
+async def recognize_posters(
+    db: Database,
+    items: Iterable[Any],
+    detail: str = "auto",
+    *,
+    count_usage: bool = True,
+) -> list[PosterOcrCache]:
+    payloads: list[tuple[bytes, str]] = []
+    for item in items:
+        data = _ensure_bytes(item)
+        digest = hashlib.sha256(data).hexdigest()
+        payloads.append((data, digest))
+    if not payloads:
+        return []
+
+    model = os.getenv("POSTER_OCR_MODEL", "gpt-4o-mini")
+    async with db.get_session() as session:
+        hashes = [digest for _, digest in payloads]
+        cache_map: dict[str, PosterOcrCache] = {}
+        if hashes:
+            result = await session.execute(
+                select(PosterOcrCache).where(PosterOcrCache.hash.in_(hashes))
+            )
+            for row in result.scalars():
+                cache_map[row.hash] = row
+
+        results: list[PosterOcrCache] = []
+        pending: list[PosterOcrCache] = []
+        total_new_tokens = 0
+
+        for data, digest in payloads:
+            cached = cache_map.get(digest)
+            if cached and cached.detail == detail:
+                results.append(cached)
+                continue
+
+            ocr_result = await run_ocr(data, model=model, detail=detail)
+            usage = ocr_result.usage
+            entry = PosterOcrCache(
+                hash=digest,
+                detail=detail,
+                model=model,
+                text=ocr_result.text,
+                prompt_tokens=int(getattr(usage, "prompt_tokens", 0) or 0),
+                completion_tokens=int(getattr(usage, "completion_tokens", 0) or 0),
+                total_tokens=int(getattr(usage, "total_tokens", 0) or 0),
+            )
+            pending.append(entry)
+            results.append(entry)
+            cache_map[digest] = entry
+            if count_usage:
+                total_new_tokens += entry.total_tokens
+
+        if pending:
+            if count_usage and total_new_tokens:
+                today = _today_key()
+                usage_row = await session.get(OcrUsageModel, today)
+                if usage_row is None:
+                    usage_row = OcrUsageModel(date=today, spent_tokens=0)
+                new_total = usage_row.spent_tokens + total_new_tokens
+                if new_total > DAILY_TOKEN_LIMIT:
+                    await session.rollback()
+                    raise RuntimeError("poster OCR daily token limit exceeded")
+                usage_row.spent_tokens = new_total
+                session.add(usage_row)
+            for entry in pending:
+                session.add(entry)
+            await session.commit()
+            for entry in pending:
+                await session.refresh(entry)
+
+        return results

--- a/tests/test_poster_ocr.py
+++ b/tests/test_poster_ocr.py
@@ -1,0 +1,102 @@
+import hashlib
+from dataclasses import dataclass
+
+import pytest
+
+from db import Database
+from models import OcrUsage, PosterOcrCache
+import poster_ocr
+from vision_test.ocr import OcrResult, OcrUsage as OcrUsageStats
+
+
+@dataclass
+class DummyPoster:
+    data: bytes
+
+
+@pytest.mark.asyncio
+async def test_recognize_posters_uses_cache(tmp_path, monkeypatch):
+    db = Database(str(tmp_path / "db.sqlite"))
+    await db.init()
+
+    call_count = 0
+
+    async def fake_run_ocr(data, *, model, detail):
+        nonlocal call_count
+        call_count += 1
+        return OcrResult(
+            text="hello",
+            usage=OcrUsageStats(prompt_tokens=1, completion_tokens=2, total_tokens=3),
+        )
+
+    monkeypatch.setattr(poster_ocr, "run_ocr", fake_run_ocr)
+
+    items = [DummyPoster(b"data")]
+    result1 = await poster_ocr.recognize_posters(db, items)
+    result2 = await poster_ocr.recognize_posters(db, items)
+
+    assert call_count == 1
+    assert result1[0].text == "hello"
+    assert result2[0].text == "hello"
+
+
+@pytest.mark.asyncio
+async def test_recognize_posters_usage_resets_by_date(tmp_path, monkeypatch):
+    db = Database(str(tmp_path / "db.sqlite"))
+    await db.init()
+
+    async def fake_run_ocr(data, *, model, detail):
+        return OcrResult(
+            text="ok",
+            usage=OcrUsageStats(prompt_tokens=0, completion_tokens=0, total_tokens=100),
+        )
+
+    monkeypatch.setattr(poster_ocr, "run_ocr", fake_run_ocr)
+    monkeypatch.setattr(poster_ocr, "_today_key", lambda: "2024-06-01")
+
+    await poster_ocr.recognize_posters(db, [DummyPoster(b"one")])
+
+    monkeypatch.setattr(poster_ocr, "_today_key", lambda: "2024-06-02")
+    await poster_ocr.recognize_posters(db, [DummyPoster(b"two")])
+
+    async with db.get_session() as session:
+        usage_first = await session.get(OcrUsage, "2024-06-01")
+        usage_second = await session.get(OcrUsage, "2024-06-02")
+
+    assert usage_first is not None
+    assert usage_second is not None
+    assert usage_first.spent_tokens == 100
+    assert usage_second.spent_tokens == 100
+
+
+@pytest.mark.asyncio
+async def test_recognize_posters_limit_exceeded(tmp_path, monkeypatch):
+    db = Database(str(tmp_path / "db.sqlite"))
+    await db.init()
+
+    async def fake_run_ocr(data, *, model, detail):
+        return OcrResult(
+            text="limit",
+            usage=OcrUsageStats(prompt_tokens=0, completion_tokens=0, total_tokens=100),
+        )
+
+    monkeypatch.setattr(poster_ocr, "run_ocr", fake_run_ocr)
+    monkeypatch.setattr(poster_ocr, "_today_key", lambda: "2024-06-03")
+
+    async with db.get_session() as session:
+        session.add(OcrUsage(date="2024-06-03", spent_tokens=poster_ocr.DAILY_TOKEN_LIMIT - 50))
+        await session.commit()
+
+    item = DummyPoster(b"exceed")
+    digest = hashlib.sha256(item.data).hexdigest()
+
+    with pytest.raises(RuntimeError):
+        await poster_ocr.recognize_posters(db, [item])
+
+    async with db.get_session() as session:
+        usage_row = await session.get(OcrUsage, "2024-06-03")
+        cached = await session.get(PosterOcrCache, digest)
+
+    assert usage_row is not None
+    assert usage_row.spent_tokens == poster_ocr.DAILY_TOKEN_LIMIT - 50
+    assert cached is None


### PR DESCRIPTION
## Summary
- add SQLModel models and Alembic migration for poster OCR cache entries and daily usage tokens
- implement `poster_ocr.recognize_posters` to reuse cached OCR results, persist new ones, and enforce a 10M token daily cap
- initialize new tables in the async database setup and add tests for cache hits, date rollovers, and limit failures

## Testing
- pytest tests/test_poster_ocr.py

------
https://chatgpt.com/codex/tasks/task_e_68cb1b55123c833284314176119e26af