### PR TITLE
Add tourist export command to help menu

### DIFF
--- a/main.py
+++ b/main.py
@@ -1782,6 +1782,11 @@ HELP_COMMANDS = [
         "roles": {"superadmin"},
     },
     {
+        "usage": "/tourist_export [period]",
+        "desc": "Export events with tourist_* fields to JSONL",
+        "roles": {"user", "superadmin"},
+    },
+    {
         "usage": "/tz <±HH:MM>",
         "desc": "Set timezone offset",
         "roles": {"superadmin"},

--- a/tests/test_help_vk_commands.py
+++ b/tests/test_help_vk_commands.py
@@ -51,6 +51,7 @@ async def test_help_superadmin_lists_vk_commands(tmp_path):
     assert any(line.startswith("/vk_crawl_now") for line in lines)
     assert any("↪️ Репостнуть в Vk" in line for line in lines)
     assert any("✂️ Сокращённый рерайт" in line for line in lines)
+    assert any(line.startswith("/tourist_export [period]") for line in lines)
     assert "/ocrtest — сравнить распознавание афиш" in lines
 
 
@@ -78,4 +79,5 @@ async def test_help_user_hides_vk_queue_and_crawl(tmp_path):
     assert not any(line.startswith("/vk_crawl_now") for line in lines)
     assert any("↪️ Репостнуть в Vk" in line for line in lines)
     assert any("✂️ Сокращённый рерайт" in line for line in lines)
+    assert any(line.startswith("/tourist_export [period]") for line in lines)
 


### PR DESCRIPTION
## Summary
- list the /tourist_export moderator command in the help catalogue for users and superadmins
- extend the help command tests to ensure authorized roles see the tourist export entry

## Testing
- pytest tests/test_help_vk_commands.py

------
https://chatgpt.com/codex/tasks/task_e_68da650daeb08332b310302b70c9fd93