### PR TITLE
Notify users when forwarded post has no events

### DIFF
--- a/main.py
+++ b/main.py
@@ -21676,6 +21676,11 @@ async def _process_forwarded(
             ocr_line = base_line
     if not results:
         logging.info("no events parsed from forwarded text")
+        await bot.send_message(
+            message.chat.id,
+            "Я не смог найти события в пересланном посте. "
+            "Попробуйте добавить событие вручную или свяжитесь с поддержкой.",
+        )
         return
     for saved, added, lines, status in results:
         if status == "missing":


### PR DESCRIPTION
## Summary
- notify users when no events could be parsed from a forwarded post before returning

## Testing
- pytest *(fails: existing suite reports multiple failures unrelated to this change)*

------
https://chatgpt.com/codex/tasks/task_e_68d06e01cd508332ad5ff8885ee540f5