### PR TITLE
Add date prefix to daily inline event format

### DIFF
--- a/main.py
+++ b/main.py
@@ -12746,6 +12746,20 @@ def format_event_daily_inline(
 ) -> str:
     """Return a compact single-line HTML representation for daily lists."""
 
+    date_part = ""
+    if e.date:
+        date_part = e.date.split("..", 1)[0]
+    elif e.end_date:
+        date_part = e.end_date.split("..", 1)[0]
+
+    formatted_date = ""
+    if date_part:
+        d = parse_iso_date(date_part)
+        if d:
+            formatted_date = d.strftime("%d.%m")
+        else:
+            formatted_date = date_part
+
     markers: list[str] = []
     if is_recent(e):
         markers.append("\U0001f6a9")
@@ -12773,8 +12787,10 @@ def format_event_daily_inline(
         link_href = e.source_post_url
     if link_href:
         title = f'<a href="{html.escape(link_href)}">{title}</a>'
-
-    return f"{prefix}{emoji_part}{title}".strip()
+    body = f"{prefix}{emoji_part}{title}".strip()
+    if formatted_date:
+        return f"{formatted_date} {body}".strip()
+    return body
 
 
 def format_exhibition_md(e: Event) -> str:

--- a/tests/test_bot.py
+++ b/tests/test_bot.py
@@ -7242,6 +7242,7 @@ async def test_build_daily_posts_groups_many_new_events(tmp_path: Path, monkeypa
     monkeypatch.setattr(main, "datetime", FakeDatetime)
 
     future_date = (FakeDate.today() + timedelta(days=1)).isoformat()
+    expected_date = datetime.fromisoformat(future_date).strftime("%d.%m")
     added_at = datetime(2025, 7, 15, 9, 0, tzinfo=timezone.utc)
 
     async with db.get_session() as session:
@@ -7283,12 +7284,13 @@ async def test_build_daily_posts_groups_many_new_events(tmp_path: Path, monkeypa
         (sov_event_line, "event-0"),
         (kal_event_line, "event-5"),
     ):
+        assert line.startswith(f"{expected_date} ")
         assert "🚩" in line
         assert "🟡" in line
         assert "🎉" in line
         assert f'href="https://telegra.ph/{telegraph_suffix}"' in line
 
-    grouped_event_lines = [line for line in lines if line.startswith("🚩")]
+    grouped_event_lines = [line for line in lines if line.startswith(f"{expected_date} ")]
     assert len(grouped_event_lines) == 10
 
 


### PR DESCRIPTION
## Summary
- prepend a formatted dd.mm date to compact daily event lines, reusing ISO parsing helpers
- keep existing marker and link rendering while ensuring the new date prefix is always shown
- extend the daily posts grouping test to expect the date prefix on every compact event line

## Testing
- pytest tests/test_bot.py::test_build_daily_posts_groups_many_new_events

------
https://chatgpt.com/codex/tasks/task_e_68d021d978b083329685a9720bb7e80a