### PR TITLE
Format VK list table cells with padding

### DIFF
--- a/main.py
+++ b/main.py
@@ -19455,9 +19455,9 @@ async def handle_vk_list(
         count_widths = {key: len(label) for key, label in VK_STATUS_LABELS}
 
     status_header_parts = [
-        label.ljust(count_widths[key]) for key, label in VK_STATUS_LABELS
+        f" {label:<{count_widths[key]}} " for key, label in VK_STATUS_LABELS
     ]
-    status_header_line = "    " + " | ".join(status_header_parts)
+    status_header_line = "    " + "|".join(status_header_parts)
 
     lines: list[str] = []
     buttons: list[list[types.InlineKeyboardButton]] = []
@@ -19471,11 +19471,11 @@ async def handle_vk_list(
             f"{offset}. {name} (vk.com/{screen}) — {info}, типовое время: {dtime or '-'}"
         )
         value_parts = [
-            str(counts[key]).rjust(count_widths[key])
+            f" {counts[key]:>{count_widths[key]}} "
             for key, _ in VK_STATUS_LABELS
         ]
         lines.append(status_header_line)
-        lines.append("    " + " | ".join(value_parts))
+        lines.append("    " + "|".join(value_parts))
         buttons.append(
             [
                 types.InlineKeyboardButton(

--- a/tests/test_vk_default_time.py
+++ b/tests/test_vk_default_time.py
@@ -73,12 +73,12 @@ async def test_vk_list_shows_numbers_and_default_time(tmp_path):
     lines = bot.messages[0].text.splitlines()
     assert lines[0].startswith("1.")
     assert "типовое время: 19:00" in lines[0]
-    assert lines[1] == "    Pending | Skipped | Imported | Rejected"
-    assert lines[2] == "          2 |       1 |        0 |        0"
+    assert lines[1] == "     Pending | Skipped | Imported | Rejected "
+    assert lines[2] == "           2 |       1 |        0 |        0 "
     assert lines[3].startswith("2.")
     assert "типовое время: -" in lines[3]
-    assert lines[4] == "    Pending | Skipped | Imported | Rejected"
-    assert lines[5] == "          0 |       0 |       12 |        1"
+    assert lines[4] == "     Pending | Skipped | Imported | Rejected "
+    assert lines[5] == "           0 |       0 |       12 |        1 "
     buttons = bot.messages[0].reply_markup.inline_keyboard
     assert buttons[0][0].text == "❌ 1"
     assert buttons[0][0].callback_data.endswith(":1")
@@ -101,8 +101,8 @@ async def test_vk_list_shows_numbers_and_default_time(tmp_path):
     assert callback.answered
     page2_lines = bot.messages[0].text.splitlines()
     assert page2_lines[0].startswith("11.")
-    assert page2_lines[1] == "    Pending | Skipped | Imported | Rejected"
-    assert page2_lines[2] == "          0 |       0 |        0 |        0"
+    assert page2_lines[1] == "     Pending | Skipped | Imported | Rejected "
+    assert page2_lines[2] == "           0 |       0 |        0 |        0 "
     nav_row = bot.messages[0].reply_markup.inline_keyboard[-1]
     assert nav_row[0].callback_data == "vksrcpage:1"
 


### PR DESCRIPTION
## Summary
- pad VK status headers and counts with explicit spacing around each cell and use a consistent `|` separator
- update the VK list default time test expectations for the adjusted table layout

## Testing
- pytest tests/test_vk_default_time.py

------
https://chatgpt.com/codex/tasks/task_e_68cfb6cf07b88332b75f893ee653fbe4