### PR TITLE
Adjust VK list column padding

### DIFF
--- a/main.py
+++ b/main.py
@@ -19459,12 +19459,12 @@ async def handle_vk_list(
         for key, label in VK_STATUS_LABELS:
             max_value_len = max(len(str(item[2][key])) for item in page_items)
             base_width = max(len(label), max_value_len)
-            count_widths[key] = max(1, math.ceil(base_width * 1.7))
+            count_widths[key] = max(1, math.ceil(base_width * 1.87))
     else:
         count_widths = {}
         for key, label in VK_STATUS_LABELS:
             base_width = len(label)
-            count_widths[key] = max(1, math.ceil(base_width * 1.7))
+            count_widths[key] = max(1, math.ceil(base_width * 1.87))
 
     status_header_parts = [f" {label} " for _, label in VK_STATUS_LABELS]
     status_header_line = "|".join(status_header_parts)

--- a/tests/test_vk_default_time.py
+++ b/tests/test_vk_default_time.py
@@ -76,14 +76,14 @@ async def test_vk_list_shows_numbers_and_default_time(tmp_path):
     assert lines[1] == " Pending | Skipped | Imported | Rejected "
     assert (
         lines[2]
-        == "      2       |      1       |       0        |       0        "
+        == "       2        |       1        |        0        |        0        "
     )
     assert lines[3].startswith("2.")
     assert "типовое время: -" in lines[3]
     assert lines[4] == " Pending | Skipped | Imported | Rejected "
     assert (
         lines[5]
-        == "      0       |      0       |       12       |       1        "
+        == "       0        |       0        |       12        |        1        "
     )
     buttons = bot.messages[0].reply_markup.inline_keyboard
     assert buttons[0][0].text == "❌ 1"
@@ -110,7 +110,7 @@ async def test_vk_list_shows_numbers_and_default_time(tmp_path):
     assert page2_lines[1] == " Pending | Skipped | Imported | Rejected "
     assert (
         page2_lines[2]
-        == "      0       |      0       |       0        |       0        "
+        == "       0        |       0        |        0        |        0        "
     )
     nav_row = bot.messages[0].reply_markup.inline_keyboard[-1]
     assert nav_row[0].callback_data == "vksrcpage:1"


### PR DESCRIPTION
## Summary
- widen the calculated VK inbox status column widths to reserve more padding for numbers
- refresh vk list formatting expectations in tests for the updated spacing

## Testing
- pytest tests/test_vk_default_time.py -q

------
https://chatgpt.com/codex/tasks/task_e_68cfd76dbc648332b38b28ccb06880c2