### PR TITLE
Log photo download sizes

### DIFF
--- a/tests/test_vkrev_import_flow.py
+++ b/tests/test_vkrev_import_flow.py
@@ -99,13 +99,15 @@ async def test_download_photo_media_logs_mime(monkeypatch, caplog):
     ]
 
     messages = [record.message for record in caplog.records if record.levelno == logging.INFO]
+    size_0 = len(payloads[urls[0]])
+    size_1 = len(payloads[urls[1]])
     assert (
-        f"vk.photo_media processed idx=0 url={urls[0]} subtype=jpeg filename=converted.jpg"
-        in messages
+        "vk.photo_media processed idx=0 url="
+        f"{urls[0]} size={size_0} subtype=jpeg filename=converted.jpg" in messages
     )
     assert (
-        f"vk.photo_media processed idx=1 url={urls[1]} subtype=jpeg filename=vk_poster_2.jpg"
-        in messages
+        "vk.photo_media processed idx=1 url="
+        f"{urls[1]} size={size_1} subtype=jpeg filename=vk_poster_2.jpg" in messages
     )
 
 

--- a/vk_intake.py
+++ b/vk_intake.py
@@ -329,17 +329,25 @@ async def _download_photo_media(urls: Sequence[str]) -> list[tuple[bytes, str]]:
                         raise ValueError("file too large")
                     return data
 
+        size = None
         try:
             data = await asyncio.wait_for(_fetch(), timeout)
+            size = len(data)
+            data, name = ensure_jpeg(data, f"vk_poster_{idx + 1}.jpg")
+            subtype = detect_image_type(data)
         except Exception as exc:  # pragma: no cover - network dependent
-            logging.warning("vk.download_photo_failed url=%s error=%s", url, exc)
+            logging.warning(
+                "vk.download_photo_failed url=%s size=%s error=%s",
+                url,
+                size if size is not None else "unknown",
+                exc,
+            )
             continue
-        data, name = ensure_jpeg(data, f"vk_poster_{idx + 1}.jpg")
-        subtype = detect_image_type(data)
         logging.info(
-            "vk.photo_media processed idx=%s url=%s subtype=%s filename=%s",
+            "vk.photo_media processed idx=%s url=%s size=%d subtype=%s filename=%s",
             idx,
             url,
+            size if size is not None else 0,
             subtype or "unknown",
             name,
         )


### PR DESCRIPTION
## Summary
- include the downloaded payload size in the photo processing log entry
- extend error logging for failed downloads to mention the observed size when available
- adjust the vk photo media logging test to assert that size information is recorded

## Testing
- pytest tests/test_vkrev_import_flow.py::test_download_photo_media_logs_mime

------
https://chatgpt.com/codex/tasks/task_e_68cd46f3f4008332ac3ab4967328fbea