### PR TITLE
Document OCR status for single-photo VK posts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Результаты распознавания кешируются и уважают дневной лимит в 10 млн токенов.
 - Added `/ocrtest` diagnostic command, чтобы сравнить распознавание афиш между `gpt-4o-mini` и `gpt-4o` с показом использования токенов.
 - Clarified the 4o parsing prompt to warn about possible OCR mistakes in poster snippets.
+- VK Intake помещает посты с одной фотографией и пустым текстом в очередь и отмечает их статусом «Ожидает OCR».
 
 ## v0.1.0 – Deploy + US-02 + /tz
 - Initial Fly.io deployment config.

--- a/README.md
+++ b/README.md
@@ -26,6 +26,10 @@ batch can be finished with "🧹 Завершить…" which sequentially rebui
 affected month pages. Operators can run `/vk_queue` to see current inbox counts
 and get a button to start reviewing candidates.
 
+Even terse posts—such as a single photo with an empty caption—also enter the
+queue and are marked as **Ожидает OCR** so operators know they still require
+text extraction before review.
+
 ### Bucket windows and priorities
 
 Each queue item is assigned to a time-based bucket by comparing its `event_ts_hint` with the current moment:


### PR DESCRIPTION
## Summary
- document that single-photo VK posts with empty captions are still queued and flagged as awaiting OCR
- note the new queue status in the changelog

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68ce6cb717308332a9770447e8925956