### PR TITLE
Document poster OCR pipeline and limits

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,17 @@ Fly.io with a webhook.
 Forwarded posts from moderators or admins are treated the same as the `/addevent` command.
 Use `/setchannel` to pick one of the channels where the bot has admin rights and register it either as an announcement source or as the calendar asset channel. `/channels` lists all admin channels and lets you disable these roles. When the asset channel is set, forwarded posts from it get a **Добавить в календарь** button linking to the calendar file.
 
+### Poster OCR and token usage
+
+When an event is added through `/addevent`, forwarded by a moderator, or imported from VK, the bot uploads each poster image to Catbox once and reuses the same bytes for OCR. Recognized text is cached per hash/detail/model pair, mixed into the 4o prompt alongside the operator message, and stored in the `EventPoster` records that feed later LLM passes. Operators see a short usage line indicating how many OCR tokens were spent and how many remain for the current day.
+
+Poster recognition can be tuned with environment variables:
+
+- `POSTER_OCR_MODEL` — overrides the default `gpt-4o-mini` model used for OCR.
+- `POSTER_OCR_DETAIL` — forwarded to the Vision API (`auto` by default) to balance quality and latency.
+
+The bot enforces a daily OCR budget of 10 000 000 tokens. Cached posters continue to work after the limit is reached, but new, uncached uploads are skipped until the counter resets at UTC midnight. Operators receive a warning whenever recognition is skipped because the limit was exhausted.
+
 Bot messages display dates in the format `DD.MM.YYYY`. Public pages such as
 Telegraph posts use the short form "D месяц" (e.g. `2 июля`).
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -28,3 +28,10 @@ When present the link is inserted into the Telegraph source page below the title
 If a text describes several events at once the LLM returns an array of event objects and the bot creates separate entries and Telegraph pages for each of them.
 Channels where the bot is admin are tracked in the `channel` table. Use `/setchannel` to choose an admin channel and mark it as an announcement source. The `/channels` command lists all admin channels and shows which ones are registered.
 `docs/LOCATIONS.md` contains standard venue names; its contents are appended to the 4o prompt so events use consistent `location_name` values.
+
+## Poster OCR pipeline
+
+- Poster media is uploaded to Catbox once per unique image; the resulting bytes feed both the Telegraph page and the OCR stage.
+- `poster_ocr.recognize_posters` caches results in `PosterOcrCache` by hash, detail level and model so retries reuse the stored text and token counts.
+- Daily usage is tracked in the `OcrUsage` table and compared against the 10 000 000-token budget. Cached entries keep working, while new, uncached OCR requests are blocked until the quota resets.
+- Recognized text is saved in `EventPoster` rows and injected into the downstream LLM pipeline so 4o sees both the operator draft and poster contents.

--- a/docs/COMMANDS.md
+++ b/docs/COMMANDS.md
@@ -7,7 +7,7 @@
 | `/help` | - | Show commands available for your role. |
 | `/requests` | - | Superadmin sees pending registrations with approve/reject buttons. |
 | `/tz <±HH:MM>` | required offset | Set timezone offset (superadmin only). |
-| `/addevent <text>` | event description | Parse text with model 4o and store one or several events. The original text is published to Telegraph. Images up to 5&nbsp;MB are uploaded to Catbox and shown on that page. Forwarded messages from moderators are processed the same way. |
+| `/addevent <text>` | event description | Parse text with model 4o and store one or several events. Poster images are uploaded to Catbox once, recognized via OCR, cached, and the extracted text is passed to 4o together with a token usage report for the operator. Forwarded messages from moderators are processed the same way. |
 | `/addevent_raw <title>|<date>|<time>|<location>` | manual fields | Add event without LLM. The bot also creates a Telegraph page with the provided text and optional attached photo. |
 | `/images` | - | Toggle uploading photos to Catbox. |
 | `/vkgroup <id|off>` | required id or `off` | Set or disable VK group for daily announcements. |
@@ -37,6 +37,9 @@
 
 Use `/addevent` to let model 4o extract fields. `/addevent_raw` lets you
 input simple data separated by `|` pipes.
+
+Poster OCR reuses cached recognitions and shares a 10 000 000-token daily budget; once the limit is exhausted new posters wait
+until the next reset at UTC midnight.
 
 ## Event topics
 


### PR DESCRIPTION
## Summary
- describe the poster OCR flow, token reporting, and configuration knobs in the README
- update /addevent command docs to explain OCR caching, token reports, and the shared daily budget
- add an architecture section covering the poster OCR pipeline, caches, and limit handling

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68ce6810967c83329b80527637e93544