### PR TITLE
Document new VK queue mixing logic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@
 
 - Clarified the 4o parsing prompt to warn about possible OCR mistakes in poster snippets.
 
+- Reworked the `/vk` review queue: URGENT cards (events happening within
+  `VK_REVIEW_URGENT_MAX_H=48` hours) always jump to the front, while the remaining
+  SOON/LONG/FAR buckets are mixed by a weighted lottery using the default
+  `VK_REVIEW_W_SOON=3`, `VK_REVIEW_W_LONG=2`, and `VK_REVIEW_W_FAR=6` factors with a
+  FAR streak breaker after `VK_REVIEW_FAR_GAP_K=5` non-FAR picks. Within the winning
+  bucket, cards keep chronological order but add a per-source jitter so big
+  communities cannot monopolise reviews.
 ## v0.1.0 – Deploy + US-02 + /tz
 - Initial Fly.io deployment config.
 - Moderator registration queue with approve/reject.


### PR DESCRIPTION
## Summary
- describe the new VK review queue prioritisation, weighted mixing, FAR streak breaker, and source jitter in the changelog

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68ce6b98b6208332b93c604e10eded77