### PR TITLE
Handle festival-only VK review imports

### DIFF
--- a/vk_review.py
+++ b/vk_review.py
@@ -458,14 +458,15 @@ async def mark_imported(
     inbox_id: int,
     batch_id: str,
     operator_id: int,
-    event_id: int,
-    event_date: str,
+    event_id: int | None,
+    event_date: str | None,
 ) -> None:
     """Mark inbox row as imported and accumulate affected month.
 
     ``event_date`` should be in ISO ``YYYY-MM-DD`` format.  The month part is
     stored in ``vk_review_batch.months_csv`` as a comma separated set.  The
-    row is unlocked and linked with ``event_id``.
+    row is unlocked and linked with ``event_id`` (which may be ``None`` when
+    only a festival record is created).
     """
 
     month = (event_date or "")[:7]


### PR DESCRIPTION
## Summary
- ensure VK review festival creation runs even when no event drafts are returned
- allow queue bookkeeping to succeed for festival-only imports
- cover the festival-only path in the VK review import flow tests

## Testing
- pytest tests/test_vkrev_import_flow.py

------
https://chatgpt.com/codex/tasks/task_e_68da60f6ed3883328dea9a820f1cc858