### PR TITLE
Adjust Poster OCR cache primary key and update detail handling

### DIFF
--- a/alembic/versions/20250903_poster_ocr_cache.py
+++ b/alembic/versions/20250903_poster_ocr_cache.py
@@ -15,8 +15,8 @@ def upgrade() -> None:
     op.create_table(
         "posterocrcache",
         sa.Column("hash", sa.String(), primary_key=True),
-        sa.Column("detail", sa.String(), nullable=False),
-        sa.Column("model", sa.String(), nullable=False),
+        sa.Column("detail", sa.String(), primary_key=True),
+        sa.Column("model", sa.String(), primary_key=True),
         sa.Column("text", sa.Text(), nullable=False),
         sa.Column("prompt_tokens", sa.Integer(), nullable=False, server_default="0"),
         sa.Column("completion_tokens", sa.Integer(), nullable=False, server_default="0"),

--- a/db.py
+++ b/db.py
@@ -351,14 +351,15 @@ class Database:
             await conn.execute(
                 """
                 CREATE TABLE IF NOT EXISTS posterocrcache(
-                    hash TEXT PRIMARY KEY,
+                    hash TEXT NOT NULL,
                     detail TEXT NOT NULL,
                     model TEXT NOT NULL,
                     text TEXT NOT NULL,
                     prompt_tokens INTEGER NOT NULL DEFAULT 0,
                     completion_tokens INTEGER NOT NULL DEFAULT 0,
                     total_tokens INTEGER NOT NULL DEFAULT 0,
-                    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+                    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+                    PRIMARY KEY (hash, detail, model)
                 )
                 """
             )

--- a/models.py
+++ b/models.py
@@ -217,8 +217,8 @@ class JobOutbox(SQLModel, table=True):
 
 class PosterOcrCache(SQLModel, table=True):
     hash: str = Field(primary_key=True)
-    detail: str
-    model: str
+    detail: str = Field(primary_key=True)
+    model: str = Field(primary_key=True)
     text: str
     prompt_tokens: int = 0
     completion_tokens: int = 0


### PR DESCRIPTION
## Summary
- extend the `PosterOcrCache` primary key to include detail and model fields, updating the migration and SQLite bootstrap
- adjust poster OCR recognition logic to look up cache entries by `(hash, detail, model)` and refresh existing rows instead of adding duplicates
- update poster OCR tests to cover detail changes and the new composite key lookups

## Testing
- pytest tests/test_poster_ocr.py

------
https://chatgpt.com/codex/tasks/task_e_68cba533165483329efb6823ca0c5f9d