### PR TITLE
Include open-ended exhibitions in feed

### DIFF
--- a/main.py
+++ b/main.py
@@ -16879,8 +16879,11 @@ async def build_exhibitions_message(
         result = await session.execute(
             select(Event)
             .where(
-                Event.end_date.is_not(None),
-                Event.end_date >= today_iso,
+                or_(
+                    Event.end_date.is_not(None),
+                    and_(Event.end_date.is_(None), Event.date >= today_iso),
+                ),
+                or_(Event.end_date >= today_iso, Event.end_date.is_(None)),
             )
             .order_by(Event.date)
         )


### PR DESCRIPTION
## Summary
- include upcoming exhibitions without an end date when building the exhibitions message
- extend the exhibitions message test to cover open-ended events and ensure their keyboard buttons are created

## Testing
- pytest tests/test_bot.py::test_build_exhibitions_message_filters_past_end

------
https://chatgpt.com/codex/tasks/task_e_68dc29c8f50c8332b217e9fe1d21401f