### PR TITLE
Add JobOutbox depends_on field to ORM and test merge handling

### DIFF
--- a/models.py
+++ b/models.py
@@ -387,6 +387,7 @@ class JobOutbox(SQLModel, table=True):
     updated_at: datetime = Field(default_factory=datetime.utcnow)
     next_run_at: datetime = Field(default_factory=datetime.utcnow)
     coalesce_key: Optional[str] = None
+    depends_on: Optional[str] = None
 
 
 class PosterOcrCache(SQLModel, table=True):

--- a/tests/test_job_outbox_depends.py
+++ b/tests/test_job_outbox_depends.py
@@ -1,0 +1,61 @@
+import os
+import sys
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+
+import pytest
+
+from main import Database, enqueue_job
+from models import Event, JobOutbox, JobStatus, JobTask
+
+
+@pytest.mark.asyncio
+async def test_enqueue_job_merges_depends_on(tmp_path):
+    db = Database(str(tmp_path / "db.sqlite"))
+    await db.init()
+
+    async with db.get_session() as session:
+        event = Event(
+            title="Title",
+            description="Description",
+            date="2025-01-01",
+            time="10:00",
+            location_name="Location",
+            source_text="Source",
+        )
+        session.add(event)
+        await session.commit()
+        await session.refresh(event)
+        event_id = event.id
+
+        job = JobOutbox(
+            event_id=event_id,
+            task=JobTask.month_pages,
+            status=JobStatus.pending,
+            depends_on="initial",
+            coalesce_key="month_pages:2025-01",
+        )
+        session.add(job)
+        await session.commit()
+        await session.refresh(job)
+        job_id = job.id
+
+    async with db.get_session() as session:
+        job = await session.get(JobOutbox, job_id)
+        assert job is not None
+        assert job.depends_on == "initial"
+
+    result = await enqueue_job(
+        db,
+        event_id=event_id,
+        task=JobTask.month_pages,
+        depends_on=["followup"],
+    )
+
+    assert result == "merged-rearmed"
+
+    async with db.get_session() as session:
+        job = await session.get(JobOutbox, job_id)
+        assert job is not None
+        assert job.depends_on == "followup,initial"
+        assert job.status == JobStatus.pending


### PR DESCRIPTION
## Summary
- expose the joboutbox.depends_on column through the SQLModel definition
- add an async test that ensures enqueue_job reads and merges depends_on values from existing rows

## Testing
- pytest tests/test_job_outbox_depends.py

------
https://chatgpt.com/codex/tasks/task_e_68cc19fea2dc8332b4935c3a5f9fae8a