### PR TITLE
Add tourist label checkmark to keyboard

### DIFF
--- a/main.py
+++ b/main.py
@@ -802,13 +802,17 @@ def build_tourist_keyboard_block(
     if not getattr(event, "id", None):
         return []
     _ = source
+    yes_prefix = "✅ " if event.tourist_label == 1 else ""
+    no_prefix = "✅ " if event.tourist_label == 0 else ""
     rows: list[list[types.InlineKeyboardButton]] = [
         [
             types.InlineKeyboardButton(
-                text="Интересно туристам", callback_data=f"tourist:yes:{event.id}"
+                text=f"{yes_prefix}Интересно туристам",
+                callback_data=f"tourist:yes:{event.id}"
             ),
             types.InlineKeyboardButton(
-                text="Не интересно туристам", callback_data=f"tourist:no:{event.id}"
+                text=f"{no_prefix}Не интересно туристам",
+                callback_data=f"tourist:no:{event.id}"
             ),
         ],
         [


### PR DESCRIPTION
## Summary
- add context-aware checkmarks to the tourist interest buttons
- extend tourist feature tests to verify keyboard rendering for selected and unselected states

## Testing
- pytest tests/test_tourist_features.py

------
https://chatgpt.com/codex/tasks/task_e_68d0240a21d88332a40bd80e84c4d7ff