### PR TITLE
Decouple alias data from prompt cache

### DIFF
--- a/tests/test_prompt_json.py
+++ b/tests/test_prompt_json.py
@@ -29,3 +29,22 @@ def test_build_prompt_omits_alias_section_when_empty():
     prompt = main._build_prompt(["Fest"], [])
     data = _extract_prompt_json(prompt)
     assert data == {"festival_names": ["Fest"]}
+
+
+def test_aliases_bypass_cache_layer():
+    main._prompt_cache.cache_clear()
+    prompt_initial = main._build_prompt([
+        "Fest",
+    ], [
+        ("old-alias", 0),
+    ])
+    data_initial = _extract_prompt_json(prompt_initial)
+    assert data_initial["festival_alias_pairs"] == [["old-alias", 0]]
+
+    prompt_updated = main._build_prompt([
+        "Fest",
+    ], [
+        ("new-alias", 0),
+    ])
+    data_updated = _extract_prompt_json(prompt_updated)
+    assert data_updated["festival_alias_pairs"] == [["new-alias", 0]]


### PR DESCRIPTION
## Summary
- limit `_prompt_cache` to caching by the sorted festival name tuple and leave alias handling outside the cached body
- rebuild alias instructions and JSON payload each time `_build_prompt` runs so fresh alias data is always emitted
- extend prompt JSON tests to confirm aliases update without clearing the cache

## Testing
- pytest tests/test_prompt_json.py

------
https://chatgpt.com/codex/tasks/task_e_68cf2b1af1c8833287b8c662c66a88bd