### PR TITLE
Adjust 4o daily token default limit

### DIFF
--- a/docs/FOUR_O_REQUEST.md
+++ b/docs/FOUR_O_REQUEST.md
@@ -91,5 +91,5 @@ calculated from the events added to the festival.
 
 OpenAI usage resets daily at 00:00 UTC. The `four_o.usage` log records each
 request with its token count and the remaining budget as defined by
-`FOUR_O_DAILY_TOKEN_LIMIT`. Grafana dashboards can filter by the
-`four_o.usage` key to visualise daily token spend.
+`FOUR_O_DAILY_TOKEN_LIMIT` (1 000 000 tokens by default). Grafana dashboards can
+filter by the `four_o.usage` key to visualise daily token spend.

--- a/main.py
+++ b/main.py
@@ -1471,7 +1471,7 @@ FOUR_O_PROMPT_LIMIT = int(os.getenv("FOUR_O_PROMPT_LIMIT", "4000"))
 FOUR_O_RESPONSE_LIMIT = int(os.getenv("FOUR_O_RESPONSE_LIMIT", "1000"))
 
 # Track OpenAI usage against a daily budget.  OpenAI resets usage at midnight UTC.
-FOUR_O_DAILY_TOKEN_LIMIT = int(os.getenv("FOUR_O_DAILY_TOKEN_LIMIT", "2000000"))
+FOUR_O_DAILY_TOKEN_LIMIT = int(os.getenv("FOUR_O_DAILY_TOKEN_LIMIT", "1000000"))
 
 
 def _current_utc_date() -> date:


### PR DESCRIPTION
## Summary
- lower the default OpenAI 4o daily token budget to 1,000,000 tokens
- document the new default limit in the 4o usage guide

## Testing
- pytest tests/test_four_o_usage.py

------
https://chatgpt.com/codex/tasks/task_e_68cfbdec0450833286a5cc65b44e810e