### PR TITLE
Clarify poster OCR handling in 4o prompt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 ## Unreleased
 - Added `/ocrtest` diagnostic command, чтобы сравнить распознавание афиш между `gpt-4o-mini` и `gpt-4o` с показом использования токенов.
 
+- Clarified the 4o parsing prompt to warn about possible OCR mistakes in poster snippets.
+
 ## v0.1.0 – Deploy + US-02 + /tz
 - Initial Fly.io deployment config.
 - Moderator registration queue with approve/reject.

--- a/docs/PROMPTS.md
+++ b/docs/PROMPTS.md
@@ -36,6 +36,10 @@ The bot adds these markers automatically on the opening and closing dates.
 Lines from `docs/LOCATIONS.md` are appended to the system prompt so the model
 can normalise venue names. Please keep that file up to date.
 
+When the user message contains a `Poster OCR` block, remember that OCR can
+introduce errors or spurious data. Compare those snippets with the main event
+description and reject details that obviously contradict the primary text.
+
 The user message will start with the current date, e.g. "Today is
 2025-07-05." Use this information to resolve missing years. **Ignore and do not
 include any event whose date is earlier than today.**

--- a/main.py
+++ b/main.py
@@ -4501,6 +4501,9 @@ async def parse_event_via_4o(
     user_msg = "".join(user_msg_parts)
     poster_lines: list[str] = []
     if poster_texts:
+        poster_lines.append(
+            "Poster OCR may contain recognition mistakes; cross-check with the main text."
+        )
         poster_lines.append("Poster OCR:")
         for idx, block in enumerate(poster_texts, start=1):
             poster_lines.append(f"[{idx}] {block.strip()}")


### PR DESCRIPTION
## Summary
- document that Poster OCR snippets may contain recognition mistakes and should be validated against the main description
- prepend the Poster OCR section in parse_event_via_4o with a warning sentence and cover it with a unit test
- note the prompt update in the changelog

## Testing
- pytest tests/test_bot.py::test_parse_event_includes_date tests/test_bot.py::test_parse_event_includes_poster_hint

------
https://chatgpt.com/codex/tasks/task_e_68cbe609af1c8332a9c9357b716b6ef5