### PR TITLE
Update event topic taxonomy and prompts

### DIFF
--- a/main.py
+++ b/main.py
@@ -179,6 +179,8 @@ from sqlalchemy import select, update, delete, text, func, or_
 
 from models import (
     TOPIC_LABELS,
+    TOPIC_IDENTIFIERS,
+    normalize_topic_identifier,
     User,
     PendingUser,
     RejectedUser,
@@ -4637,10 +4639,11 @@ _EVENT_TOPIC_LISTING = "\n".join(
 EVENT_TOPIC_SYSTEM_PROMPT = textwrap.dedent(
     f"""
     Ты — ассистент, который классифицирует культурные события по темам.
-    Верни JSON с массивом `topics`, где указаны подходящие идентификаторы тем.
-    Используй ровно англоязычные идентификаторы из списка ниже и не добавляй ничего вне его.
-    Не используй темы «Бесплатно» и «Фестивали».
-    Каждый идентификатор должен быть записан ровно так, как указан ниже:
+    Верни JSON с массивом `topics`: выбери от 0 до 3 подходящих идентификаторов тем.
+    Используй только идентификаторы из списка ниже, записывай их ровно так, как показано, и не добавляй другие значения.
+    Не отмечай темы про скидки, «Бесплатно» или бесплатное участие и игнорируй «Фестивали», сетевые программы и серии мероприятий.
+    Не повторяй одинаковые идентификаторы.
+    Допустимые темы:
     {_EVENT_TOPIC_LISTING}
     Если ни одна тема не подходит, верни пустой массив.
     """
@@ -4649,7 +4652,7 @@ EVENT_TOPIC_SYSTEM_PROMPT = textwrap.dedent(
 EVENT_TOPIC_RESPONSE_FORMAT = {
     "type": "json_schema",
     "json_schema": {
-        "name": "event_topics",
+        "name": "EventTopics",
         "schema": {
             "type": "object",
             "properties": {
@@ -4659,6 +4662,8 @@ EVENT_TOPIC_RESPONSE_FORMAT = {
                         "type": "string",
                         "enum": sorted(TOPIC_LABELS.keys()),
                     },
+                    "maxItems": 3,
+                    "uniqueItems": True,
                 }
             },
             "required": ["topics"],
@@ -4685,7 +4690,7 @@ def _extract_available_hashtags(event: Event) -> list[str]:
 
 
 async def classify_event_topics(event: Event) -> list[str]:
-    allowed_topics = set(TOPIC_LABELS.keys())
+    allowed_topics = TOPIC_IDENTIFIERS
     title = (getattr(event, "title", "") or "").strip()
     descriptions: list[str] = []
     for attr in ("description", "source_text"):
@@ -4750,15 +4755,15 @@ async def classify_event_topics(event: Event) -> list[str]:
         logging.warning("Topic classification response missing list: %s", raw)
         return []
     result: list[str] = []
+    seen: set[str] = set()
     for topic in topics:
-        if not isinstance(topic, str):
+        canonical = normalize_topic_identifier(topic)
+        if canonical is None or canonical not in allowed_topics:
             continue
-        normalized = topic.strip().lower()
-        if not normalized or normalized not in allowed_topics:
+        if canonical in seen:
             continue
-        if normalized in result:
-            continue
-        result.append(normalized)
+        seen.add(canonical)
+        result.append(canonical)
         if len(result) >= 3:
             break
     return result
@@ -13734,14 +13739,23 @@ def _topic_labels_for_display(topics: Sequence[str] | None) -> list[str]:
 
     seen: set[str] = set()
     for topic in topics:
-        if not topic:
+        if not isinstance(topic, str):
             continue
-        key = topic.casefold()
-        label = TOPIC_LABELS.get(key, topic)
-        if key in seen:
+        raw = topic.strip()
+        if not raw:
             continue
-        seen.add(key)
-        labels.append(label)
+        canonical = normalize_topic_identifier(raw)
+        if canonical:
+            if canonical in seen:
+                continue
+            seen.add(canonical)
+            labels.append(TOPIC_LABELS.get(canonical, canonical))
+        else:
+            dedup_key = raw.casefold()
+            if dedup_key in seen:
+                continue
+            seen.add(dedup_key)
+            labels.append(raw)
     return labels
 
 
@@ -15402,16 +15416,14 @@ async def handle_backfill_topics(
                 )
                 continue
 
-            seen: dict[str, None] = {}
+            seen: set[str] = set()
             normalized_topics: list[str] = []
             for topic in new_topics_raw:
-                if not isinstance(topic, str):
+                canonical = normalize_topic_identifier(topic)
+                if canonical is None or canonical in seen:
                     continue
-                normalized = topic.strip()
-                if not normalized or normalized in seen:
-                    continue
-                seen[normalized] = None
-                normalized_topics.append(normalized)
+                seen.add(canonical)
+                normalized_topics.append(canonical)
 
             event.topics = normalized_topics
             event.topics_manual = False

--- a/models.py
+++ b/models.py
@@ -8,16 +8,56 @@ from sqlalchemy.types import Enum as SAEnum
 
 
 TOPIC_LABELS: dict[str, str] = {
-    "искусство": "Искусство",
-    "история россии": "История России",
-    "технологии": "Технологии",
-    "психология": "Психология",
-    "урбанистика": "Урбанистика",
-    "литература": "Литература",
-    "кино": "Кино",
-    "музыка": "Музыка",
-    "бизнес": "Бизнес",
+    "ART": "Искусство",
+    "HISTORY_RU": "История России",
+    "TECH": "Технологии",
+    "PSYCHOLOGY": "Психология",
+    "URBANISM": "Урбанистика",
+    "LITERATURE": "Литература",
+    "CINEMA": "Кино",
+    "MUSIC": "Музыка",
+    "BUSINESS": "Бизнес",
+    "PARTY": "Вечеринки",
+    "STANDUP": "Стендапы/комедия",
 }
+
+TOPIC_IDENTIFIERS: set[str] = set(TOPIC_LABELS.keys())
+
+_TOPIC_LEGACY_ALIASES: dict[str, str] = {
+    "искусство": "ART",
+    "история россии": "HISTORY_RU",
+    "технологии": "TECH",
+    "психология": "PSYCHOLOGY",
+    "урбанистика": "URBANISM",
+    "литература": "LITERATURE",
+    "кино": "CINEMA",
+    "музыка": "MUSIC",
+    "бизнес": "BUSINESS",
+    "вечеринка": "PARTY",
+    "вечер": "PARTY",
+    "вечеринки": "PARTY",
+    "стендап": "STANDUP",
+    "стендапы": "STANDUP",
+    "комедия": "STANDUP",
+}
+
+TOPIC_IDENTIFIERS_BY_CASEFOLD: dict[str, str] = {
+    key.casefold(): key for key in TOPIC_IDENTIFIERS
+}
+TOPIC_IDENTIFIERS_BY_CASEFOLD.update(
+    {alias.casefold(): canonical for alias, canonical in _TOPIC_LEGACY_ALIASES.items()}
+)
+
+
+def normalize_topic_identifier(value: str | None) -> str | None:
+    if not isinstance(value, str):
+        return None
+    candidate = value.strip()
+    if not candidate:
+        return None
+    if candidate in TOPIC_IDENTIFIERS:
+        return candidate
+    return TOPIC_IDENTIFIERS_BY_CASEFOLD.get(candidate.casefold())
 
 
 class User(SQLModel, table=True):

--- a/tests/test_add_events_from_text_topics.py
+++ b/tests/test_add_events_from_text_topics.py
@@ -34,7 +34,7 @@ async def test_add_events_from_text_assigns_topics(tmp_path: Path, monkeypatch):
         return "https://t.me/test", "path", "", 0
 
     async def fake_classify(event: Event):
-        return ["музыка", "вечер"]
+        return ["MUSIC", "PARTY"]
 
     monkeypatch.setattr(main, "parse_event_via_4o", fake_parse)
     monkeypatch.setattr(main, "schedule_event_update_tasks", fake_schedule_event_update_tasks)
@@ -48,7 +48,7 @@ async def test_add_events_from_text_assigns_topics(tmp_path: Path, monkeypatch):
     async with db.get_session() as session:
         stored = await session.get(Event, saved_events[0].id)
 
-    assert stored.topics == ["музыка", "вечер"]
+    assert stored.topics == ["MUSIC", "PARTY"]
     assert stored.topics_manual is False
 
 
@@ -77,7 +77,7 @@ async def test_add_events_from_text_multiday_inherits_topics(tmp_path: Path, mon
 
     async def fake_classify(event: Event):
         calls["classify"] += 1
-        return ["фестиваль"]
+        return ["PARTY"]
 
     async def fake_schedule_event_update_tasks(db_obj, event_obj, drain_nav=True):
         return {}
@@ -105,5 +105,5 @@ async def test_add_events_from_text_multiday_inherits_topics(tmp_path: Path, mon
         (start_day + timedelta(days=1)).isoformat(),
     ]
     for ev in stored_events:
-        assert ev.topics == ["фестиваль"]
+        assert ev.topics == ["PARTY"]
         assert ev.topics_manual is False

--- a/tests/test_backfill_topics_command.py
+++ b/tests/test_backfill_topics_command.py
@@ -73,10 +73,14 @@ async def test_backfill_topics_command_updates_events(tmp_path, monkeypatch):
         await session.commit()
 
     captured_titles: list[str] = []
+    topic_map = {
+        "Event A": ["ART"],
+        "Event B": ["MUSIC"],
+    }
 
     async def fake_classify(event):
         captured_titles.append(event.title)
-        return [f"topic-{event.title}"]
+        return topic_map.get(event.title, [])
 
     monkeypatch.setattr(main, "classify_event_topics", fake_classify)
 
@@ -118,9 +122,9 @@ async def test_backfill_topics_command_updates_events(tmp_path, monkeypatch):
         event_c = stored_c.scalars().first()
         event_d = stored_d.scalars().first()
 
-    assert event_a.topics == ["topic-Event A"]
+    assert event_a.topics == ["ART"]
     assert event_a.topics_manual is False
-    assert event_b.topics == ["topic-Event B"]
+    assert event_b.topics == ["MUSIC"]
     assert event_b.topics_manual is False
     assert event_c.topics == ["manual"]
     assert event_c.topics_manual is True

--- a/tests/test_bot.py
+++ b/tests/test_bot.py
@@ -888,7 +888,7 @@ async def test_show_edit_menu_formats_topics():
         date=FUTURE_DATE,
         time="18:00",
         location_name="Hall",
-        topics=["искусство", "музыка"],
+        topics=["ART", "MUSIC"],
         topics_manual=True,
     )
 
@@ -4642,7 +4642,7 @@ async def test_build_events_message_includes_topic_badges(tmp_path: Path):
                 date=target.isoformat(),
                 time="10:00",
                 location_name="Hall",
-                topics=["искусство", "музыка"],
+                topics=["ART", "MUSIC"],
             )
         )
         await session.commit()

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -84,7 +84,7 @@ async def test_event_topics_roundtrip(tmp_path):
             time="10:00",
             location_name="Loc",
             source_text="Src",
-            topics=["искусство"],
+            topics=["ART"],
             topics_manual=True,
         )
         session.add(ev)
@@ -96,12 +96,12 @@ async def test_event_topics_roundtrip(tmp_path):
             "SELECT topics, topics_manual FROM event WHERE id=?", (event_id,)
         )
         row = await cursor.fetchone()
-    assert json.loads(row[0]) == ["искусство"]
+    assert json.loads(row[0]) == ["ART"]
     assert row[1] in (1, True)
 
     async with db.get_session() as session:
         stored = await session.get(Event, event_id)
         assert stored is not None
-        assert stored.topics == ["искусство"]
+        assert stored.topics == ["ART"]
         assert stored.topics_manual is True
 

--- a/tests/test_event_topics.py
+++ b/tests/test_event_topics.py
@@ -30,12 +30,12 @@ async def test_classify_event_topics_filters_and_limits(monkeypatch):
         return json.dumps(
             {
                 "topics": [
-                    "Музыка",
+                    "MUSIC",
                     "неизвестная",
-                    "искусство",
-                    "кино",
-                    "музыка",
-                    "урбанистика",
+                    "art",
+                    "CINEMA",
+                    "MUSIC",
+                    "URBANISM",
                 ]
             }
         )
@@ -53,7 +53,7 @@ async def test_classify_event_topics_filters_and_limits(monkeypatch):
 
     result = await main.classify_event_topics(event)
 
-    assert result == ["музыка", "искусство", "кино"]
+    assert result == ["MUSIC", "ART", "CINEMA"]
     assert "#музыка" in captured["text"]
     kwargs = captured["kwargs"]
     assert kwargs["model"] == "gpt-4o-mini"

--- a/tests/test_lecture_digest.py
+++ b/tests/test_lecture_digest.py
@@ -334,16 +334,16 @@ def test_format_event_line_and_link_priority():
 
 def test_aggregate_topics():
     events = [
-        SimpleNamespace(topics=["искусство", "культура"]),
-        SimpleNamespace(topics=["история россии", "российская история"]),
-        SimpleNamespace(topics=["ит", "тех"]),
-        SimpleNamespace(topics=["музыка"]),
+        SimpleNamespace(topics=["ART", "культура"]),
+        SimpleNamespace(topics=["HISTORY_RU", "российская история"]),
+        SimpleNamespace(topics=["TECH", "тех"]),
+        SimpleNamespace(topics=["MUSIC"]),
         SimpleNamespace(topics=["культура"]),
     ]
     assert aggregate_digest_topics(events) == [
-        "искусство",
-        "история россии",
-        "музыка",
+        "ART",
+        "HISTORY_RU",
+        "MUSIC",
     ]
 
 

--- a/tests/test_vk_persist_source_post_url.py
+++ b/tests/test_vk_persist_source_post_url.py
@@ -87,7 +87,7 @@ async def test_persist_event_and_pages_classifies_topics(tmp_path, monkeypatch):
 
     async def fake_classify(event: Event):
         calls["topics"] += 1
-        return ["музыка"]
+        return ["MUSIC"]
 
     monkeypatch.setattr(main, "schedule_event_update_tasks", fake_schedule_event_update_tasks)
     monkeypatch.setattr(main, "classify_event_topics", fake_classify)
@@ -106,7 +106,7 @@ async def test_persist_event_and_pages_classifies_topics(tmp_path, monkeypatch):
         saved = await session.get(Event, res.event_id)
 
     assert calls["topics"] == 1
-    assert saved.topics == ["музыка"]
+    assert saved.topics == ["MUSIC"]
     assert saved.topics_manual is False
 
 
@@ -168,7 +168,7 @@ async def test_upsert_event_preserves_manual_topics(tmp_path):
             location_address="Addr",
             city="City",
             source_text="Manual",
-            topics=["искусство"],
+        topics=["ART"],
             topics_manual=True,
         )
         session.add(existing)
@@ -186,7 +186,7 @@ async def test_upsert_event_preserves_manual_topics(tmp_path):
             location_address="Addr",
             city="City",
             source_text="Manual",
-            topics=["музыка"],
+            topics=["MUSIC"],
             topics_manual=False,
         )
         saved, created = await main.upsert_event(session, new)
@@ -196,7 +196,7 @@ async def test_upsert_event_preserves_manual_topics(tmp_path):
     async with db.get_session() as session:
         refreshed = await session.get(Event, event_id)
         assert refreshed is not None
-        assert refreshed.topics == ["искусство"]
+        assert refreshed.topics == ["ART"]
         assert refreshed.topics_manual is True
 
 
@@ -234,7 +234,7 @@ async def test_upsert_event_updates_topics_when_not_manual(tmp_path):
             location_address="Addr",
             city="City",
             source_text="Auto",
-            topics=["музыка"],
+            topics=["MUSIC"],
             topics_manual=True,
         )
         saved, created = await main.upsert_event(session, new)
@@ -244,5 +244,5 @@ async def test_upsert_event_updates_topics_when_not_manual(tmp_path):
     async with db.get_session() as session:
         refreshed = await session.get(Event, event_id)
         assert refreshed is not None
-        assert refreshed.topics == ["музыка"]
+        assert refreshed.topics == ["MUSIC"]
         assert refreshed.topics_manual is True


### PR DESCRIPTION
## Summary
- switch TOPIC_LABELS to uppercase English identifiers with legacy normalization helpers
- refresh the topic classification prompt, response schema, and post-processing to honour the new taxonomy
- align digests and tests with the canonical identifiers and updated display logic

## Testing
- pytest tests/test_event_topics.py tests/test_add_events_from_text_topics.py tests/test_backfill_topics_command.py tests/test_vk_persist_source_post_url.py tests/test_lecture_digest.py -q

------
https://chatgpt.com/codex/tasks/task_e_68cbc13c88608332af4590167c030407