### PR TITLE
Add logging for poster media uploads

### DIFF
--- a/poster_media.py
+++ b/poster_media.py
@@ -103,8 +103,22 @@ async def process_media(
 
     if need_catbox:
         main_mod = _get_main_module()
+        catbox_enabled = getattr(main_mod, "CATBOX_ENABLED", None)
+        preprocessed_provided = any(p.catbox_url for p in posters)
+        logging.info(
+            "poster_media upload start: need_catbox=%s catbox_enabled=%s raw_count=%d preprocessed=%s",
+            need_catbox,
+            catbox_enabled,
+            len(raw),
+            preprocessed_provided,
+        )
         upload_images = main_mod.upload_images
         catbox_urls, catbox_msg = await upload_images(raw)
+        logging.info(
+            "poster_media upload complete: url_count=%d catbox_msg=%s",
+            len(catbox_urls),
+            catbox_msg,
+        )
         for poster, url in zip(posters, catbox_urls):
             poster.catbox_url = url
 

--- a/tests/test_poster_media.py
+++ b/tests/test_poster_media.py
@@ -49,6 +49,27 @@ async def test_process_media_uses_active_main(monkeypatch, caplog):
         assert all(p.catbox_url for p in posters)
         assert catbox_msg == "ok"
         assert "CATBOX disabled" not in caplog.text
+        start_log = next(
+            record
+            for record in caplog.records
+            if "poster_media upload start" in record.getMessage()
+        )
+        assert start_log.levelno == logging.INFO
+        message = start_log.getMessage()
+        assert "need_catbox=True" in message
+        assert "catbox_enabled=True" in message
+        assert "raw_count=1" in message
+        assert "preprocessed=False" in message
+
+        complete_log = next(
+            record
+            for record in caplog.records
+            if "poster_media upload complete" in record.getMessage()
+        )
+        assert complete_log.levelno == logging.INFO
+        complete_message = complete_log.getMessage()
+        assert "url_count=1" in complete_message
+        assert "catbox_msg=ok" in complete_message
     finally:
         if original_main is not None:
             sys.modules["main"] = original_main


### PR DESCRIPTION
## Summary
- add diagnostic logging around Catbox uploads in poster_media.process_media
- include upload result details in logs for correlation
- extend poster media tests to verify the new log entries

## Testing
- pytest tests/test_poster_media.py

------
https://chatgpt.com/codex/tasks/task_e_68cc879c0dcc8332b36de7f68b1aefb5