### PR TITLE
Add historical detection for VK intake posts

### DIFF
--- a/tests/test_vk_intake_history.py
+++ b/tests/test_vk_intake_history.py
@@ -1,0 +1,62 @@
+import os
+import sys
+import time
+
+import pytest
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+
+import main
+import vk_intake
+from db import Database
+
+
+@pytest.mark.asyncio
+async def test_crawl_enqueues_historical_posts(tmp_path, monkeypatch):
+    db = Database(str(tmp_path / "db.sqlite"))
+    await db.init()
+
+    async with db.raw_conn() as conn:
+        await conn.execute(
+            "INSERT INTO vk_source(group_id, screen_name, name, location, default_time) VALUES(?,?,?,?,?)",
+            (1, "g", "Group", "", None),
+        )
+        await conn.commit()
+
+    post_text = "В 1945 году в Кёнигсберге пройдет фестиваль памяти"
+    posts = [
+        {
+            "date": int(time.time()),
+            "post_id": 10,
+            "text": post_text,
+            "photos": [],
+        }
+    ]
+
+    async def fake_wall_since(gid, since, count, offset=0):
+        return posts if offset == 0 else []
+
+    monkeypatch.setattr(main, "vk_wall_since", fake_wall_since)
+
+    async def no_sleep(_):
+        pass
+
+    monkeypatch.setattr(vk_intake.asyncio, "sleep", no_sleep)
+
+    stats = await vk_intake.crawl_once(db)
+    assert stats["added"] == 1
+
+    async with db.raw_conn() as conn:
+        cur = await conn.execute(
+            "SELECT text, matched_kw, has_date, event_ts_hint, status FROM vk_inbox WHERE post_id=?",
+            (10,),
+        )
+        row = await cur.fetchone()
+
+    assert row == (
+        post_text,
+        vk_intake.HISTORY_MATCHED_KEYWORD,
+        0,
+        None,
+        "pending",
+    )

--- a/vk_intake.py
+++ b/vk_intake.py
@@ -36,6 +36,7 @@ VK_USE_PYMORPHY = os.getenv("VK_USE_PYMORPHY", "false").lower() == "true"
 
 # Sentinel used to flag posts awaiting poster OCR before keyword/date checks.
 OCR_PENDING_SENTINEL = "__ocr_pending__"
+HISTORY_MATCHED_KEYWORD = "history"
 
 # optional pymorphy3 initialisation
 MORPH = None
@@ -105,6 +106,16 @@ DATE_PATTERNS = [
 
 COMPILED_DATE_PATTERNS = [re.compile(p, re.I | re.U) for p in DATE_PATTERNS]
 
+HISTORICAL_TOPONYMS = [
+    "кёнигсберг",
+    "кенигсберг",
+    "гумбинен",
+    "инстербург",
+    "тильзит",
+    "мемель",
+]
+HISTORICAL_YEAR_RE = re.compile(r"\b(1\d{3})\b")
+
 NUM_DATE_RE = re.compile(r"\b(\d{1,2})[./-](\d{1,2})(?:[./-](\d{2,4}))?\b")
 DATE_RANGE_RE = re.compile(r"\b(\d{1,2})[–-](\d{1,2})(?:[./](\d{1,2}))\b")
 MONTH_NAME_RE = re.compile(r"\b(\d{1,2})\s+([а-яё.]+)\b", re.I)
@@ -144,6 +155,22 @@ def match_keywords(text: str) -> tuple[bool, list[str]]:
 def detect_date(text: str) -> bool:
     """Heuristically detect a date or time mention in the text."""
     return any(p.search(text) for p in COMPILED_DATE_PATTERNS)
+
+
+def detect_historical_context(text: str) -> bool:
+    """Return True if text mentions a pre-1995 year alongside historical toponyms."""
+
+    text_low = text.lower()
+    if not any(name in text_low for name in HISTORICAL_TOPONYMS):
+        return False
+    for match in HISTORICAL_YEAR_RE.findall(text_low):
+        try:
+            year = int(match)
+        except ValueError:
+            continue
+        if year <= 1994:
+            return True
+    return False
 
 
 def extract_event_ts_hint(
@@ -955,15 +982,22 @@ async def crawl_once(db, *, broadcast: bool = False, bot: Any | None = None) -> 
                     has_date_value = 0
                     event_ts_hint = None
                 else:
+                    history_hit = detect_historical_context(post_text)
                     kw_ok, kws = match_keywords(post_text)
                     has_date = detect_date(post_text)
-                    event_ts_hint = extract_event_ts_hint(post_text, default_time)
                     if not (kw_ok and has_date):
-                        continue
-                    if event_ts_hint is None or event_ts_hint < int(time.time()) + 2 * 3600:
-                        continue
-                    matched_kw_value = ",".join(kws)
-                    has_date_value = int(has_date)
+                        if history_hit:
+                            matched_kw_value = HISTORY_MATCHED_KEYWORD
+                            has_date_value = int(has_date)
+                            event_ts_hint = None
+                        else:
+                            continue
+                    else:
+                        event_ts_hint = extract_event_ts_hint(post_text, default_time)
+                        if event_ts_hint is None or event_ts_hint < int(time.time()) + 2 * 3600:
+                            continue
+                        matched_kw_value = ",".join(kws)
+                        has_date_value = int(has_date)
 
                 stats["matches"] += 1
                 try:


### PR DESCRIPTION
## Summary
- add a detector for historical references that combines legacy toponyms with pre-1995 years
- enqueue VK posts flagged by the detector with a dedicated matched keyword without requiring a future date hint
- cover the new behavior with a crawl_once test using a 1945 Königsberg example

## Testing
- pytest tests/test_vk_intake_history.py

------
https://chatgpt.com/codex/tasks/task_e_68d61fd2e2208332af097b1a92bfff93