### PR TITLE
Allow festcover callbacks through filter

### DIFF
--- a/main.py
+++ b/main.py
@@ -23497,6 +23497,7 @@ def create_app() -> web.Application:
         or c.data.startswith("festdays:")
         or c.data.startswith("festimgs:")
         or c.data.startswith("festsetcover:")
+        or c.data.startswith("festcover:")
         or c.data.startswith("requeue:")
         or c.data.startswith("tourist:")
     ,


### PR DESCRIPTION
## Summary
- include `festcover:` callbacks in the dispatcher filter so they reach the existing handler

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dc3e261e3c83328d7b83854fe41de2