### PR TITLE
Handle exhibition end dates in digest

### DIFF
--- a/digests.py
+++ b/digests.py
@@ -733,6 +733,25 @@ def format_event_line_html(
 
     dt = datetime.strptime(event.date, "%Y-%m-%d")
     date_part = dt.strftime("%d.%m")
+    if (event.event_type or "").lower() == "выставка":
+        end_raw = getattr(event, "end_date", None)
+        if end_raw:
+            try:
+                end_dt = datetime.strptime(end_raw, "%Y-%m-%d")
+            except ValueError:
+                logging.warning(
+                    "digest.end_date.format event_id=%s end_date_raw=%r",
+                    getattr(event, "id", None),
+                    end_raw,
+                )
+            else:
+                date_part = f"{date_part} по {end_dt.strftime('%d.%m')}"
+        else:
+            logging.warning(
+                "digest.end_date.missing event_id=%s event_type=%r",
+                getattr(event, "id", None),
+                event.event_type,
+            )
     time_part = ""
     parsed = parse_start_time(event.time or "")
     if parsed is not None:

--- a/tests/test_lecture_digest.py
+++ b/tests/test_lecture_digest.py
@@ -460,6 +460,66 @@ def test_format_event_line_and_link_priority():
     assert pick_display_link(e) == "https://telegra.ph/foo"
 
 
+def test_format_event_line_html_exhibition_end_date():
+    e = Event(
+        title="T",
+        description="d",
+        date="2025-05-10",
+        time="18:30",
+        location_name="L",
+        source_text="s",
+        event_type="выставка",
+        source_post_url="http://t.me/post",
+        end_date="2025-05-12",
+    )
+
+    line = format_event_line_html(e, None)
+
+    assert line == "10.05 по 12.05 18:30 | T"
+
+
+def test_format_event_line_html_exhibition_missing_end_date(caplog):
+    caplog.set_level(logging.WARNING)
+
+    e = Event(
+        title="T",
+        description="d",
+        date="2025-05-10",
+        time="18:30",
+        location_name="L",
+        source_text="s",
+        event_type="выставка",
+        source_post_url="http://t.me/post",
+        end_date=None,
+    )
+
+    line = format_event_line_html(e, None)
+
+    assert line == "10.05 18:30 | T"
+    assert any("digest.end_date.missing" in r.message for r in caplog.records)
+
+
+def test_format_event_line_html_exhibition_bad_end_date(caplog):
+    caplog.set_level(logging.WARNING)
+
+    e = Event(
+        title="T",
+        description="d",
+        date="2025-05-10",
+        time="18:30",
+        location_name="L",
+        source_text="s",
+        event_type="выставка",
+        source_post_url="http://t.me/post",
+        end_date="2025/05/12",
+    )
+
+    line = format_event_line_html(e, None)
+
+    assert line == "10.05 18:30 | T"
+    assert any("digest.end_date.format" in r.message for r in caplog.records)
+
+
 def test_aggregate_topics():
     events = [
         SimpleNamespace(topics=["ART", "культура"]),


### PR DESCRIPTION
## Summary
- append exhibition end dates to digest lines and log malformed or missing end dates without failing
- extend digest formatting tests to cover exhibition date formatting and logging edge cases

## Testing
- pytest tests/test_lecture_digest.py::test_format_event_line_html_exhibition_end_date tests/test_lecture_digest.py::test_format_event_line_html_exhibition_missing_end_date tests/test_lecture_digest.py::test_format_event_line_html_exhibition_bad_end_date

------
https://chatgpt.com/codex/tasks/task_e_68cd8128089883329ff7f43f396e9cb7