### PR TITLE
Prefer Telegraph link for VK daily events

### DIFF
--- a/main.py
+++ b/main.py
@@ -12600,6 +12600,8 @@ def format_event_daily(
     link_href: str | None = None
     if is_partner_creator and is_vk_wall_url(e.source_post_url):
         link_href = e.source_post_url
+    elif is_vk_wall_url(e.source_post_url):
+        link_href = e.telegraph_url or e.source_post_url
     elif is_vk_wall_url(e.source_vk_post_url):
         link_href = e.telegraph_url or e.source_vk_post_url
     elif e.source_post_url:

--- a/tests/test_daily_format.py
+++ b/tests/test_daily_format.py
@@ -38,6 +38,17 @@ def test_format_event_daily_prefers_telegraph_for_vk_queue() -> None:
     assert '<a href="https://telegra.ph/test">' in rendered
 
 
+def test_format_event_daily_prefers_telegraph_for_vk_source_url() -> None:
+    event = make_event(
+        source_post_url="https://vk.com/wall-1_3",
+        telegraph_url="https://telegra.ph/source",
+    )
+
+    rendered = main.format_event_daily(event)
+
+    assert '<a href="https://telegra.ph/source">' in rendered
+
+
 def test_format_event_daily_handles_timezone_aware_added_at() -> None:
     event = make_event(
         added_at=datetime(2024, 1, 2, 12, tzinfo=timezone.utc),


### PR DESCRIPTION
## Summary
- update daily event formatter to prefer Telegraph link even when the source_post_url is a VK wall
- extend daily formatter tests to cover VK source URL handling with Telegraph fallback

## Testing
- pytest tests/test_daily_format.py

------
https://chatgpt.com/codex/tasks/task_e_68cf97409fd88332b85426d6792a7c47