### PR TITLE
Handle tourist reasons button without start callback

### DIFF
--- a/tests/test_tourist_features.py
+++ b/tests/test_tourist_features.py
@@ -91,7 +91,7 @@ def test_tourist_block_appended(base_rows, source):
     flat = [btn.callback_data for row in rows for btn in row]
     texts = [btn.text for row in rows for btn in row]
     assert f"tourist:yes:{event.id}" in flat
-    assert f"tourist:fx:start:{event.id}" in flat
+    assert f"tourist:fxdone:{event.id}" in flat
     assert f"tourist:note:start:{event.id}" in flat
     assert "Интересно туристам" in texts
     assert "Причины" in texts
@@ -267,7 +267,7 @@ async def test_tourist_factor_flow(tmp_path, monkeypatch):
     )
     answers = patch_answer(monkeypatch)
     bot = DummyBot()
-    cb_menu = make_callback(f"tourist:fx:start:{event_id}", message)
+    cb_menu = make_callback(f"tourist:fxdone:{event_id}", message)
     await main.process_request(cb_menu, db, bot)
     assert main.tourist_reason_sessions
     assert any(call["text"] == "Выберите причины" for call in answers)
@@ -323,7 +323,7 @@ async def test_tourist_factor_skip(tmp_path, monkeypatch):
     )
     answers = patch_answer(monkeypatch)
     bot = DummyBot()
-    cb_menu = make_callback(f"tourist:fx:start:{event_id}", message)
+    cb_menu = make_callback(f"tourist:fxdone:{event_id}", message)
     await main.process_request(cb_menu, db, bot)
     cb_skip = make_callback(f"tourist:fxskip:{event_id}", message)
     await main.process_request(cb_skip, db, bot)
@@ -367,7 +367,7 @@ async def test_tourist_factor_timeout(tmp_path, monkeypatch):
     )
     answers = patch_answer(monkeypatch)
     bot = DummyBot()
-    cb_menu = make_callback(f"tourist:fx:start:{event_id}", message)
+    cb_menu = make_callback(f"tourist:fxdone:{event_id}", message)
     await main.process_request(cb_menu, db, bot)
     assert any(call["text"] == "Выберите причины" for call in answers)
     assert bot.edited_text_calls
@@ -398,9 +398,9 @@ async def test_tourist_factor_timeout(tmp_path, monkeypatch):
         for btn in row
         if btn.callback_data
     ]
-    assert f"tourist:fx:start:{event_id}" in restored_callbacks
+    assert f"tourist:fxdone:{event_id}" in restored_callbacks
     assert all(
-        callback == f"tourist:fx:start:{event_id}"
+        callback == f"tourist:fxdone:{event_id}"
         or not callback.startswith("tourist:fx:")
         for callback in restored_callbacks
     )
@@ -446,7 +446,7 @@ async def test_tourist_note_flow(tmp_path, monkeypatch):
     )
     answers = patch_answer(monkeypatch)
     bot = DummyBot()
-    cb_menu = make_callback(f"tourist:fx:start:{event_id}", message)
+    cb_menu = make_callback(f"tourist:fxdone:{event_id}", message)
     await main.process_request(cb_menu, db, bot)
     assert bot.edited_text_calls
     menu_markup = bot.edited_text_calls[-1]["reply_markup"]
@@ -512,7 +512,7 @@ async def test_tourist_note_trim_long_text(tmp_path, monkeypatch):
     )
     patch_answer(monkeypatch)
     bot = DummyBot()
-    cb_menu = make_callback(f"tourist:fx:start:{event_id}", message)
+    cb_menu = make_callback(f"tourist:fxdone:{event_id}", message)
     await main.process_request(cb_menu, db, bot)
     assert bot.edited_text_calls
     menu_markup = bot.edited_text_calls[-1]["reply_markup"]
@@ -599,7 +599,7 @@ async def test_tourist_note_clear(tmp_path, monkeypatch):
     )
     answers = patch_answer(monkeypatch)
     bot = DummyBot()
-    cb_menu = make_callback(f"tourist:fx:start:{event_id}", message)
+    cb_menu = make_callback(f"tourist:fxdone:{event_id}", message)
     await main.process_request(cb_menu, db, bot)
     assert bot.edited_text_calls
     menu_markup = bot.edited_text_calls[-1]["reply_markup"]


### PR DESCRIPTION
## Summary
- update the tourist "reasons" button to use the allowed callback
- start a TouristReasonSession from the fxdone handler when necessary and keep the existing completion flow
- adjust tourist feature tests for the new callback and menu initialization

## Testing
- pytest tests/test_tourist_features.py

------
https://chatgpt.com/codex/tasks/task_e_68cf0bb38f648332a6ccc17a0eecf776