### PR TITLE
Center align VK list counts

### DIFF
--- a/main.py
+++ b/main.py
@@ -19471,7 +19471,7 @@ async def handle_vk_list(
             f"{offset}. {name} (vk.com/{screen}) — {info}, типовое время: {dtime or '-'}"
         )
         value_parts = [
-            f" {counts[key]:<{count_widths[key]}} "
+            f" {counts[key]:^{count_widths[key]}} "
             for key, _ in VK_STATUS_LABELS
         ]
         lines.append(status_header_line)

--- a/tests/test_vk_default_time.py
+++ b/tests/test_vk_default_time.py
@@ -74,11 +74,11 @@ async def test_vk_list_shows_numbers_and_default_time(tmp_path):
     assert lines[0].startswith("1.")
     assert "типовое время: 19:00" in lines[0]
     assert lines[1] == "     Pending | Skipped | Imported | Rejected "
-    assert lines[2] == "     2       | 1       | 0        | 0        "
+    assert lines[2] == "        2    |    1    |    0     |    0     "
     assert lines[3].startswith("2.")
     assert "типовое время: -" in lines[3]
     assert lines[4] == "     Pending | Skipped | Imported | Rejected "
-    assert lines[5] == "     0       | 0       | 12       | 1        "
+    assert lines[5] == "        0    |    0    |    12    |    1     "
     buttons = bot.messages[0].reply_markup.inline_keyboard
     assert buttons[0][0].text == "❌ 1"
     assert buttons[0][0].callback_data.endswith(":1")
@@ -102,7 +102,7 @@ async def test_vk_list_shows_numbers_and_default_time(tmp_path):
     page2_lines = bot.messages[0].text.splitlines()
     assert page2_lines[0].startswith("11.")
     assert page2_lines[1] == "     Pending | Skipped | Imported | Rejected "
-    assert page2_lines[2] == "     0       | 0       | 0        | 0        "
+    assert page2_lines[2] == "        0    |    0    |    0     |    0     "
     nav_row = bot.messages[0].reply_markup.inline_keyboard[-1]
     assert nav_row[0].callback_data == "vksrcpage:1"
 


### PR DESCRIPTION
## Summary
- center the VK list status counts so numbers are padded symmetrically within each column
- refresh the vk default time list test assertions for the centered formatting on both pages

## Testing
- pytest tests/test_vk_default_time.py

------
https://chatgpt.com/codex/tasks/task_e_68cfc69dd0fc833284f1ba2b528a2be2