### PR TITLE
Show VK source last crawl timestamp

### DIFF
--- a/main.py
+++ b/main.py
@@ -19432,10 +19432,24 @@ async def handle_vk_add_message(message: types.Message, db: Database, bot: Bot) 
     )
 
 
-async def _fetch_vk_sources(db: Database) -> list[tuple[int, int, str, str, str | None, str | None]]:
+async def _fetch_vk_sources(
+    db: Database,
+) -> list[tuple[int, int, str, str, str | None, str | None, str | None]]:
     async with db.raw_conn() as conn:
         cursor = await conn.execute(
-            "SELECT id, group_id, screen_name, name, location, default_time FROM vk_source ORDER BY id"
+            """
+            SELECT
+                s.id,
+                s.group_id,
+                s.screen_name,
+                s.name,
+                s.location,
+                s.default_time,
+                c.updated_at
+            FROM vk_source AS s
+            LEFT JOIN vk_crawl_cursor AS c ON c.group_id = s.group_id
+            ORDER BY s.id
+            """
         )
         rows = await cursor.fetchall()
     return rows
@@ -19491,9 +19505,11 @@ async def handle_vk_list(
     end = start + VK_SOURCES_PER_PAGE
     page_rows = rows[start:end]
     inbox_counts = await _fetch_vk_inbox_counts(db)
-    page_items: list[tuple[int, tuple[int, int, str, str, str | None, str | None], dict[str, int]]] = []
+    page_items: list[
+        tuple[int, tuple[int, int, str, str, str | None, str | None, str | None], dict[str, int]]
+    ] = []
     for offset, row in enumerate(page_rows, start=start + 1):
-        rid, gid, screen, name, loc, dtime = row
+        rid, gid, screen, name, loc, dtime, updated_at = row
         counts = inbox_counts.get(gid)
         if counts is None:
             counts = _zero_vk_status_counts()
@@ -19519,13 +19535,23 @@ async def handle_vk_list(
     lines: list[str] = []
     buttons: list[list[types.InlineKeyboardButton]] = []
     for offset, row, counts in page_items:
-        rid, gid, screen, name, loc, dtime = row
+        rid, gid, screen, name, loc, dtime, updated_at = row
         info_parts = [f"id={gid}"]
         if loc:
             info_parts.append(loc)
         info = ", ".join(info_parts)
+        if updated_at:
+            try:
+                parsed_updated = datetime.fromisoformat(updated_at)
+                if parsed_updated.tzinfo is None:
+                    parsed_updated = parsed_updated.replace(tzinfo=timezone.utc)
+                human_updated = parsed_updated.astimezone(LOCAL_TZ).strftime("%Y-%m-%d %H:%M")
+            except ValueError:
+                human_updated = updated_at
+        else:
+            human_updated = "-"
         lines.append(
-            f"{offset}. {name} (vk.com/{screen}) — {info}, типовое время: {dtime or '-'}"
+            f"{offset}. {name} (vk.com/{screen}) — {info}, типовое время: {dtime or '-'}, последняя проверка: {human_updated}"
         )
         value_parts = [
             f" {counts[key]:^{count_widths[key]}} "

--- a/tests/test_vk_default_time.py
+++ b/tests/test_vk_default_time.py
@@ -44,6 +44,10 @@ async def test_vk_list_shows_numbers_and_default_time(tmp_path):
                     "19:00" if idx == 1 else None,
                 ),
             )
+        await conn.execute(
+            "INSERT INTO vk_crawl_cursor(group_id, updated_at) VALUES(?, ?)",
+            (1, "2024-05-31 12:34:56"),
+        )
         # inbox stats for first two groups
         for post_id in range(2):
             await conn.execute(
@@ -73,6 +77,7 @@ async def test_vk_list_shows_numbers_and_default_time(tmp_path):
     lines = bot.messages[0].text.splitlines()
     assert lines[0].startswith("1.")
     assert "типовое время: 19:00" in lines[0]
+    assert "последняя проверка: 2024-05-31 12:34" in lines[0]
     assert lines[1] == " Pending | Skipped | Imported | Rejected "
     assert (
         lines[2]
@@ -80,6 +85,7 @@ async def test_vk_list_shows_numbers_and_default_time(tmp_path):
     )
     assert lines[3].startswith("2.")
     assert "типовое время: -" in lines[3]
+    assert ", последняя проверка: -" in lines[3]
     assert lines[4] == " Pending | Skipped | Imported | Rejected "
     assert (
         lines[5]


### PR DESCRIPTION
## Summary
- include the last crawl timestamp for VK sources when listing them
- cover the new output with tests, including formatting expectations

## Testing
- pytest tests/test_vk_default_time.py

------
https://chatgpt.com/codex/tasks/task_e_68d01cd8210483329fad8361a041ecb0