### PR TITLE
Extend makefest session cache duration

### DIFF
--- a/main.py
+++ b/main.py
@@ -611,7 +611,7 @@ partner_info_sessions: TTLCache[int, int] = TTLCache(maxsize=64, ttl=3600)
 festival_edit_sessions: TTLCache[int, tuple[int, str | None]] = TTLCache(maxsize=64, ttl=3600)
 
 # user_id -> cached festival inference for makefest flow
-makefest_sessions: TTLCache[int, dict[str, Any]] = TTLCache(maxsize=64, ttl=15 * 60)
+makefest_sessions: TTLCache[int, dict[str, Any]] = TTLCache(maxsize=64, ttl=3600)
 
 # cache for first image in Telegraph pages
 telegraph_first_image: TTLCache[str, str] = TTLCache(maxsize=128, ttl=24 * 3600)

--- a/tests/test_bot.py
+++ b/tests/test_bot.py
@@ -68,6 +68,10 @@ import poster_ocr
 REAL_SYNC_WEEKEND_PAGE = main.sync_weekend_page
 
 
+def test_makefest_sessions_ttl():
+    assert main.makefest_sessions.ttl == 3600
+
+
 @pytest.fixture(autouse=True)
 def _mock_sync_vk_source_post(monkeypatch):
     async def fake_sync(*args, **kwargs):


### PR DESCRIPTION
## Summary
- extend the makefest session cache lifetime to one hour
- add a regression test to verify the configured TTL

## Testing
- pytest tests/test_bot.py::test_makefest_sessions_ttl

------
https://chatgpt.com/codex/tasks/task_e_68ce9158a8e083329666104143fc4506