### PR TITLE
Improve digest refresh handling

### DIFF
--- a/tests/test_digest_command.py
+++ b/tests/test_digest_command.py
@@ -175,7 +175,12 @@ async def test_handle_digest_sends_masterclasses_preview(tmp_path, monkeypatch):
     assert bot.media_groups
     panel = bot.messages[-1]
     assert panel.text.startswith("Управление дайджестом мастер-классов")
-    assert main.digest_preview_sessions[digest_id]["items_noun"] == "мастер-классов"
+    session = main.digest_preview_sessions[digest_id]
+    assert session["items_noun"] == "мастер-классов"
+    assert session["items"][0]["event_type"] == "мастер-класс"
+    assert session["items"][0]["norm_description"] == "d"
+    assert session["items"][0]["date"]
+    assert session["items"][0]["end_date"] is None
 
 
 @pytest.mark.asyncio
@@ -194,6 +199,7 @@ async def test_handle_digest_sends_exhibitions_preview(tmp_path, monkeypatch):
             source_text="s",
             event_type="выставка",
             telegraph_url="https://telegra.ph/test3",
+            end_date=dt.strftime("%Y-%m-%d"),
         )
         session.add(ev)
         await session.commit()
@@ -234,7 +240,13 @@ async def test_handle_digest_sends_exhibitions_preview(tmp_path, monkeypatch):
     assert bot.media_groups
     panel = bot.messages[-1]
     assert panel.text.startswith("Управление дайджестом выставок")
-    assert main.digest_preview_sessions[digest_id]["items_noun"] == "выставок"
+    session = main.digest_preview_sessions[digest_id]
+    assert session["items_noun"] == "выставок"
+    item = session["items"][0]
+    assert item["event_type"] == "выставка"
+    assert item["norm_description"] == "d"
+    assert item["date"]
+    assert item["end_date"] == ev.date
 
 
 @pytest.mark.asyncio

--- a/tests/test_digest_refresh.py
+++ b/tests/test_digest_refresh.py
@@ -1,0 +1,195 @@
+import pytest
+from types import SimpleNamespace
+
+import main
+
+
+class BotStub:
+    def __init__(self):
+        self.deleted = []
+
+    async def delete_message(self, chat_id, message_id):
+        self.deleted.append((chat_id, message_id))
+
+
+@pytest.mark.asyncio
+async def test_handle_digest_refresh_masterclasses(monkeypatch):
+    digest_id = "dg-test-master"
+    session = {
+        "chat_id": 1,
+        "preview_msg_ids": [101],
+        "panel_msg_id": 202,
+        "items": [
+            {
+                "title": "Title 1",
+                "norm_title": "Norm 1",
+                "norm_description": "Desc 1",
+                "event_type": "мастер-класс",
+                "date": "2025-05-01",
+                "end_date": None,
+                "line_html": "<b>Item1</b>",
+            },
+            {
+                "title": "Title 2",
+                "norm_title": "Norm 2",
+                "norm_description": "Desc 2",
+                "event_type": "мастер-класс",
+                "date": "2025-05-02",
+                "end_date": None,
+                "line_html": "<b>Item2</b>",
+            },
+        ],
+        "intro_html": "Old intro",
+        "footer_html": "Footer",
+        "excluded": {1},
+        "horizon_days": 7,
+        "channels": [],
+        "items_noun": "мастер-классов",
+        "panel_text": "panel",
+        "digest_type": "masterclasses",
+    }
+    main.digest_preview_sessions[digest_id] = session
+
+    captured = {}
+
+    async def fake_master(n, horizon, payload):
+        captured["master_args"] = (n, horizon, payload)
+        return "New intro"
+
+    async def fail(*args, **kwargs):  # pragma: no cover - defensive
+        raise AssertionError("unexpected composer call")
+
+    async def fake_send_preview(session_obj, digest_id_arg, bot):
+        captured["preview"] = (session_obj["intro_html"], digest_id_arg)
+        return ("cap", False, 0, n)
+
+    n = len(session["items"]) - len(session["excluded"])
+    bot = BotStub()
+
+    async def answer(**kwargs):
+        captured["answered"] = True
+
+    callback = SimpleNamespace(
+        data=f"dg:r:{digest_id}",
+        from_user=SimpleNamespace(id=1),
+        message=None,
+        answer=answer,
+        id="cb1",
+    )
+
+    monkeypatch.setattr(main, "compose_masterclasses_intro_via_4o", fake_master)
+    monkeypatch.setattr(main, "compose_exhibitions_intro_via_4o", fail)
+    monkeypatch.setattr(main, "compose_digest_intro_via_4o", fail)
+    monkeypatch.setattr(main, "_send_preview", fake_send_preview)
+
+    try:
+        await main.handle_digest_refresh(callback, bot)
+    finally:
+        main.digest_preview_sessions.pop(digest_id, None)
+
+    assert captured["master_args"] == (
+        n,
+        session["horizon_days"],
+        [{"title": "Norm 1", "description": "Desc 1"}],
+    )
+    assert captured["preview"] == ("New intro", digest_id)
+    assert captured.get("answered")
+    assert session["intro_html"] == "New intro"
+    assert bot.deleted == [(1, 101), (1, 202)]
+
+
+@pytest.mark.asyncio
+async def test_handle_digest_refresh_exhibitions(monkeypatch):
+    digest_id = "dg-test-exhib"
+    session = {
+        "chat_id": 2,
+        "preview_msg_ids": [],
+        "panel_msg_id": None,
+        "items": [
+            {
+                "title": "Title 1",
+                "norm_title": "Norm 1",
+                "norm_description": "Desc 1",
+                "event_type": "выставка",
+                "date": "2025-06-01",
+                "end_date": "2025-06-10",
+                "line_html": "<b>Item1</b>",
+            },
+            {
+                "title": "Title 2",
+                "norm_title": "Norm 2",
+                "norm_description": "Desc 2",
+                "event_type": "выставка",
+                "date": "2025-06-05",
+                "end_date": None,
+                "line_html": "<b>Item2</b>",
+            },
+        ],
+        "intro_html": "Old intro",
+        "footer_html": "Footer",
+        "excluded": set(),
+        "horizon_days": 14,
+        "channels": [],
+        "items_noun": "выставок",
+        "panel_text": "panel",
+        "digest_type": "exhibitions",
+    }
+    main.digest_preview_sessions[digest_id] = session
+
+    captured = {}
+
+    async def fake_exhib(n, horizon, payload):
+        captured["exhib_args"] = (n, horizon, payload)
+        return "Fresh intro"
+
+    async def fail(*args, **kwargs):  # pragma: no cover - defensive
+        raise AssertionError("unexpected composer call")
+
+    async def fake_send_preview(session_obj, digest_id_arg, bot):
+        captured["preview"] = (session_obj["intro_html"], digest_id_arg)
+        return ("cap", False, 0, n)
+
+    n = len(session["items"]) - len(session["excluded"])
+    bot = BotStub()
+
+    async def answer(**kwargs):
+        captured["answered"] = True
+
+    callback = SimpleNamespace(
+        data=f"dg:r:{digest_id}",
+        from_user=SimpleNamespace(id=1),
+        message=None,
+        answer=answer,
+        id="cb2",
+    )
+
+    monkeypatch.setattr(main, "compose_masterclasses_intro_via_4o", fail)
+    monkeypatch.setattr(main, "compose_exhibitions_intro_via_4o", fake_exhib)
+    monkeypatch.setattr(main, "compose_digest_intro_via_4o", fail)
+    monkeypatch.setattr(main, "_send_preview", fake_send_preview)
+
+    try:
+        await main.handle_digest_refresh(callback, bot)
+    finally:
+        main.digest_preview_sessions.pop(digest_id, None)
+
+    assert captured["exhib_args"] == (
+        n,
+        session["horizon_days"],
+        [
+            {
+                "title": "Norm 1",
+                "description": "Desc 1",
+                "date_range": {"start": "2025-06-01", "end": "2025-06-10"},
+            },
+            {
+                "title": "Norm 2",
+                "description": "Desc 2",
+                "date_range": {"start": "2025-06-05", "end": "2025-06-05"},
+            },
+        ],
+    )
+    assert captured["preview"] == ("Fresh intro", digest_id)
+    assert captured.get("answered")
+    assert session["intro_html"] == "Fresh intro"
+    assert bot.deleted == []


### PR DESCRIPTION
## Summary
- persist additional metadata for digest items and re-use it when regenerating introductions
- switch digest refresh to call the composer that matches the digest type
- add async tests covering digest refresh routing and stored session payloads

## Testing
- pytest tests/test_digest_refresh.py tests/test_digest_command.py::test_handle_digest_sends_masterclasses_preview tests/test_digest_command.py::test_handle_digest_sends_exhibitions_preview

------
https://chatgpt.com/codex/tasks/task_e_68d00877c6088332a944369d6686c952