### PR TITLE
Refine festival prompt data

### DIFF
--- a/tests/test_prompt_json.py
+++ b/tests/test_prompt_json.py
@@ -1,0 +1,31 @@
+import json
+
+import main
+
+
+def _extract_prompt_json(value: str) -> dict:
+    json_text = value.rsplit("\n", 1)[-1]
+    return json.loads(json_text)
+
+
+def test_build_prompt_includes_aliases():
+    main._prompt_cache.cache_clear()
+    prompt = main._build_prompt([
+        "Fest B",
+        "Fest A",
+    ], [
+        ("alias", "Fest A"),
+    ])
+    assert "Use the JSON below" in prompt
+    data = _extract_prompt_json(prompt)
+    assert data == {
+        "festival_names": ["Fest A", "Fest B"],
+        "festival_alias_pairs": [["alias", "Fest A"]],
+    }
+
+
+def test_build_prompt_omits_alias_section_when_empty():
+    main._prompt_cache.cache_clear()
+    prompt = main._build_prompt(["Fest"], [])
+    data = _extract_prompt_json(prompt)
+    assert data == {"festival_names": ["Fest"]}


### PR DESCRIPTION
## Summary
- limit the festival lookup to recent or undated records and collect normalised alias pairs for parsing
- embed a compact JSON block with festival names and alias mappings in the system prompt and thread it through the parser
- cover the new prompt format with tests for presence and absence of alias data

## Testing
- pytest tests/test_prompt_json.py tests/test_add_events_from_text_topics.py

------
https://chatgpt.com/codex/tasks/task_e_68cf1d65ed588332912c0432f242ef47