### PR TITLE
Ensure VK shortpost publish uses source markup

### DIFF
--- a/main.py
+++ b/main.py
@@ -20829,9 +20829,25 @@ async def _vkrev_publish_shortpost(
         return
     op_state = vk_shortpost_ops.get(event_id)
     poster_texts = await get_event_poster_texts(event_id, db)
+    def _ensure_publish_markup(message: str) -> str:
+        lines = message.split("\n")
+        markup = f"[{vk_url}|Источник]"
+        for idx, line in enumerate(lines):
+            if line.strip() == "Источник":
+                if idx + 1 < len(lines):
+                    del lines[idx + 1]
+                lines[idx] = markup
+                return "\n".join(lines)
+        for idx, line in enumerate(lines):
+            stripped = line.strip()
+            if stripped.startswith("[") and stripped.endswith("|Источник]"):
+                lines[idx] = markup
+                return "\n".join(lines)
+        return message
+
     if text is None:
         if op_state and op_state.preview_text is not None:
-            message = op_state.preview_text
+            message = _ensure_publish_markup(op_state.preview_text)
             link_attachment = (
                 op_state.preview_link_attachment
                 if op_state.preview_link_attachment is not None
@@ -20844,7 +20860,7 @@ async def _vkrev_publish_shortpost(
                 poster_texts=poster_texts,
             )
     else:
-        message = text
+        message = _ensure_publish_markup(text)
         link_attachment = ev.telegraph_url or vk_url
 
     photo_attachments: list[str] = []

--- a/tests/test_vk_shortpost.py
+++ b/tests/test_vk_shortpost.py
@@ -272,6 +272,9 @@ async def test_shortpost_publish_uses_cached_preview(tmp_path, monkeypatch):
     await main._vkrev_publish_shortpost(77, db, bot, actor_chat_id=1, operator_id=10)
     assert build_calls == 1
     assert posts and posts[0]["message"].startswith("TEST")
+    lines = posts[0]["message"].split("\n")
+    assert "Источник" not in lines
+    assert "[https://vk.com/wall-1_2|Источник]" in lines
 
     main.vk_shortpost_ops.clear()
 


### PR DESCRIPTION
## Summary
- ensure cached VK shortpost previews are rewritten with the [vk_url|Источник] markup before publishing
- extend the cached-preview publishing test to assert the formatted source link is emitted

## Testing
- pytest tests/test_vk_shortpost.py

------
https://chatgpt.com/codex/tasks/task_e_68cfea41a17c8332afbacf410733d976