### PR TITLE
Update event topic system prompt

### DIFF
--- a/main.py
+++ b/main.py
@@ -4630,11 +4630,21 @@ async def ask_4o(
     return content
 
 
-EVENT_TOPIC_SYSTEM_PROMPT = (
-    "You are an assistant that classifies cultural events into topics. "
-    "Respond with JSON containing the `topics` array of applicable topic identifiers. "
-    "Use only the allowed topics and prefer the most relevant ones. Return an empty array if no topics apply."
+_EVENT_TOPIC_LISTING = "\n".join(
+    f"- {topic} — «{label}»" for topic, label in TOPIC_LABELS.items()
 )
+
+EVENT_TOPIC_SYSTEM_PROMPT = textwrap.dedent(
+    f"""
+    Ты — ассистент, который классифицирует культурные события по темам.
+    Верни JSON с массивом `topics`, где указаны подходящие идентификаторы тем.
+    Используй ровно англоязычные идентификаторы из списка ниже и не добавляй ничего вне его.
+    Не используй темы «Бесплатно» и «Фестивали».
+    Каждый идентификатор должен быть записан ровно так, как указан ниже:
+    {_EVENT_TOPIC_LISTING}
+    Если ни одна тема не подходит, верни пустой массив.
+    """
+).strip()
 
 EVENT_TOPIC_RESPONSE_FORMAT = {
     "type": "json_schema",

--- a/tests/test_event_topics.py
+++ b/tests/test_event_topics.py
@@ -10,6 +10,15 @@ sys.path.append(os.path.dirname(os.path.dirname(__file__)))
 import main
 
 
+def test_event_topic_prompt_mentions_topics():
+    prompt = main.EVENT_TOPIC_SYSTEM_PROMPT
+    for key, label in main.TOPIC_LABELS.items():
+        assert key in prompt
+        assert label in prompt
+    assert "Бесплатно" in prompt
+    assert "Фестивали" in prompt
+
+
 @pytest.mark.asyncio
 async def test_classify_event_topics_filters_and_limits(monkeypatch):
     monkeypatch.setenv("FOUR_O_MINI", "1")


### PR DESCRIPTION
## Summary
- rewrite the event topic classification system prompt in Russian with an auto-generated list of topics and explicit rules for identifiers
- cover the prompt contents with a regression test to ensure topic keys and labels remain listed

## Testing
- `pytest tests/test_event_topics.py`


------
https://chatgpt.com/codex/tasks/task_e_68cbbd442c2c8332913ed7f8fc053f12