### PR TITLE
Handle missing festival photo URLs

### DIFF
--- a/main.py
+++ b/main.py
@@ -7080,10 +7080,11 @@ async def process_request(callback: types.CallbackQuery, db: Database, bot: Bot)
         if not fest:
             await callback.answer("Festival not found", show_alert=True)
             return
-        total = len(fest.photo_urls)
+        photo_urls = list(fest.photo_urls or [])
+        total = len(photo_urls)
         current = (
-            fest.photo_urls.index(fest.photo_url) + 1
-            if fest.photo_url in fest.photo_urls
+            photo_urls.index(fest.photo_url) + 1
+            if fest.photo_url in photo_urls
             else 0
         )
         text = (
@@ -7111,10 +7112,11 @@ async def process_request(callback: types.CallbackQuery, db: Database, bot: Bot)
         idx_i = int(idx)
         async with db.get_session() as session:
             fest = await session.get(Festival, fid_i)
-            if not fest or idx_i < 1 or idx_i > len(fest.photo_urls):
+            photo_urls = list(fest.photo_urls or []) if fest else []
+            if not fest or idx_i < 1 or idx_i > len(photo_urls):
                 await callback.answer("Invalid selection", show_alert=True)
                 return
-            fest.photo_url = fest.photo_urls[idx_i - 1]
+            fest.photo_url = photo_urls[idx_i - 1]
             await session.commit()
             name = fest.name
         asyncio.create_task(sync_festival_page(db, name))


### PR DESCRIPTION
## Summary
- guard festival image selection callbacks against missing photo URL lists
- reuse the sanitized list when updating festival covers
- add a regression test covering festivals with null photo URL collections

## Testing
- pytest tests/test_bot.py::test_festimgs_handles_missing_photo_urls -q

------
https://chatgpt.com/codex/tasks/task_e_68dbb17e3b1083328f39ea5f662d08b9