### PR TITLE
Add rewrite label to VK review buttons

### DIFF
--- a/main.py
+++ b/main.py
@@ -16667,7 +16667,7 @@ async def build_events_message(db: Database, target_date: date, tz: timezone, cr
                     text=f"\u270e {e.id}", callback_data=f"edit:{e.id}"
                 ),
                 types.InlineKeyboardButton(
-                    text=f"{icon} {e.id}",
+                    text=f"{icon} Рерайт {e.id}",
                     callback_data=f"vkrev:shortpost:{e.id}",
                 ),
             ]

--- a/tests/test_bot.py
+++ b/tests/test_bot.py
@@ -5620,11 +5620,11 @@ async def test_events_markup_includes_rewrite_status(tmp_path: Path):
     _, markup = await main.build_events_message(db, target, timezone.utc)
 
     first_row = markup.inline_keyboard[0]
-    assert first_row[2].text == f"✂️ {first_id}"
+    assert first_row[2].text == f"✂️ Рерайт {first_id}"
     assert first_row[2].callback_data == f"vkrev:shortpost:{first_id}"
 
     second_row = markup.inline_keyboard[1]
-    assert second_row[2].text == f"✅ {second_id}"
+    assert second_row[2].text == f"✅ Рерайт {second_id}"
     assert second_row[2].callback_data == f"vkrev:shortpost:{second_id}"
 
 


### PR DESCRIPTION
## Summary
- add the "Рерайт" label to the VK review button in the events message markup
- update the rewrite status test to expect the new label for both unpublished and published events

## Testing
- pytest tests/test_bot.py -k "events_markup_includes_rewrite_status" -vv

------
https://chatgpt.com/codex/tasks/task_e_68d068fdd1688332b7599edbaef9d6c8