### PR TITLE
Format VK list status table with headers

### DIFF
--- a/main.py
+++ b/main.py
@@ -18509,12 +18509,17 @@ async def handle_vk_list(
         page_items.append((offset, row, counts))
 
     if page_items:
-        count_widths = {
-            key: max(1, max(len(str(item[2][key])) for item in page_items))
-            for key, _ in VK_STATUS_LABELS
-        }
+        count_widths = {}
+        for key, label in VK_STATUS_LABELS:
+            max_value_len = max(len(str(item[2][key])) for item in page_items)
+            count_widths[key] = max(len(label), max_value_len)
     else:
-        count_widths = {key: 1 for key, _ in VK_STATUS_LABELS}
+        count_widths = {key: len(label) for key, label in VK_STATUS_LABELS}
+
+    status_header_parts = [
+        label.ljust(count_widths[key]) for key, label in VK_STATUS_LABELS
+    ]
+    status_header_line = "    " + " | ".join(status_header_parts)
 
     lines: list[str] = []
     buttons: list[list[types.InlineKeyboardButton]] = []
@@ -18527,12 +18532,12 @@ async def handle_vk_list(
         lines.append(
             f"{offset}. {name} (vk.com/{screen}) — {info}, типовое время: {dtime or '-'}"
         )
-        status_parts = []
-        for key, label in VK_STATUS_LABELS:
-            status_parts.append(
-                f"{label:<8} {counts[key]:>{count_widths[key]}}"
-            )
-        lines.append("    " + " | ".join(status_parts))
+        value_parts = [
+            str(counts[key]).rjust(count_widths[key])
+            for key, _ in VK_STATUS_LABELS
+        ]
+        lines.append(status_header_line)
+        lines.append("    " + " | ".join(value_parts))
         buttons.append(
             [
                 types.InlineKeyboardButton(

--- a/tests/test_vk_default_time.py
+++ b/tests/test_vk_default_time.py
@@ -73,10 +73,12 @@ async def test_vk_list_shows_numbers_and_default_time(tmp_path):
     lines = bot.messages[0].text.splitlines()
     assert lines[0].startswith("1.")
     assert "типовое время: 19:00" in lines[0]
-    assert lines[1] == "    Pending  2 | Skipped  1 | Imported  0 | Rejected 0"
-    assert lines[2].startswith("2.")
-    assert "типовое время: -" in lines[2]
-    assert lines[3] == "    Pending  0 | Skipped  0 | Imported 12 | Rejected 1"
+    assert lines[1] == "    Pending | Skipped | Imported | Rejected"
+    assert lines[2] == "          2 |       1 |        0 |        0"
+    assert lines[3].startswith("2.")
+    assert "типовое время: -" in lines[3]
+    assert lines[4] == "    Pending | Skipped | Imported | Rejected"
+    assert lines[5] == "          0 |       0 |       12 |        1"
     buttons = bot.messages[0].reply_markup.inline_keyboard
     assert buttons[0][0].text == "❌ 1"
     assert buttons[0][0].callback_data.endswith(":1")
@@ -99,7 +101,8 @@ async def test_vk_list_shows_numbers_and_default_time(tmp_path):
     assert callback.answered
     page2_lines = bot.messages[0].text.splitlines()
     assert page2_lines[0].startswith("11.")
-    assert page2_lines[1] == "    Pending  0 | Skipped  0 | Imported 0 | Rejected 0"
+    assert page2_lines[1] == "    Pending | Skipped | Imported | Rejected"
+    assert page2_lines[2] == "          0 |       0 |        0 |        0"
     nav_row = bot.messages[0].reply_markup.inline_keyboard[-1]
     assert nav_row[0].callback_data == "vksrcpage:1"
 


### PR DESCRIPTION
## Summary
- align VK status counts beneath their headers in handle_vk_list and emit separate header/value rows for each source
- update vk default time tests to expect the two-line status table format

## Testing
- pytest tests/test_vk_default_time.py

------
https://chatgpt.com/codex/tasks/task_e_68cea7fb752083328bdf9f79addf6056