### PR TITLE
Handle festival pagination callbacks

### DIFF
--- a/main.py
+++ b/main.py
@@ -19509,6 +19509,7 @@ def create_app() -> web.Application:
         or c.data.startswith("festedit:")
         or c.data.startswith("festeditfield:")
         or c.data == "festeditdone"
+        or c.data.startswith("festpage:")
         or c.data.startswith("festdel:")
         or c.data.startswith("setfest:")
         or c.data.startswith("festdays:")


### PR DESCRIPTION
## Summary
- ensure the dispatcher routes `festpage` callback queries to the existing request handler so pagination buttons are processed
- add a regression test covering active/archived festival pagination updates

## Testing
- pytest tests/test_bot.py -k fest_pagination_callback_updates_pages

------
https://chatgpt.com/codex/tasks/task_e_68cd9134a68083328e5216d5add79b69