### PR TITLE
Allow OCR-only VK posts to reach review queue

### DIFF
--- a/main.py
+++ b/main.py
@@ -18209,7 +18209,15 @@ async def _vkrev_show_next(chat_id: int, batch_id: str, operator_id: int, db: Da
 
     url = f"https://vk.com/wall-{post.group_id}_{post.post_id}"
     pending = await _vkrev_queue_size(db)
-    status_line = f"ключи: {post.matched_kw or '-'} | дата: {'да' if post.has_date else 'нет'} | в очереди: {pending}"
+    if post.matched_kw == vk_intake.OCR_PENDING_SENTINEL:
+        matched_kw_display = "ожидает OCR"
+    elif post.matched_kw:
+        matched_kw_display = post.matched_kw
+    else:
+        matched_kw_display = "-"
+    status_line = (
+        f"ключи: {matched_kw_display} | дата: {'да' if post.has_date else 'нет'} | в очереди: {pending}"
+    )
     markup = types.InlineKeyboardMarkup(
         inline_keyboard=[
             [


### PR DESCRIPTION
## Summary
- allow blank-text, single-photo VK posts to bypass keyword/date filters and mark them as OCR pending in intake
- show an "ожидает OCR" keyword indicator in the review UI so blank-text posts still render with the inline keyboard
- cover the new intake path and review rendering with regression tests

## Testing
- pytest tests/test_vk_intake_future.py tests/test_vk_review_show_next.py

------
https://chatgpt.com/codex/tasks/task_e_68ce6695e44083328c73cd5399626f8e