### PR TITLE
Document paragraph preservation in rewrite output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Уточнены правила очереди: URGENT с горизонтом 48 ч, окна SOON/LONG завершаются на 14 / 30 дней, FAR использует веса 3 / 2 / 6, джиттер задаётся по источнику, а стрик-брейкер FAR срабатывает после K=5 не-FAR выборов.
 - Список сообществ ВК показывает статусы `Pending | Skipped | Imported | Rejected` и поддерживает пагинацию.
 - Ежедневный Telegram-анонс теперь ссылается на Telegraph-страницу для событий из VK-очереди (кроме партнёрских авторов).
+- «✂️ Сокращённый рерайт» сохраняет разбивку на абзацы вместо склеивания всего текста в один блок.
 
 - Introduced automatic topic classification with a closed topic list, editor display, and `/backfill_topics` command.
 - Classifier/digest topic list now includes the `PSYCHOLOGY`, `THEATRE_CLASSIC`, and `THEATRE_MODERN` categories.


### PR DESCRIPTION
## Summary
- note in the changelog that the "✂️ Сокращённый рерайт" output now keeps paragraph breaks

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cfcd57fd7c8332a854bd2511bc9b85