### PR TITLE
Add aliases column to festival

### DIFF
--- a/alembic/versions/20250906_festival_aliases.py
+++ b/alembic/versions/20250906_festival_aliases.py
@@ -1,0 +1,21 @@
+"""add aliases column to festival"""
+
+from __future__ import annotations
+
+from typing import Sequence, Union
+
+from alembic import op
+
+
+revision: str = "20250906_festival_aliases"
+down_revision: Union[str, None] = "20250905_tourist_factor_codes"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.execute("ALTER TABLE festival ADD COLUMN aliases JSON DEFAULT '[]'")
+
+
+def downgrade() -> None:
+    op.execute("ALTER TABLE festival DROP COLUMN aliases")

--- a/models.py
+++ b/models.py
@@ -401,6 +401,7 @@ class Festival(SQLModel, table=True):
     vk_poll_url: Optional[str] = None
     photo_url: Optional[str] = None
     photo_urls: list[str] = Field(default_factory=list, sa_column=Column(JSON))
+    aliases: list[str] = Field(default_factory=list, sa_column=Column(JSON))
     website_url: Optional[str] = None
     program_url: Optional[str] = None
     vk_url: Optional[str] = None


### PR DESCRIPTION
## Summary
- add an aliases JSON column to the Festival SQLModel definition
- create an Alembic migration that adds the aliases column and links to the existing chain

## Testing
- alembic history --verbose *(fails: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68ced675e68083329428735f646b8bfd