### PR TITLE
Adjust exhibition date formatting

### DIFF
--- a/digests.py
+++ b/digests.py
@@ -873,6 +873,8 @@ def format_event_line_html(
                 getattr(event, "id", None),
                 event.event_type,
             )
+        if not date_part.startswith("по "):
+            date_part = f"по {dt.strftime('%d.%m')}"
         time_part = ""
     else:
         time_part = ""

--- a/tests/test_lecture_digest.py
+++ b/tests/test_lecture_digest.py
@@ -601,7 +601,7 @@ def test_format_event_line_html_exhibition_missing_end_date(caplog):
 
     line = format_event_line_html(e, None)
 
-    assert line == "10.05 | T"
+    assert line == "по 10.05 | T"
     assert any("digest.end_date.missing" in r.message for r in caplog.records)
 
 
@@ -622,7 +622,7 @@ def test_format_event_line_html_exhibition_bad_end_date(caplog):
 
     line = format_event_line_html(e, None)
 
-    assert line == "10.05 | T"
+    assert line == "по 10.05 | T"
     assert any("digest.end_date.format" in r.message for r in caplog.records)
 
 


### PR DESCRIPTION
## Summary
- ensure exhibition digest lines always use the "по <date>" pattern, falling back to the start date when end_date is missing or invalid
- update exhibition formatting tests to cover the new behaviour

## Testing
- pytest tests/test_lecture_digest.py -k format_event_line_html_exhibition

------
https://chatgpt.com/codex/tasks/task_e_68d00244602483328ab0001c4cd1337c