### PR TITLE
Route tourist callbacks through process_request

### DIFF
--- a/main.py
+++ b/main.py
@@ -22496,6 +22496,7 @@ def create_app() -> web.Application:
         or c.data.startswith("festimgs:")
         or c.data.startswith("festsetcover:")
         or c.data.startswith("requeue:")
+        or c.data.startswith("tourist:")
     ,
     )
     dp.callback_query.register(


### PR DESCRIPTION
## Summary
- extend the callback dispatcher predicate so tourist-related callback data is routed through `process_request`

## Testing
- not run (requires production bot environment for verification)


------
https://chatgpt.com/codex/tasks/task_e_68cfc78404908332b0e2f930cf370169