### PR TITLE
Handle numeric updated_at for VK list

### DIFF
--- a/main.py
+++ b/main.py
@@ -19620,12 +19620,15 @@ async def handle_vk_list(
         info = ", ".join(info_parts)
         if updated_at:
             try:
-                parsed_updated = datetime.fromisoformat(updated_at)
-                if parsed_updated.tzinfo is None:
-                    parsed_updated = parsed_updated.replace(tzinfo=timezone.utc)
+                if isinstance(updated_at, (int, float)):
+                    parsed_updated = datetime.fromtimestamp(updated_at, tz=timezone.utc)
+                else:
+                    parsed_updated = datetime.fromisoformat(updated_at)
+                    if parsed_updated.tzinfo is None:
+                        parsed_updated = parsed_updated.replace(tzinfo=timezone.utc)
                 human_updated = parsed_updated.astimezone(LOCAL_TZ).strftime("%Y-%m-%d %H:%M")
-            except ValueError:
-                human_updated = updated_at
+            except (ValueError, TypeError):
+                human_updated = str(updated_at)
         else:
             human_updated = "-"
         lines.append(

--- a/tests/test_vk_default_time.py
+++ b/tests/test_vk_default_time.py
@@ -48,6 +48,10 @@ async def test_vk_list_shows_numbers_and_default_time(tmp_path):
             "INSERT INTO vk_crawl_cursor(group_id, updated_at) VALUES(?, ?)",
             (1, "2024-05-31 12:34:56"),
         )
+        await conn.execute(
+            "INSERT INTO vk_crawl_cursor(group_id, updated_at) VALUES(?, ?)",
+            (2, 1717156496),
+        )
         # inbox stats for first two groups
         for post_id in range(2):
             await conn.execute(
@@ -85,7 +89,7 @@ async def test_vk_list_shows_numbers_and_default_time(tmp_path):
     )
     assert lines[3].startswith("2.")
     assert "типовое время: -" in lines[3]
-    assert ", последняя проверка: -" in lines[3]
+    assert ", последняя проверка: 2024-05-31 11:54" in lines[3]
     assert lines[4] == " Pending | Skipped | Imported | Rejected "
     assert (
         lines[5]


### PR DESCRIPTION
## Summary
- format numeric `vk_crawl_cursor.updated_at` values via UTC-aware timestamps in the VK list handler
- widen the handler's error handling and keep ISO parsing behaviour
- extend the VK list test to cover integer timestamps alongside existing assertions

## Testing
- pytest tests/test_vk_default_time.py

------
https://chatgpt.com/codex/tasks/task_e_68d05914d44c83329de37a819daecee0