### PR TITLE
Update handmade topic label to highlight fairs

### DIFF
--- a/docs/COMMANDS.md
+++ b/docs/COMMANDS.md
@@ -37,3 +37,29 @@
 
 Use `/addevent` to let model 4o extract fields. `/addevent_raw` lets you
 input simple data separated by `|` pipes.
+
+## Event topics
+
+The classifier assigns up to three topic identifiers to each event. The same labels
+appear in the `/events` listing so moderators instantly see the context. Current
+labels:
+
+- `STANDUP` — «Стендап и комедия»
+- `QUIZ_GAMES` — «Квизы и игры»
+- `OPEN_AIR` — «Фестивали и open-air»
+- `PARTIES` — «Вечеринки»
+- `CONCERTS` — «Концерты»
+- `MOVIES` — «Кино»
+- `EXHIBITIONS` — «Выставки и арт»
+- `THEATRE` — «Театр»
+- `LECTURES` — «Лекции и встречи»
+- `MASTERCLASS` — «Мастер-классы»
+- `SCIENCE_POP` — «Научпоп»
+- `HANDMADE` — «Хендмейд/маркеты/ярмарки/МК» (сюда попадают ярмарки и pop-up маркеты)
+- `NETWORKING` — «Нетворкинг и карьера»
+- `ACTIVE` — «Активный отдых и спорт»
+- `PERSONALITIES` — «Личности и встречи»
+- `KIDS_SCHOOL` — «Дети и школа»
+- `FAMILY` — «Семейные события»
+
+Редактируя события, ориентируйтесь на эти подписи: их видят админы и читатели.

--- a/models.py
+++ b/models.py
@@ -19,7 +19,7 @@ TOPIC_LABELS: dict[str, str] = {
     "LECTURES": "Лекции и встречи",
     "MASTERCLASS": "Мастер-классы",
     "SCIENCE_POP": "Научпоп",
-    "HANDMADE": "Маркет и хендмейд",
+    "HANDMADE": "Хендмейд/маркеты/ярмарки/МК",
     "NETWORKING": "Нетворкинг и карьера",
     "ACTIVE": "Активный отдых и спорт",
     "PERSONALITIES": "Личности и встречи",

--- a/tests/test_event_topics.py
+++ b/tests/test_event_topics.py
@@ -18,6 +18,7 @@ def test_event_topic_prompt_mentions_topics():
         assert label in prompt
     assert "Бесплатно" in prompt
     assert "Фестивали" in prompt
+    assert "ярмарк" in prompt.casefold()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- expand the HANDMADE topic label so fairs and markets are mentioned in the UI and prompts
- assert the regenerated system prompt keeps the new wording for fairs
- document the available event topics for moderators including the updated HANDMADE label

## Testing
- pytest tests/test_event_topics.py

------
https://chatgpt.com/codex/tasks/task_e_68cc054fa4508332a3a9ba239e1719f1