### PR TITLE
Update tourist tourist menu callbacks

### DIFF
--- a/main.py
+++ b/main.py
@@ -743,7 +743,7 @@ def build_tourist_keyboard_block(
         [
             types.InlineKeyboardButton(
                 text="Причины",
-                callback_data=f"tourist:fx:menu:{event.id}",
+                callback_data=f"tourist:fxmenu:{event.id}",
             )
         ],
         [
@@ -7115,11 +7115,34 @@ async def process_request(callback: types.CallbackQuery, db: Database, bot: Bot)
                 )
                 tourist_reason_sessions[callback.from_user.id] = session_state
                 await update_tourist_message(callback, bot, event, source, menu=True)
-                await callback.answer("Выберите причины")
+                await callback.answer("Отмечено")
             else:
                 tourist_reason_sessions.pop(callback.from_user.id, None)
                 await update_tourist_message(callback, bot, event, source)
                 await callback.answer("Отмечено")
+        elif action == "fxmenu":
+            try:
+                event_id = int(parts[2])
+            except (ValueError, IndexError):
+                event_id = 0
+            if not event_id:
+                await callback.answer("Некорректное событие", show_alert=True)
+                return
+            async with db.get_session() as session:
+                user = await session.get(User, callback.from_user.id)
+                event = await session.get(Event, event_id)
+                if not event or not _user_can_label_event(user):
+                    await callback.answer("Not authorized", show_alert=True)
+                    return
+            if callback.message:
+                tourist_reason_sessions[callback.from_user.id] = TouristReasonSession(
+                    event_id=event_id,
+                    chat_id=callback.message.chat.id,
+                    message_id=callback.message.message_id,
+                    source=source,
+                )
+                await update_tourist_message(callback, bot, event, source, menu=True)
+            await callback.answer("Выберите причины")
         elif action == "fx":
             code = parts[2] if len(parts) > 2 else ""
             try:
@@ -7128,25 +7151,6 @@ async def process_request(callback: types.CallbackQuery, db: Database, bot: Bot)
                 event_id = 0
             if not event_id:
                 await callback.answer("Некорректное событие", show_alert=True)
-                return
-            if code == "menu":
-                async with db.get_session() as session:
-                    user = await session.get(User, callback.from_user.id)
-                    event = await session.get(Event, event_id)
-                    if not event or not _user_can_label_event(user):
-                        await callback.answer("Not authorized", show_alert=True)
-                        return
-                if callback.message:
-                    tourist_reason_sessions[callback.from_user.id] = TouristReasonSession(
-                        event_id=event_id,
-                        chat_id=callback.message.chat.id,
-                        message_id=callback.message.message_id,
-                        source=source,
-                    )
-                    await update_tourist_message(
-                        callback, bot, event, source, menu=True
-                    )
-                await callback.answer("Выберите причины")
                 return
             try:
                 session_state = tourist_reason_sessions[callback.from_user.id]

--- a/tests/test_tourist_features.py
+++ b/tests/test_tourist_features.py
@@ -91,6 +91,7 @@ def test_tourist_block_appended(base_rows, source):
     flat = [btn.callback_data for row in rows for btn in row]
     texts = [btn.text for row in rows for btn in row]
     assert f"tourist:yes:{event.id}" in flat
+    assert f"tourist:fxmenu:{event.id}" in flat
     assert f"tourist:note:start:{event.id}" in flat
     assert "Интересно туристам" in texts
     assert "Причины" in texts
@@ -182,7 +183,7 @@ async def test_tourist_yes_callback_updates_event(tmp_path, monkeypatch):
         assert updated.tourist_label_source == "operator"
     session_state = main.tourist_reason_sessions.get(1)
     assert session_state and session_state.event_id == event_id
-    assert any(call["text"] == "Выберите причины" for call in answers)
+    assert any(call["text"] == "Отмечено" for call in answers)
     assert bot.edited_text_calls
     last_call = bot.edited_text_calls[-1]
     assert "🌍 Туристам: Да" in last_call["text"]
@@ -246,9 +247,10 @@ async def test_tourist_factor_flow(tmp_path, monkeypatch):
     )
     answers = patch_answer(monkeypatch)
     bot = DummyBot()
-    cb_menu = make_callback(f"tourist:fx:menu:{event_id}", message)
+    cb_menu = make_callback(f"tourist:fxmenu:{event_id}", message)
     await main.process_request(cb_menu, db, bot)
     assert main.tourist_reason_sessions
+    assert any(call["text"] == "Выберите причины" for call in answers)
     cb_toggle = make_callback(
         f"tourist:fx:targeted_for_tourists:{event_id}", message
     )
@@ -301,7 +303,7 @@ async def test_tourist_factor_skip(tmp_path, monkeypatch):
     )
     answers = patch_answer(monkeypatch)
     bot = DummyBot()
-    cb_menu = make_callback(f"tourist:fx:menu:{event_id}", message)
+    cb_menu = make_callback(f"tourist:fxmenu:{event_id}", message)
     await main.process_request(cb_menu, db, bot)
     cb_skip = make_callback(f"tourist:fxskip:{event_id}", message)
     await main.process_request(cb_skip, db, bot)


### PR DESCRIPTION
## Summary
- switch the tourist reason menu button to the new `tourist:fxmenu:{event_id}` prefix and handle it in `process_request`
- keep the automatic reason menu open on `tourist:yes` while replying with the "Отмечено" toast
- refresh tourist feature tests for the new callback prefix and toast expectations

## Testing
- pytest tests/test_tourist_features.py

------
https://chatgpt.com/codex/tasks/task_e_68ced94d55c88332915b8286581b4dd6