### PR TITLE
Add late evening VK crawl slot and document schedule

### DIFF
--- a/README_cron.md
+++ b/README_cron.md
@@ -1,6 +1,6 @@
 # Cron Schedule
 
-The bot uses APScheduler to run periodic maintenance tasks every 15 minutes. Each job checks whether its specific conditions are met and exits quickly if not.
+The bot uses APScheduler to run periodic maintenance tasks on a fixed schedule. Each job checks whether its specific conditions are met and exits quickly if not. VK crawling runs six times per day by default at `05:15`, `09:15`, `13:15`, `17:15`, `21:15` and `22:45` Europe/Kaliningrad time (`VK_CRAWL_TIMES_LOCAL` / `VK_CRAWL_TZ`).
 
 ## Jobs
 

--- a/scheduling.py
+++ b/scheduling.py
@@ -550,7 +550,9 @@ def startup(
         "SCHED registered job id=%s next_run=%s", job.id, _job_next_run(job)
     )
 
-    times_raw = os.getenv("VK_CRAWL_TIMES_LOCAL", "05:15,09:15,13:15,17:15,21:15")
+    times_raw = os.getenv(
+        "VK_CRAWL_TIMES_LOCAL", "05:15,09:15,13:15,17:15,21:15,22:45"
+    )
     tz_name = os.getenv("VK_CRAWL_TZ", "Europe/Kaliningrad")
     tz = ZoneInfo(tz_name)
     for idx, t in enumerate(times_raw.split(",")):


### PR DESCRIPTION
## Summary
- add 22:45 to the default VK crawl schedule so a sixth cron job is registered
- document the six default VK crawl times in the cron README so docs match configuration

## Testing
- `python - <<'PY' ...` (see logs for vk_crawl_cron_* jobs)
- `pytest tests/test_scheduling.py`


------
https://chatgpt.com/codex/tasks/task_e_68d03721958c8332b9e7ab19de4161de