### PR TITLE
Support telegraph fallback for fest cover

### DIFF
--- a/main.py
+++ b/main.py
@@ -3124,11 +3124,12 @@ async def try_set_fest_cover_from_program(
     db: Database, fest: Festival, force: bool = False
 ) -> bool:
     """Fetch Telegraph cover and set festival.photo_url if missing."""
-    if not fest.program_url:
-        return False
     if not force and fest.photo_url:
         return False
-    cover = await extract_telegra_ph_cover_url(fest.program_url)
+    target_url = fest.program_url or _festival_telegraph_url(fest)
+    if not target_url:
+        return False
+    cover = await extract_telegra_ph_cover_url(target_url)
     if not cover:
         return False
     async with db.get_session() as session:


### PR DESCRIPTION
## Summary
- use the festival's program or telegraph URL when fetching cover images
- add regression coverage for telegraph-only festivals updating their cover fields

## Testing
- pytest tests/test_telegraph_cover.py

------
https://chatgpt.com/codex/tasks/task_e_68dc35c1e3748332b769031ea2a89314