### PR TITLE
Add exhibitions digest selection

### DIFF
--- a/main.py
+++ b/main.py
@@ -129,6 +129,7 @@ from net import http_call, VK_FALLBACK_CODES
 from digests import (
     build_lectures_digest_preview,
     build_masterclasses_digest_preview,
+    build_exhibitions_digest_preview,
     format_event_line_html,
     pick_display_link,
     extract_catbox_covers_from_telegraph,
@@ -14648,7 +14649,10 @@ async def show_digest_menu(message: types.Message, db: Database, bot: Bot) -> No
             types.InlineKeyboardButton(text="⏳ Популярное за неделю", callback_data="digest:disabled"),
         ],
         [
-            types.InlineKeyboardButton(text="⏳ Новые выставки", callback_data="digest:disabled"),
+            types.InlineKeyboardButton(
+                text="✅ Выставки",
+                callback_data=f"digest:select:exhibitions:{digest_id}",
+            ),
         ],
     ]
     markup = types.InlineKeyboardMarkup(inline_keyboard=keyboard)
@@ -19009,6 +19013,9 @@ def create_app() -> web.Application:
     async def digest_select_masterclasses_wrapper(callback: types.CallbackQuery):
         await handle_digest_select_masterclasses(callback, db, bot)
 
+    async def digest_select_exhibitions_wrapper(callback: types.CallbackQuery):
+        await handle_digest_select_exhibitions(callback, db, bot)
+
     async def digest_disabled_wrapper(callback: types.CallbackQuery):
         await callback.answer("Ещё не реализовано", show_alert=False)
 
@@ -19325,6 +19332,10 @@ def create_app() -> web.Application:
         lambda c: c.data.startswith("digest:select:masterclasses:"),
     )
     dp.callback_query.register(
+        digest_select_exhibitions_wrapper,
+        lambda c: c.data.startswith("digest:select:exhibitions:"),
+    )
+    dp.callback_query.register(
         digest_disabled_wrapper, lambda c: c.data == "digest:disabled"
     )
     dp.callback_query.register(
@@ -19580,6 +19591,20 @@ async def handle_digest_select_masterclasses(
         preview_builder=build_masterclasses_digest_preview,
         items_noun="мастер-классов",
         panel_text="Управление дайджестом мастер-классов\nВыключите лишнее и нажмите «Обновить превью».",
+    )
+
+
+async def handle_digest_select_exhibitions(
+    callback: types.CallbackQuery, db: Database, bot: Bot
+) -> None:
+    await _handle_digest_select(
+        callback,
+        db,
+        bot,
+        digest_type="exhibitions",
+        preview_builder=build_exhibitions_digest_preview,
+        items_noun="выставок",
+        panel_text="Управление дайджестом выставок\nВыключите лишнее и нажмите «Обновить превью».",
     )
 
 

--- a/tests/test_digest_command.py
+++ b/tests/test_digest_command.py
@@ -179,6 +179,65 @@ async def test_handle_digest_sends_masterclasses_preview(tmp_path, monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_handle_digest_sends_exhibitions_preview(tmp_path, monkeypatch):
+    db = Database(str(tmp_path / "db.sqlite"))
+    await db.init()
+    async with db.get_session() as session:
+        session.add(User(user_id=1, is_superadmin=True))
+        dt = datetime.now(timezone.utc) + timedelta(days=1)
+        ev = Event(
+            title="E1",
+            description="d",
+            date=dt.strftime("%Y-%m-%d"),
+            time="12:00",
+            location_name="loc",
+            source_text="s",
+            event_type="выставка",
+            telegraph_url="https://telegra.ph/test3",
+        )
+        session.add(ev)
+        await session.commit()
+    msg = types.Message.model_validate({
+        "message_id": 1,
+        "date": 0,
+        "chat": {"id": 1, "type": "private"},
+        "from": {"id": 1, "is_bot": False, "first_name": "U"},
+        "text": "/digest",
+    })
+    bot = DummyBot()
+
+    async def fake_ask(prompt, max_tokens=0):
+        return "Интро"
+
+    async def fake_extract(url, **kw):
+        return ["https://example.com/img3.jpg"]
+
+    monkeypatch.setattr(main, "ask_4o", fake_ask)
+    monkeypatch.setattr(main, "extract_catbox_covers_from_telegraph", fake_extract)
+
+    await main.show_digest_menu(msg, db, bot)
+    menu_msg = bot.messages[0]
+    digest_id = menu_msg.reply_markup.inline_keyboard[2][0].callback_data.split(":")[-1]
+
+    async def answer(**kw):
+        return None
+
+    cb = SimpleNamespace(
+        id="1",
+        from_user=SimpleNamespace(id=1),
+        message=menu_msg,
+        data=f"digest:select:exhibitions:{digest_id}",
+        answer=answer,
+    )
+
+    await main.handle_digest_select_exhibitions(cb, db, bot)
+    assert bot.media_groups
+    panel = bot.messages[-1]
+    assert panel.text.startswith("Управление дайджестом выставок")
+    assert main.digest_preview_sessions[digest_id]["items_noun"] == "выставок"
+
+
+@pytest.mark.asyncio
 async def test_digest_preview_deduplicates_media(monkeypatch):
     session = {
         "chat_id": 123,


### PR DESCRIPTION
## Summary
- enable digest selection for exhibitions with a dedicated inline button and handler
- register the exhibitions callback alongside existing digest handlers and preview flow

## Testing
- pytest tests/test_digest_command.py

------
https://chatgpt.com/codex/tasks/task_e_68cd82f8c72c833295ef4bbfadc08b6b