### PR TITLE
Align VK status header left

### DIFF
--- a/main.py
+++ b/main.py
@@ -19462,7 +19462,7 @@ async def handle_vk_list(
     status_header_parts = [
         f" {label:<{count_widths[key]}} " for key, label in VK_STATUS_LABELS
     ]
-    status_header_line = "    " + "|".join(status_header_parts)
+    status_header_line = "|".join(status_header_parts)
 
     lines: list[str] = []
     buttons: list[list[types.InlineKeyboardButton]] = []
@@ -19480,7 +19480,7 @@ async def handle_vk_list(
             for key, _ in VK_STATUS_LABELS
         ]
         lines.append(status_header_line)
-        lines.append("    " + "|".join(value_parts))
+        lines.append("|".join(value_parts))
         buttons.append(
             [
                 types.InlineKeyboardButton(

--- a/tests/test_vk_default_time.py
+++ b/tests/test_vk_default_time.py
@@ -75,21 +75,21 @@ async def test_vk_list_shows_numbers_and_default_time(tmp_path):
     assert "типовое время: 19:00" in lines[0]
     assert (
         lines[1]
-        == "     Pending      | Skipped      | Imported       | Rejected       "
+        == " Pending      | Skipped      | Imported       | Rejected       "
     )
     assert (
         lines[2]
-        == "          2       |      1       |       0        |       0        "
+        == "      2       |      1       |       0        |       0        "
     )
     assert lines[3].startswith("2.")
     assert "типовое время: -" in lines[3]
     assert (
         lines[4]
-        == "     Pending      | Skipped      | Imported       | Rejected       "
+        == " Pending      | Skipped      | Imported       | Rejected       "
     )
     assert (
         lines[5]
-        == "          0       |      0       |       12       |       1        "
+        == "      0       |      0       |       12       |       1        "
     )
     buttons = bot.messages[0].reply_markup.inline_keyboard
     assert buttons[0][0].text == "❌ 1"
@@ -115,11 +115,11 @@ async def test_vk_list_shows_numbers_and_default_time(tmp_path):
     assert page2_lines[0].startswith("11.")
     assert (
         page2_lines[1]
-        == "     Pending      | Skipped      | Imported       | Rejected       "
+        == " Pending      | Skipped      | Imported       | Rejected       "
     )
     assert (
         page2_lines[2]
-        == "          0       |      0       |       0        |       0        "
+        == "      0       |      0       |       0        |       0        "
     )
     nav_row = bot.messages[0].reply_markup.inline_keyboard[-1]
     assert nav_row[0].callback_data == "vksrcpage:1"


### PR DESCRIPTION
## Summary
- drop the extra indentation prefix when rendering VK inbox status headers
- update the VK list spacing expectations in tests to match the new formatting

## Testing
- pytest tests/test_vk_default_time.py

------
https://chatgpt.com/codex/tasks/task_e_68cfca09dd708332b93997e41ff8e557