### PR TITLE
Adjust shortpost hashtag order after date line

### DIFF
--- a/main.py
+++ b/main.py
@@ -20615,9 +20615,9 @@ async def _vkrev_build_shortpost(
         ev.title.upper(),
         "",
     ]
+    lines.append(date_line)
     if type_line:
         lines.append(type_line)
-    lines.append(date_line)
     if ev.ticket_link:
         if getattr(ev, "is_free", False):
             lines.append(f"🆓 Бесплатно, по регистрации {ev.ticket_link}")

--- a/tests/test_vk_shortpost.py
+++ b/tests/test_vk_shortpost.py
@@ -590,7 +590,7 @@ async def test_shortpost_type_line_for_hyphenated_type(monkeypatch):
 
     lines = msg.splitlines()
     date_idx = next(i for i, line in enumerate(lines) if line.startswith("🗓"))
-    assert lines[date_idx - 1] == "#мастеркласс"
+    assert lines[date_idx + 1] == "#мастеркласс"
 
     hashtags_line = lines[-1]
     hashtags = hashtags_line.split()
@@ -625,7 +625,7 @@ async def test_shortpost_plain_type_hashtag_not_repeated(monkeypatch):
 
     lines = msg.splitlines()
     date_idx = next(i for i, line in enumerate(lines) if line.startswith("🗓"))
-    assert lines[date_idx - 1] == "#выставка"
+    assert lines[date_idx + 1] == "#выставка"
 
     hashtags_line = lines[-1]
     assert "#выставка" not in hashtags_line.split()


### PR DESCRIPTION
## Summary
- ensure shortpost date/time line is added before the type hashtag in shortpost generation
- update vk shortpost tests to reflect the new order of date and type lines

## Testing
- pytest tests/test_vk_shortpost.py

------
https://chatgpt.com/codex/tasks/task_e_68cfac98f3c8833280cca41924beeacf