### PR TITLE
Handle missing festival photo_urls when setting telegraph cover

### DIFF
--- a/main.py
+++ b/main.py
@@ -3135,8 +3135,10 @@ async def try_set_fest_cover_from_program(
         fresh = await session.get(Festival, fest.id)
         if not fresh:
             return False
-        if cover not in fresh.photo_urls:
-            fresh.photo_urls = [cover] + fresh.photo_urls
+        photos = list(fresh.photo_urls or [])
+        if cover not in photos:
+            photos = [cover] + photos
+        fresh.photo_urls = photos
         fresh.photo_url = cover
         await session.commit()
     logging.info("telegraph_cover: set_ok")


### PR DESCRIPTION
## Summary
- normalize festival photo_urls in try_set_fest_cover_from_program before updating the cover
- persist the refreshed photo_urls list alongside the new cover value
- add a regression test covering a festival with photo_urls=None

## Testing
- pytest tests/test_telegraph_cover.py

------
https://chatgpt.com/codex/tasks/task_e_68dc23f643e483329478800c7e134ef7