### PR TITLE
Preserve paragraphs when truncating VK summary

### DIFF
--- a/tests/test_short_rewrite.py
+++ b/tests/test_short_rewrite.py
@@ -62,3 +62,21 @@ async def test_build_short_vk_text_handles_missing_text_reply(monkeypatch):
     result = await main.build_short_vk_text(event, original, max_sentences=3)
 
     assert result == "Первое предложение. Второе предложение."
+
+
+@pytest.mark.asyncio
+async def test_build_short_vk_text_preserves_paragraphs(monkeypatch):
+    async def fake_ask(prompt, **kwargs):
+        return (
+            "Первое предложение. Второе предложение.\n\n"
+            "Третье предложение. Четвертое предложение."
+        )
+
+    monkeypatch.setattr(main, "ask_4o", fake_ask)
+
+    event = SimpleNamespace(description="Описание события", title="Название события")
+
+    result = await main.build_short_vk_text(event, "Исходный текст", max_sentences=3)
+
+    assert result == "Первое предложение. Второе предложение.\n\nТретье предложение."
+    assert "\n\n" in result


### PR DESCRIPTION
## Summary
- preserve paragraph spacing when truncating VK short text summaries
- reuse the same truncation logic for fallback summaries based on the original text
- add a regression test ensuring blank lines remain between paragraphs after truncation

## Testing
- pytest tests/test_short_rewrite.py

------
https://chatgpt.com/codex/tasks/task_e_68cfcacb5b448332a1658e937cffdb00