### PR TITLE
Document topic auto-assignment enhancements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 
 ## Unreleased
+- Added automatic topic assignment when adding or importing events, finalized the list of 17 topic keys,
+  display topics in the editor, and added the `/backfill_topics` command.
 - Added `/ocrtest` diagnostic command, чтобы сравнить распознавание афиш между `gpt-4o-mini` и `gpt-4o` с показом использования токенов.
 
 - Clarified the 4o parsing prompt to warn about possible OCR mistakes in poster snippets.


### PR DESCRIPTION
## Summary
- note the new automatic topic assignment when adding or importing events, finalized list of 17 topic keys, editor display, and `/backfill_topics` command in the changelog

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68ce6c1387b083329eac3f031df32ee4