### PR TITLE
Clarify VK queue changelog entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 - Added `/ocrtest` diagnostic command, чтобы сравнить распознавание афиш между `gpt-4o-mini` и `gpt-4o` с показом использования токенов.
 - Clarified the 4o parsing prompt to warn about possible OCR mistakes in poster snippets.
 - VK Intake помещает посты с одной фотографией и пустым текстом в очередь и отмечает их статусом «Ожидает OCR».
-- Уточнены приоритет URGENT (48 ч), взвешенное смешивание SOON/LONG/FAR (веса 3/2/6), стрик-брейкер FAR (30 д) и джиттер по источникам (14 д, K=5).
+- Уточнены правила очереди: URGENT с горизонтом 48 ч, окна SOON/LONG завершаются на 14 / 30 дней, FAR использует веса 3 / 2 / 6, джиттер задаётся по источнику, а стрик-брейкер FAR срабатывает после K=5 не-FAR выборов.
 
 - Introduced automatic topic classification with a closed topic list, editor display, and `/backfill_topics` command.
 


### PR DESCRIPTION
## Summary
- update the unreleased changelog entry to describe the current VK queue behaviour, including URGENT horizon, SOON/LONG windows, FAR weights, per-source jitter, and FAR streak breaker criteria

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68ce70650a388332af6d0ffbe3e20059