### PR TITLE
Use per-loop lock for due jobs

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -11,6 +11,11 @@ from models import PosterOcrCache
 
 
 @pytest.fixture(autouse=True)
+def _reset_run_due_jobs_lock():
+    main._reset_run_due_jobs_locks()
+
+
+@pytest.fixture(autouse=True)
 def _mock_telegraph(monkeypatch, request):
     if "get_telegraph_token" not in request.node.nodeid:
         monkeypatch.setattr(main, "get_telegraph_token", lambda: "t")


### PR DESCRIPTION
## Summary
- create a weakly-referenced lock cache keyed by the running asyncio loop so each loop uses its own `_run_due_jobs` guard
- update `_run_due_jobs_once` to acquire the loop-scoped lock
- reset the lock cache in the pytest autouse fixture to avoid cross-loop leakage in async tests

## Testing
- pytest tests/test_job_due_filter.py

------
https://chatgpt.com/codex/tasks/task_e_68cc71bb756883329fa22df13df4c70e