### PR TITLE
Add festival shortcuts to VK review flow

### DIFF
--- a/tests/test_vk_review_show_next.py
+++ b/tests/test_vk_review_show_next.py
@@ -173,6 +173,13 @@ async def test_vkrev_show_next_handles_blank_text(tmp_path, monkeypatch):
     message = bot.messages[0]
     assert isinstance(message.reply_markup, types.InlineKeyboardMarkup)
     assert message.reply_markup.inline_keyboard
+    callbacks = {
+        button.callback_data
+        for row in message.reply_markup.inline_keyboard
+        for button in row
+    }
+    assert "vkrev:accept_fest:1" in callbacks
+    assert "vkrev:accept_fest_extra:1" in callbacks
     assert "https://vk.com/wall-1_10" in message.text
     assert "ожидает OCR" in message.text
 

--- a/tests/test_vk_shortpost.py
+++ b/tests/test_vk_shortpost.py
@@ -357,7 +357,15 @@ async def test_handle_vk_review_accept_notifies_before_import(monkeypatch, tmp_p
     sent = []
 
     async def fake_import_flow(
-        chat_id, operator_id, inbox_id, batch_id, db_, bot_, operator_extra=None
+        chat_id,
+        operator_id,
+        inbox_id,
+        batch_id,
+        db_,
+        bot_,
+        operator_extra=None,
+        *,
+        force_festival=False,
     ):
         sent.append((chat_id, operator_id, inbox_id, batch_id))
         await bot_.send_message(chat_id, "import flow called")


### PR DESCRIPTION
## Summary
- add dedicated inline buttons in the VK review UI to trigger festival imports with and without extra information
- extend the VK review callback handling to respect forced festival imports, reuse the extra-info flow, and clear sessions on stop
- broaden VK review tests to cover the new buttons and forced festival paths

## Testing
- pytest tests/test_vk_review_show_next.py tests/test_vkrev_import_flow.py tests/test_vk_shortpost.py::test_handle_vk_review_accept_notifies_before_import

------
https://chatgpt.com/codex/tasks/task_e_68d910b6b67083329e63013dc2dd7a5a