### PR TITLE
Add edit button to VK review import flow

### DIFF
--- a/main.py
+++ b/main.py
@@ -20814,7 +20814,13 @@ async def _vkrev_import_flow(
                     text="✂️ Сокращённый рерайт",
                     callback_data=f"vkrev:shortpost:{res.event_id}",
                 ),
-            ]
+            ],
+            [
+                types.InlineKeyboardButton(
+                    text="Редактировать",
+                    callback_data=f"edit:{res.event_id}",
+                )
+            ],
         ]
         if event_obj:
             inline_keyboard = append_tourist_block(base_keyboard, event_obj, "vk")


### PR DESCRIPTION
## Summary
- add an inline "Edit" button to the VK review import flow keyboard ahead of the tourist controls
- capture reply markup in the VK review import tests and assert the new button is included

## Testing
- pytest tests/test_vkrev_import_flow.py

------
https://chatgpt.com/codex/tasks/task_e_68da2a02d460833280dc8169866fb023