### PR TITLE
Widen VK list stat columns

### DIFF
--- a/main.py
+++ b/main.py
@@ -14,6 +14,7 @@ import time as unixtime
 import time as _time
 import tempfile
 import calendar
+import math
 from collections import Counter
 
 
@@ -19450,9 +19451,13 @@ async def handle_vk_list(
         count_widths = {}
         for key, label in VK_STATUS_LABELS:
             max_value_len = max(len(str(item[2][key])) for item in page_items)
-            count_widths[key] = max(len(label), max_value_len)
+            base_width = max(len(label), max_value_len)
+            count_widths[key] = max(1, math.ceil(base_width * 1.7))
     else:
-        count_widths = {key: len(label) for key, label in VK_STATUS_LABELS}
+        count_widths = {}
+        for key, label in VK_STATUS_LABELS:
+            base_width = len(label)
+            count_widths[key] = max(1, math.ceil(base_width * 1.7))
 
     status_header_parts = [
         f" {label:<{count_widths[key]}} " for key, label in VK_STATUS_LABELS

--- a/tests/test_vk_default_time.py
+++ b/tests/test_vk_default_time.py
@@ -73,12 +73,24 @@ async def test_vk_list_shows_numbers_and_default_time(tmp_path):
     lines = bot.messages[0].text.splitlines()
     assert lines[0].startswith("1.")
     assert "типовое время: 19:00" in lines[0]
-    assert lines[1] == "     Pending | Skipped | Imported | Rejected "
-    assert lines[2] == "        2    |    1    |    0     |    0     "
+    assert (
+        lines[1]
+        == "     Pending      | Skipped      | Imported       | Rejected       "
+    )
+    assert (
+        lines[2]
+        == "          2       |      1       |       0        |       0        "
+    )
     assert lines[3].startswith("2.")
     assert "типовое время: -" in lines[3]
-    assert lines[4] == "     Pending | Skipped | Imported | Rejected "
-    assert lines[5] == "        0    |    0    |    12    |    1     "
+    assert (
+        lines[4]
+        == "     Pending      | Skipped      | Imported       | Rejected       "
+    )
+    assert (
+        lines[5]
+        == "          0       |      0       |       12       |       1        "
+    )
     buttons = bot.messages[0].reply_markup.inline_keyboard
     assert buttons[0][0].text == "❌ 1"
     assert buttons[0][0].callback_data.endswith(":1")
@@ -101,8 +113,14 @@ async def test_vk_list_shows_numbers_and_default_time(tmp_path):
     assert callback.answered
     page2_lines = bot.messages[0].text.splitlines()
     assert page2_lines[0].startswith("11.")
-    assert page2_lines[1] == "     Pending | Skipped | Imported | Rejected "
-    assert page2_lines[2] == "        0    |    0    |    0     |    0     "
+    assert (
+        page2_lines[1]
+        == "     Pending      | Skipped      | Imported       | Rejected       "
+    )
+    assert (
+        page2_lines[2]
+        == "          0       |      0       |       0        |       0        "
+    )
     nav_row = bot.messages[0].reply_markup.inline_keyboard[-1]
     assert nav_row[0].callback_data == "vksrcpage:1"
 


### PR DESCRIPTION
## Summary
- widen the computed widths for VK status columns to give numbers more margin
- update expectations in vk list tests for the expanded cell spacing

## Testing
- pytest tests/test_vk_default_time.py

------
https://chatgpt.com/codex/tasks/task_e_68cfc8ab906c83328fa45161be9cab33