### PR TITLE
Skip VK sync during makefest flow

### DIFF
--- a/main.py
+++ b/main.py
@@ -5730,7 +5730,6 @@ async def process_request(callback: types.CallbackQuery, db: Database, bot: Bot)
         await schedule_event_update_tasks(db, event)
         asyncio.create_task(sync_festival_page(db, fest_obj.name))
         asyncio.create_task(sync_festivals_index_page(db))
-        asyncio.create_task(sync_festival_vk_post(db, fest_obj.name, bot))
         summary_lines = [
             f"Фестиваль {fest_obj.name} создан." if created else f"Фестиваль {fest_obj.name} обновлён.",
             "Событие привязано к фестивалю.",
@@ -5816,7 +5815,6 @@ async def process_request(callback: types.CallbackQuery, db: Database, bot: Bot)
         await schedule_event_update_tasks(db, event)
         asyncio.create_task(sync_festival_page(db, fest.name))
         asyncio.create_task(sync_festivals_index_page(db))
-        asyncio.create_task(sync_festival_vk_post(db, fest.name, bot))
         await callback.message.answer(
             f"Событие привязано к фестивалю {fest.name}.",
         )

--- a/tests/test_bot.py
+++ b/tests/test_bot.py
@@ -2989,8 +2989,8 @@ async def test_makefest_create_links_event(tmp_path: Path, monkeypatch):
     async def fake_sync_index(db_obj):
         fake_sync_index.called = getattr(fake_sync_index, "called", []) + [True]
 
-    async def fake_sync_vk(db_obj, name, bot_obj, **kwargs):
-        fake_sync_vk.called = getattr(fake_sync_vk, "called", []) + [name]
+    async def fake_sync_vk(*args, **kwargs):
+        pytest.fail("VK sync should not be triggered for makefest create")
 
     monkeypatch.setattr(main, "schedule_event_update_tasks", fake_schedule)
     monkeypatch.setattr(main, "rebuild_fest_nav_if_changed", fake_rebuild)
@@ -3030,7 +3030,7 @@ async def test_makefest_create_links_event(tmp_path: Path, monkeypatch):
     assert getattr(fake_schedule, "called", []) == [event.id]
     assert getattr(fake_sync_page, "called", []) == ["New Fest"]
     assert getattr(fake_sync_index, "called", []) == [True]
-    assert getattr(fake_sync_vk, "called", []) == ["New Fest"]
+    # VK sync should not be triggered for makefest create flow
     assert responses
 
     async with db.get_session() as session:
@@ -3097,8 +3097,8 @@ async def test_makefest_bind_existing_festival(tmp_path: Path, monkeypatch):
     async def fake_sync_index(db_obj):
         fake_sync_index.called = getattr(fake_sync_index, "called", []) + [True]
 
-    async def fake_sync_vk(db_obj, name, bot_obj, **kwargs):
-        fake_sync_vk.called = getattr(fake_sync_vk, "called", []) + [name]
+    async def fake_sync_vk(*args, **kwargs):
+        pytest.fail("VK sync should not be triggered for makefest bind")
 
     monkeypatch.setattr(main, "schedule_event_update_tasks", fake_schedule)
     monkeypatch.setattr(main, "rebuild_fest_nav_if_changed", fake_rebuild)
@@ -3138,7 +3138,7 @@ async def test_makefest_bind_existing_festival(tmp_path: Path, monkeypatch):
     assert getattr(fake_schedule, "called", []) == [event.id]
     assert getattr(fake_sync_page, "called", []) == ["Existing"]
     assert getattr(fake_sync_index, "called", []) == [True]
-    assert getattr(fake_sync_vk, "called", []) == ["Existing"]
+    # VK sync should not be triggered for makefest bind flow
     assert responses
 
     async with db.get_session() as session:


### PR DESCRIPTION
## Summary
- stop triggering VK festival post synchronization when creating or binding a festival via the makefest flow
- keep other festival sync tasks (page and index) running after makefest actions
- extend makefest flow tests to ensure VK sync is not invoked

## Testing
- pytest tests/test_bot.py::test_makefest_create_links_event tests/test_bot.py::test_makefest_bind_existing_festival

------
https://chatgpt.com/codex/tasks/task_e_68ce5cfaf7a08332b7853b3fa0171ff5