### PR TITLE
Log context when Catbox is disabled

### DIFF
--- a/main.py
+++ b/main.py
@@ -2727,6 +2727,7 @@ async def upload_images(
     limit: int = MAX_ALBUM_IMAGES,
     *,
     force: bool = False,
+    event_hint: str | None = None,
 ) -> tuple[list[str], str]:
     """Upload images to Catbox with retries."""
     catbox_urls: list[str] = []
@@ -2735,7 +2736,13 @@ async def upload_images(
         return [], ""
     logging.info("CATBOX start images=%d limit=%d", len(images or []), limit)
     if not CATBOX_ENABLED and not force:
-        logging.info("CATBOX disabled")
+        logging.info(
+            "CATBOX disabled catbox_enabled=%s force=%s images=%d event_hint=%s",
+            CATBOX_ENABLED,
+            force,
+            len(images or []),
+            event_hint,
+        )
         return [], "disabled"
 
     session = get_http_session()

--- a/tests/test_upload_images.py
+++ b/tests/test_upload_images.py
@@ -1,4 +1,5 @@
 import asyncio
+import logging
 
 import pytest
 
@@ -24,7 +25,7 @@ class DummySession:
     def __init__(self, responses):
         self._responses = iter(responses)
 
-    async def post(self, url, data):
+    def post(self, url, data):
         return next(self._responses)
 
 
@@ -51,4 +52,18 @@ async def test_upload_images_fail(monkeypatch):
     urls, msg = await main.upload_images([(b"1", "a.png")])
     assert urls == []
     assert "failed" in msg
+
+
+@pytest.mark.asyncio
+async def test_upload_images_catbox_disabled(monkeypatch, caplog):
+    main.CATBOX_ENABLED = False
+    caplog.set_level(logging.INFO)
+    urls, msg = await main.upload_images([(b"1", "a.png")], event_hint="test")
+    assert urls == []
+    assert msg == "disabled"
+    assert any(
+        "CATBOX disabled catbox_enabled=False force=False images=1 event_hint=test"
+        in record.message
+        for record in caplog.records
+    )
 


### PR DESCRIPTION
## Summary
- add an optional `event_hint` argument to `upload_images` and enrich the Catbox disabled log with flag, force, and image count details
- expand upload image tests to cover the disabled Catbox branch and adjust the dummy session to mimic aiohttp's context manager

## Testing
- pytest tests/test_upload_images.py

------
https://chatgpt.com/codex/tasks/task_e_68cc886ab3fc83329c42910b572c0eda