### PR TITLE
Add event topic classification via 4o

### DIFF
--- a/tests/test_event_topics.py
+++ b/tests/test_event_topics.py
@@ -1,0 +1,97 @@
+import json
+import os
+import sys
+from types import SimpleNamespace
+
+import pytest
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+
+import main
+
+
+@pytest.mark.asyncio
+async def test_classify_event_topics_filters_and_limits(monkeypatch):
+    monkeypatch.setenv("FOUR_O_MINI", "1")
+    captured: dict[str, object] = {}
+
+    async def fake_ask(text, **kwargs):
+        captured["text"] = text
+        captured["kwargs"] = kwargs
+        return json.dumps(
+            {
+                "topics": [
+                    "Музыка",
+                    "неизвестная",
+                    "искусство",
+                    "кино",
+                    "музыка",
+                    "урбанистика",
+                ]
+            }
+        )
+
+    monkeypatch.setattr(main, "ask_4o", fake_ask)
+
+    event = SimpleNamespace(
+        title="Большой концерт",
+        description="Подробное описание мероприятия.",
+        source_text="Анонс события #музыка #концерт",
+        location_name="Главная сцена",
+        location_address="Невский проспект, 1",
+        city="Санкт-Петербург",
+    )
+
+    result = await main.classify_event_topics(event)
+
+    assert result == ["музыка", "искусство", "кино"]
+    assert "#музыка" in captured["text"]
+    kwargs = captured["kwargs"]
+    assert kwargs["model"] == "gpt-4o-mini"
+    assert kwargs["system_prompt"] == main.EVENT_TOPIC_SYSTEM_PROMPT
+    enum_values = kwargs["response_format"]["json_schema"]["schema"]["properties"]["topics"]["items"][
+        "enum"
+    ]
+    assert sorted(enum_values) == sorted(main.TOPIC_LABELS.keys())
+
+
+@pytest.mark.asyncio
+async def test_classify_event_topics_handles_invalid_json(monkeypatch):
+    async def fake_ask(*args, **kwargs):
+        return "{invalid_json}"
+
+    monkeypatch.setattr(main, "ask_4o", fake_ask)
+
+    event = SimpleNamespace(
+        title="Лекция",
+        description="Интересное событие",
+        source_text="",
+        location_name="",
+        location_address="",
+        city="",
+    )
+
+    result = await main.classify_event_topics(event)
+
+    assert result == []
+
+
+@pytest.mark.asyncio
+async def test_classify_event_topics_handles_exception(monkeypatch):
+    async def fake_ask(*args, **kwargs):
+        raise RuntimeError("network error")
+
+    monkeypatch.setattr(main, "ask_4o", fake_ask)
+
+    event = SimpleNamespace(
+        title="Мастер-класс",
+        description="",
+        source_text="",
+        location_name="",
+        location_address="",
+        city="",
+    )
+
+    result = await main.classify_event_topics(event)
+
+    assert result == []


### PR DESCRIPTION
## Summary
- allow overriding the model used by ask_4o to support the mini variant
- add classify_event_topics helper that prepares prompt context, calls 4o and validates the response
- cover topic classification behaviour with async unit tests that mock ask_4o

## Testing
- pytest tests/test_event_topics.py

------
https://chatgpt.com/codex/tasks/task_e_68cba491e57c83328353ad1042fb4997