### PR TITLE
Align VK status columns and update tests

### DIFF
--- a/main.py
+++ b/main.py
@@ -17831,12 +17831,20 @@ async def handle_vk_list(
         page_items.append((offset, row, counts))
 
     if page_items:
-        count_widths = {
-            key: max(1, max(len(str(item[2][key])) for item in page_items))
-            for key, _ in VK_STATUS_LABELS
+        column_widths = {
+            key: max(
+                len(label),
+                max(len(str(item[2][key])) for item in page_items),
+            )
+            for key, label in VK_STATUS_LABELS
         }
     else:
-        count_widths = {key: 1 for key, _ in VK_STATUS_LABELS}
+        column_widths = {key: len(label) for key, label in VK_STATUS_LABELS}
+
+    header_parts = [
+        label.ljust(column_widths[key]) for key, label in VK_STATUS_LABELS
+    ]
+    header_line = "    " + " | ".join(header_parts)
 
     lines: list[str] = []
     buttons: list[list[types.InlineKeyboardButton]] = []
@@ -17849,12 +17857,12 @@ async def handle_vk_list(
         lines.append(
             f"{offset}. {name} (vk.com/{screen}) — {info}, типовое время: {dtime or '-'}"
         )
-        status_parts = []
-        for key, label in VK_STATUS_LABELS:
-            status_parts.append(
-                f"{label:<8} {counts[key]:>{count_widths[key]}}"
-            )
-        lines.append("    " + " | ".join(status_parts))
+        value_parts = [
+            str(counts[key]).rjust(column_widths[key])
+            for key, _ in VK_STATUS_LABELS
+        ]
+        lines.append(header_line)
+        lines.append("    " + " | ".join(value_parts))
         buttons.append(
             [
                 types.InlineKeyboardButton(

--- a/tests/test_vk_default_time.py
+++ b/tests/test_vk_default_time.py
@@ -73,10 +73,12 @@ async def test_vk_list_shows_numbers_and_default_time(tmp_path):
     lines = bot.messages[0].text.splitlines()
     assert lines[0].startswith("1.")
     assert "типовое время: 19:00" in lines[0]
-    assert lines[1] == "    Pending  2 | Skipped  1 | Imported  0 | Rejected 0"
-    assert lines[2].startswith("2.")
-    assert "типовое время: -" in lines[2]
-    assert lines[3] == "    Pending  0 | Skipped  0 | Imported 12 | Rejected 1"
+    assert lines[1] == "    Pending | Skipped | Imported | Rejected"
+    assert lines[2] == "          2 |       1 |        0 |        0"
+    assert lines[3].startswith("2.")
+    assert "типовое время: -" in lines[3]
+    assert lines[4] == "    Pending | Skipped | Imported | Rejected"
+    assert lines[5] == "          0 |       0 |       12 |        1"
     buttons = bot.messages[0].reply_markup.inline_keyboard
     assert buttons[0][0].text == "❌ 1"
     assert buttons[0][0].callback_data.endswith(":1")
@@ -99,7 +101,8 @@ async def test_vk_list_shows_numbers_and_default_time(tmp_path):
     assert callback.answered
     page2_lines = bot.messages[0].text.splitlines()
     assert page2_lines[0].startswith("11.")
-    assert page2_lines[1] == "    Pending  0 | Skipped  0 | Imported 0 | Rejected 0"
+    assert page2_lines[1] == "    Pending | Skipped | Imported | Rejected"
+    assert page2_lines[2] == "          0 |       0 |        0 |        0"
     nav_row = bot.messages[0].reply_markup.inline_keyboard[-1]
     assert nav_row[0].callback_data == "vksrcpage:1"
 


### PR DESCRIPTION
## Summary
- align VK status counters by computing shared column widths per page and rendering header/value rows separately
- update vk default time tests to match the new two-line status layout

## Testing
- pytest tests/test_vk_default_time.py

------
https://chatgpt.com/codex/tasks/task_e_68ce97039764833299f5d7dc5794041b