### PR TITLE
Show full poster OCR text in edit menu

### DIFF
--- a/main.py
+++ b/main.py
@@ -14149,22 +14149,6 @@ async def show_edit_menu(
             ).scalars().all()
         if posters:
             poster_lines.append("Poster OCR:")
-
-            def _clean_lines(text: str) -> list[str]:
-                max_lines = 3
-                max_len = 120
-                result: list[str] = []
-                for raw in text.splitlines():
-                    cleaned = raw.strip()
-                    if not cleaned:
-                        continue
-                    if len(cleaned) > max_len:
-                        cleaned = cleaned[: max_len - 1] + "…"
-                    result.append(cleaned)
-                    if len(result) >= max_lines:
-                        break
-                return result or ["<пусто>"]
-
             for idx, poster in enumerate(posters[:3], 1):
                 token_parts: list[str] = []
                 if poster.prompt_tokens:
@@ -14176,7 +14160,11 @@ async def show_edit_menu(
                 token_info = f" ({', '.join(token_parts)})" if token_parts else ""
                 hash_display = poster.poster_hash[:10]
                 poster_lines.append(f"{idx}. hash={hash_display}{token_info}")
-                for text_line in _clean_lines(poster.ocr_text or ""):
+                raw_lines = (poster.ocr_text or "").splitlines()
+                cleaned_lines = [line.strip() for line in raw_lines if line.strip()]
+                if not cleaned_lines:
+                    cleaned_lines = ["<пусто>"]
+                for text_line in cleaned_lines:
                     poster_lines.append(f"    {text_line}")
                 if poster.catbox_url:
                     url = poster.catbox_url

--- a/tests/test_bot.py
+++ b/tests/test_bot.py
@@ -898,7 +898,7 @@ async def test_show_edit_menu_formats_topics():
 
     assert bot.messages
     message_text = bot.messages[-1][1]
-    assert "Темы: Искусство, Музыка (ручной режим)" in message_text
+    assert "Темы: Выставки и арт, Концерты (ручной режим)" in message_text
 
 
 @pytest.mark.asyncio
@@ -946,7 +946,7 @@ async def test_show_edit_menu_displays_poster_ocr_preview(tmp_path: Path):
     assert "Строка один" in message_text
     assert "Строка два" in message_text
     assert "Строка три" in message_text
-    assert "Строка четыре" not in message_text
+    assert "Строка четыре" in message_text
     assert "https://cat.box/a" in message_text
 
 


### PR DESCRIPTION
## Summary
- show the full OCR transcript for each poster in the edit menu while keeping catbox link truncation and blank-line cleanup
- ensure empty OCR blocks render as `<пусто>`
- update bot tests to expect the expanded OCR block and current topic labels

## Testing
- pytest tests/test_bot.py::test_show_edit_menu_displays_poster_ocr_preview
- pytest tests/test_bot.py::test_show_edit_menu_formats_topics


------
https://chatgpt.com/codex/tasks/task_e_68cc395045908332a02e06240198f3aa