### PR TITLE
Update changelog for Telegram daily Telegraph link

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - VK Intake помещает посты с одной фотографией и пустым текстом в очередь и отмечает их статусом «Ожидает OCR».
 - Уточнены правила очереди: URGENT с горизонтом 48 ч, окна SOON/LONG завершаются на 14 / 30 дней, FAR использует веса 3 / 2 / 6, джиттер задаётся по источнику, а стрик-брейкер FAR срабатывает после K=5 не-FAR выборов.
 - Список сообществ ВК показывает статусы `Pending | Skipped | Imported | Rejected` и поддерживает пагинацию.
+- Ежедневный Telegram-анонс теперь ссылается на Telegraph-страницу для событий из VK-очереди (кроме партнёрских авторов).
 
 - Introduced automatic topic classification with a closed topic list, editor display, and `/backfill_topics` command.
 - Classifier/digest topic list now includes the `PSYCHOLOGY`, `THEATRE_CLASSIC`, and `THEATRE_MODERN` categories.


### PR DESCRIPTION
## Summary
- document that Telegram daily announcement links to Telegraph pages for VK queue events except partner authors

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cf99300aa083329ea2682aefbc27a8