### PR TITLE
Update tourist factor vocabulary

### DIFF
--- a/alembic/versions/20250907_new_tourist_factor_vocab.py
+++ b/alembic/versions/20250907_new_tourist_factor_vocab.py
@@ -14,26 +14,33 @@ depends_on: Union[str, Sequence[str], None] = None
 NEW_CODES: list[str] = [
     "targeted_for_tourists",
     "unique_to_region",
-    "iconic_location",
-    "shows_local_life",
-    "scenic_nature",
-    "local_cuisine",
-    "family_friendly",
+    "festival_major",
+    "nature_or_landmark",
+    "photogenic_blogger",
+    "local_flavor_crafts",
+    "easy_logistics",
 ]
 NEW_CODE_SET = set(NEW_CODES)
 ALIAS_TO_NEW: dict[str, str] = {
     "history": "unique_to_region",
     "culture": "unique_to_region",
-    "atmosphere": "shows_local_life",
-    "city": "shows_local_life",
-    "sea": "scenic_nature",
-    "water": "scenic_nature",
-    "nature": "scenic_nature",
-    "food": "local_cuisine",
-    "gastronomy": "local_cuisine",
-    "family": "family_friendly",
-    "events": "targeted_for_tourists",
-    "event": "targeted_for_tourists",
+    "atmosphere": "local_flavor_crafts",
+    "city": "local_flavor_crafts",
+    "sea": "nature_or_landmark",
+    "water": "nature_or_landmark",
+    "nature": "nature_or_landmark",
+    "scenic_nature": "nature_or_landmark",
+    "iconic_location": "photogenic_blogger",
+    "shows_local_life": "local_flavor_crafts",
+    "local_cuisine": "local_flavor_crafts",
+    "food": "local_flavor_crafts",
+    "gastronomy": "local_flavor_crafts",
+    "family": "easy_logistics",
+    "family_friendly": "easy_logistics",
+    "events": "festival_major",
+    "event": "festival_major",
+    "photogenic": "photogenic_blogger",
+    "blogger": "photogenic_blogger",
 }
 
 DOWN_CODES: list[str] = [
@@ -49,11 +56,11 @@ DOWN_CODE_SET = set(DOWN_CODES)
 NEW_TO_OLD: dict[str, str] = {
     "targeted_for_tourists": "events",
     "unique_to_region": "culture",
-    "iconic_location": "culture",
-    "shows_local_life": "atmosphere",
-    "scenic_nature": "nature",
-    "local_cuisine": "food",
-    "family_friendly": "family",
+    "festival_major": "atmosphere",
+    "nature_or_landmark": "nature",
+    "photogenic_blogger": "culture",
+    "local_flavor_crafts": "food",
+    "easy_logistics": "family",
 }
 
 

--- a/main.py
+++ b/main.py
@@ -631,13 +631,13 @@ class TouristFactor:
 
 
 TOURIST_FACTORS: list[TouristFactor] = [
-    TouristFactor("targeted_for_tourists", "🎯", "Специально для туристов"),
-    TouristFactor("unique_to_region", "🧭", "Есть только здесь"),
-    TouristFactor("iconic_location", "📍", "Знаковое место"),
-    TouristFactor("shows_local_life", "🏙️", "Погружает в жизнь местных"),
-    TouristFactor("scenic_nature", "🌿", "Природа и виды"),
-    TouristFactor("local_cuisine", "🍽️", "Местная гастрономия"),
-    TouristFactor("family_friendly", "👨‍👩‍👧‍👦", "Подходит для семьи"),
+    TouristFactor("targeted_for_tourists", "🎯", "Нацелен на туристов"),
+    TouristFactor("unique_to_region", "🧭", "Уникально для региона"),
+    TouristFactor("festival_major", "🎪", "Крупный фестиваль или событие"),
+    TouristFactor("nature_or_landmark", "🌊", "Природа или знаковое место"),
+    TouristFactor("photogenic_blogger", "📸", "Фотогенично, понравится блогерам"),
+    TouristFactor("local_flavor_crafts", "🍲", "Местный колорит и ремёсла"),
+    TouristFactor("easy_logistics", "🚆", "Простая логистика"),
 ]
 
 TOURIST_FACTOR_BY_CODE: dict[str, TouristFactor] = {
@@ -647,16 +647,23 @@ TOURIST_FACTOR_CODES: list[str] = [factor.code for factor in TOURIST_FACTORS]
 TOURIST_FACTOR_ALIASES: dict[str, str] = {
     "history": "unique_to_region",
     "culture": "unique_to_region",
-    "atmosphere": "shows_local_life",
-    "city": "shows_local_life",
-    "sea": "scenic_nature",
-    "water": "scenic_nature",
-    "nature": "scenic_nature",
-    "food": "local_cuisine",
-    "gastronomy": "local_cuisine",
-    "family": "family_friendly",
-    "events": "targeted_for_tourists",
-    "event": "targeted_for_tourists",
+    "atmosphere": "local_flavor_crafts",
+    "city": "local_flavor_crafts",
+    "sea": "nature_or_landmark",
+    "water": "nature_or_landmark",
+    "nature": "nature_or_landmark",
+    "scenic_nature": "nature_or_landmark",
+    "iconic_location": "photogenic_blogger",
+    "shows_local_life": "local_flavor_crafts",
+    "local_cuisine": "local_flavor_crafts",
+    "food": "local_flavor_crafts",
+    "gastronomy": "local_flavor_crafts",
+    "family": "easy_logistics",
+    "family_friendly": "easy_logistics",
+    "events": "festival_major",
+    "event": "festival_major",
+    "photogenic": "photogenic_blogger",
+    "blogger": "photogenic_blogger",
 }
 
 

--- a/tests/test_tourist_features.py
+++ b/tests/test_tourist_features.py
@@ -123,7 +123,7 @@ def test_build_event_card_message_with_factors():
         time="10:00",
         location_name="L",
         source_text="S",
-        tourist_factors=["targeted_for_tourists", "local_cuisine"],
+        tourist_factors=["targeted_for_tourists", "local_flavor_crafts"],
         tourist_label=1,
     )
     text = build_event_card_message("Event added", event, ["title: Title"])
@@ -133,9 +133,29 @@ def test_build_event_card_message_with_factors():
 def test_normalize_tourist_factors_handles_legacy_codes():
     normalized = main._normalize_tourist_factors(["culture", "food", "events"])
     assert normalized == [
-        "targeted_for_tourists",
         "unique_to_region",
-        "local_cuisine",
+        "festival_major",
+        "local_flavor_crafts",
+    ]
+
+
+def test_normalize_tourist_factors_idempotent_and_ordered():
+    normalized = main._normalize_tourist_factors(
+        [
+            "festival_major",
+            "events",
+            "scenic_nature",
+            "nature_or_landmark",
+            "targeted_for_tourists",
+            "targeted_for_tourists",
+            "local_cuisine",
+        ]
+    )
+    assert normalized == [
+        "targeted_for_tourists",
+        "festival_major",
+        "nature_or_landmark",
+        "local_flavor_crafts",
     ]
 
 
@@ -207,7 +227,7 @@ async def test_tourist_yes_callback_updates_event(tmp_path, monkeypatch):
     }
     assert expected_callbacks <= {btn.callback_data for btn in factor_buttons}
     assert any(
-        btn.text.startswith("➕ 🎯 Специально для туристов") for btn in factor_buttons
+        btn.text.startswith("➕ 🎯 Нацелен на туристов") for btn in factor_buttons
     )
 
 


### PR DESCRIPTION
## Summary
- replace tourist factor constants with the new vocabulary and refresh button captions
- update normalization aliases and tests to cover the new codes and ordering behaviour
- adjust the tourist factor migration to translate historical data to the refreshed set of codes

## Testing
- pytest tests/test_tourist_features.py

------
https://chatgpt.com/codex/tasks/task_e_68cede2ab7f88332a45209b29f0be9a2