### PR TITLE
Add hint for compact daily posts

### DIFF
--- a/main.py
+++ b/main.py
@@ -15271,6 +15271,8 @@ async def build_daily_posts(
                         partner_creator_ids=partner_creator_ids,
                     )
                 )
+        lines2.append("")
+        lines2.append("ℹ️ Нажмите на название мероприятия, чтобы открыть подробности")
     else:
         for e in events_new:
             w_url = None

--- a/tests/test_bot.py
+++ b/tests/test_bot.py
@@ -7277,6 +7277,11 @@ async def test_build_daily_posts_groups_many_new_events(tmp_path: Path, monkeypa
     kal_idx = lines.index("КАЛИНИНГРАД")
     assert lines[sov_idx - 1] == ""
     assert lines[kal_idx - 1] == ""
+    assert lines[-2] == ""
+    assert (
+        lines[-1]
+        == "ℹ️ Нажмите на название мероприятия, чтобы открыть подробности"
+    )
 
     sov_event_line = lines[sov_idx + 1]
     kal_event_line = lines[kal_idx + 1]


### PR DESCRIPTION
## Summary
- add a hint after grouped daily events to explain how to open details
- extend the compact daily posts test to cover the new hint line

## Testing
- pytest tests/test_bot.py::test_build_daily_posts_groups_many_new_events

------
https://chatgpt.com/codex/tasks/task_e_68d0305e8314833290b5aa51b143b35d