### PR TITLE
Simplify VK list status headers

### DIFF
--- a/main.py
+++ b/main.py
@@ -19466,9 +19466,7 @@ async def handle_vk_list(
             base_width = len(label)
             count_widths[key] = max(1, math.ceil(base_width * 1.7))
 
-    status_header_parts = [
-        f" {label:<{count_widths[key]}} " for key, label in VK_STATUS_LABELS
-    ]
+    status_header_parts = [f" {label} " for _, label in VK_STATUS_LABELS]
     status_header_line = "|".join(status_header_parts)
 
     lines: list[str] = []

--- a/tests/test_vk_default_time.py
+++ b/tests/test_vk_default_time.py
@@ -73,20 +73,14 @@ async def test_vk_list_shows_numbers_and_default_time(tmp_path):
     lines = bot.messages[0].text.splitlines()
     assert lines[0].startswith("1.")
     assert "типовое время: 19:00" in lines[0]
-    assert (
-        lines[1]
-        == " Pending      | Skipped      | Imported       | Rejected       "
-    )
+    assert lines[1] == " Pending | Skipped | Imported | Rejected "
     assert (
         lines[2]
         == "      2       |      1       |       0        |       0        "
     )
     assert lines[3].startswith("2.")
     assert "типовое время: -" in lines[3]
-    assert (
-        lines[4]
-        == " Pending      | Skipped      | Imported       | Rejected       "
-    )
+    assert lines[4] == " Pending | Skipped | Imported | Rejected "
     assert (
         lines[5]
         == "      0       |      0       |       12       |       1        "
@@ -113,10 +107,7 @@ async def test_vk_list_shows_numbers_and_default_time(tmp_path):
     assert callback.answered
     page2_lines = bot.messages[0].text.splitlines()
     assert page2_lines[0].startswith("11.")
-    assert (
-        page2_lines[1]
-        == " Pending      | Skipped      | Imported       | Rejected       "
-    )
+    assert page2_lines[1] == " Pending | Skipped | Imported | Rejected "
     assert (
         page2_lines[2]
         == "      0       |      0       |       0        |       0        "


### PR DESCRIPTION
## Summary
- format the VK status header cells with single-space padding around each label
- update vk list default time test expectations to reflect the new header layout

## Testing
- pytest tests/test_vk_default_time.py::test_vk_list_shows_numbers_and_default_time

------
https://chatgpt.com/codex/tasks/task_e_68cfd1b4e47c8332a0f8b4f5354be6db