### PR TITLE
Enhance festival listing with paging and archive filter

### DIFF
--- a/docs/COMMANDS.md
+++ b/docs/COMMANDS.md
@@ -25,7 +25,7 @@
 | `/exhibitions` | - | List active exhibitions similar to `/events`; each entry shows the period `c <start>` / `по <end>` and includes edit/delete buttons. |
 | `/digest` | - | Build lecture digest with images, toggles and quick send buttons (superadmin only). |
 | `/pages` | - | Show links to Telegraph month and weekend pages. |
-| `/fest` | - | List festivals with edit/delete options. Tap **Edit** to pick description or contact fields to update. |
+| `/fest [archive] [page]` | optional `archive` flag and page number | List festivals with edit/delete options. Ten rows are shown per page with navigation buttons. Use `archive` to view finished festivals that no longer have upcoming events; omit it to see active ones. |
 
 
 

--- a/tests/test_bot.py
+++ b/tests/test_bot.py
@@ -6627,7 +6627,7 @@ async def test_daily_posts_festival_link(tmp_path: Path):
 
 
 @pytest.mark.asyncio
-async def test_handle_fest_list(tmp_path: Path):
+async def test_handle_fest_list_buttons(tmp_path: Path):
     db = Database(str(tmp_path / "db.sqlite"))
     await db.init()
     bot = DummyBot("123:abc")
@@ -6658,7 +6658,8 @@ async def test_handle_fest_list(tmp_path: Path):
         for btn in row
     )
     assert any(
-        btn.text == f"Delete {fid}" and btn.callback_data == f"festdel:{fid}"
+        btn.text == f"Delete {fid}"
+        and btn.callback_data == f"festdel:{fid}:1:active"
         for row in markup.inline_keyboard
         for btn in row
     )
@@ -7101,7 +7102,7 @@ async def test_festdays_requires_dates(tmp_path: Path, monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_handle_fest_list(tmp_path: Path):
+async def test_handle_fest_list_heading(tmp_path: Path):
     db = Database(str(tmp_path / "db.sqlite"))
     await db.init()
     bot = DummyBot("123:abc")
@@ -7121,10 +7122,203 @@ async def test_handle_fest_list(tmp_path: Path):
         }
     )
     await main.handle_fest(msg, db, bot)
-    assert "Jazz" in bot.messages[-1][1]
+    text = bot.messages[-1][1]
+    assert text.startswith("Фестивали активные (стр. 1/1)")
+    assert "Jazz" in text
 
 
 @pytest.mark.asyncio
+async def test_fest_list_pagination(tmp_path: Path):
+    db = Database(str(tmp_path / "db.sqlite"))
+    await db.init()
+    bot = DummyBot("123:abc")
+
+    async with db.get_session() as session:
+        session.add(User(user_id=1))
+        for idx in range(12):
+            session.add(main.Festival(name=f"Fest {idx+1}"))
+        await session.commit()
+
+    msg = types.Message.model_validate(
+        {
+            "message_id": 1,
+            "date": 0,
+            "chat": {"id": 1, "type": "private"},
+            "from": {"id": 1, "is_bot": False, "first_name": "A"},
+            "text": "/fest",
+        }
+    )
+    await main.handle_fest(msg, db, bot)
+    first_markup = bot.messages[-1][2]["reply_markup"]
+    per_fest_rows = [
+        row
+        for row in first_markup.inline_keyboard
+        if len(row) == 2 and row[0].text.startswith("Edit")
+    ]
+    assert len(per_fest_rows) == 10
+    assert any(
+        btn.callback_data == "festpage:2:active"
+        for row in first_markup.inline_keyboard
+        for btn in row
+    )
+    assert any(
+        btn.callback_data == "festpage:1:archive"
+        for row in first_markup.inline_keyboard
+        for btn in row
+    )
+
+    msg_page2 = types.Message.model_validate(
+        {
+            "message_id": 2,
+            "date": 0,
+            "chat": {"id": 1, "type": "private"},
+            "from": {"id": 1, "is_bot": False, "first_name": "A"},
+            "text": "/fest 2",
+        }
+    )
+    await main.handle_fest(msg_page2, db, bot)
+    text_page2 = bot.messages[-1][1]
+    assert "стр. 2/2" in text_page2
+    markup_page2 = bot.messages[-1][2]["reply_markup"]
+    per_fest_rows_page2 = [
+        row
+        for row in markup_page2.inline_keyboard
+        if len(row) == 2 and row[0].text.startswith("Edit")
+    ]
+    assert len(per_fest_rows_page2) == 2
+    assert any(
+        btn.callback_data == "festpage:1:active"
+        for row in markup_page2.inline_keyboard
+        for btn in row
+    )
+
+
+@pytest.mark.asyncio
+async def test_fest_list_filters_future_events(tmp_path: Path):
+    db = Database(str(tmp_path / "db.sqlite"))
+    await db.init()
+    bot = DummyBot("123:abc")
+
+    past_day = date.today() - timedelta(days=3)
+    future_day = date.today() + timedelta(days=5)
+
+    async with db.get_session() as session:
+        session.add(User(user_id=1))
+        fest_past = main.Festival(name="Past")
+        fest_future = main.Festival(name="Future")
+        session.add(fest_past)
+        session.add(fest_future)
+        session.add(
+            Event(
+                title="Old",
+                description="d",
+                source_text="s",
+                date=past_day.isoformat(),
+                end_date=past_day.isoformat(),
+                time="18:00",
+                location_name="Hall",
+                festival="Past",
+            )
+        )
+        session.add(
+            Event(
+                title="New",
+                description="d",
+                source_text="s",
+                date=future_day.isoformat(),
+                time="18:00",
+                location_name="Hall",
+                festival="Future",
+            )
+        )
+        await session.commit()
+
+    msg = types.Message.model_validate(
+        {
+            "message_id": 1,
+            "date": 0,
+            "chat": {"id": 1, "type": "private"},
+            "from": {"id": 1, "is_bot": False, "first_name": "A"},
+            "text": "/fest",
+        }
+    )
+    await main.handle_fest(msg, db, bot)
+    text = bot.messages[-1][1]
+    assert "Future" in text
+    assert "Past" not in text
+    markup = bot.messages[-1][2]["reply_markup"]
+    assert any(
+        btn.callback_data == "festpage:1:archive"
+        for row in markup.inline_keyboard
+        for btn in row
+    )
+
+
+@pytest.mark.asyncio
+async def test_fest_list_archive_mode(tmp_path: Path):
+    db = Database(str(tmp_path / "db.sqlite"))
+    await db.init()
+    bot = DummyBot("123:abc")
+
+    past_day = date.today() - timedelta(days=3)
+
+    async with db.get_session() as session:
+        session.add(User(user_id=1))
+        fest_past = main.Festival(name="Past")
+        fest_future = main.Festival(name="Future")
+        session.add(fest_past)
+        session.add(fest_future)
+        session.add(
+            Event(
+                title="Old",
+                description="d",
+                source_text="s",
+                date=past_day.isoformat(),
+                end_date=past_day.isoformat(),
+                time="18:00",
+                location_name="Hall",
+                festival="Past",
+            )
+        )
+        session.add(
+            Event(
+                title="Upcoming",
+                description="d",
+                source_text="s",
+                date=(date.today() + timedelta(days=1)).isoformat(),
+                time="18:00",
+                location_name="Hall",
+                festival="Future",
+            )
+        )
+        await session.commit()
+        past_id = fest_past.id
+
+    msg = types.Message.model_validate(
+        {
+            "message_id": 1,
+            "date": 0,
+            "chat": {"id": 1, "type": "private"},
+            "from": {"id": 1, "is_bot": False, "first_name": "A"},
+            "text": "/fest archive",
+        }
+    )
+    await main.handle_fest(msg, db, bot)
+    text = bot.messages[-1][1]
+    assert text.startswith("Фестивали архив (стр. 1/1)")
+    assert "Past" in text
+    assert "Future" not in text
+    markup = bot.messages[-1][2]["reply_markup"]
+    assert any(
+        btn.callback_data == f"festdel:{past_id}:1:archive"
+        for row in markup.inline_keyboard
+        for btn in row
+    )
+    assert any(
+        btn.callback_data == "festpage:1:active"
+        for row in markup.inline_keyboard
+        for btn in row
+    )
 async def test_month_page_festival_link(tmp_path: Path):
     db = Database(str(tmp_path / "db.sqlite"))
     await db.init()


### PR DESCRIPTION
## Summary
- paginate the `/fest` listing with aggregated event data, archive filtering, and navigation buttons
- extend callbacks and command parsing to preserve the selected page/mode and expose the archive view
- cover the new flows in tests and document the updated `/fest` command syntax

## Testing
- pytest tests/test_bot.py -k fest_list

------
https://chatgpt.com/codex/tasks/task_e_68cd8beb08708332ae1fcb2ec4215d70