### PR TITLE
Extend festival cover discovery via events

### DIFF
--- a/tests/test_telegraph_cover.py
+++ b/tests/test_telegraph_cover.py
@@ -4,7 +4,7 @@ from pathlib import Path
 
 import main
 from db import Database
-from models import Festival
+from models import Event, Festival
 
 
 class FakeResponse:
@@ -134,3 +134,61 @@ async def test_try_set_fest_cover_uses_telegraph_url(tmp_path: Path, monkeypatch
         fest = await session.get(Festival, fid)
         assert fest.photo_url == "https://telegra.ph/file/cover-telegraph.jpg"
         assert fest.photo_urls == ["https://telegra.ph/file/cover-telegraph.jpg"]
+
+
+@pytest.mark.asyncio
+async def test_try_set_fest_cover_uses_event_media(tmp_path: Path, monkeypatch):
+    db = Database(str(tmp_path / "db.sqlite"))
+    await db.init()
+    async with db.get_session() as session:
+        fest = Festival(
+            name="FestEvents",
+            photo_urls=["https://example.com/existing.jpg"],
+        )
+        session.add(fest)
+        await session.flush()
+
+        event_with_photo = Event(
+            title="Event 1",
+            description="Desc",
+            festival=fest.name,
+            date="2024-01-01",
+            time="10:00",
+            location_name="Place",
+            source_text="Source",
+            photo_urls=["https://example.com/event-photo.jpg"],
+        )
+        event_with_telegra_ph = Event(
+            title="Event 2",
+            description="Desc",
+            festival=fest.name,
+            date="2024-01-02",
+            time="11:00",
+            location_name="Place",
+            source_text="Source",
+            telegraph_url="https://telegra.ph/event-cover",
+        )
+        session.add_all([event_with_photo, event_with_telegra_ph])
+        await session.commit()
+        fid = fest.id
+
+    async def fake_extract(url, *, event_id=None):
+        if url == "https://telegra.ph/event-cover":
+            return "https://telegra.ph/file/event-cover.jpg"
+        return None
+
+    monkeypatch.setattr(main, "extract_telegra_ph_cover_url", fake_extract)
+
+    async with db.get_session() as session:
+        fest = await session.get(Festival, fid)
+        ok = await main.try_set_fest_cover_from_program(db, fest)
+        assert ok
+
+    async with db.get_session() as session:
+        fest = await session.get(Festival, fid)
+        assert fest.photo_urls == [
+            "https://example.com/event-photo.jpg",
+            "https://telegra.ph/file/event-cover.jpg",
+            "https://example.com/existing.jpg",
+        ]
+        assert fest.photo_url == "https://example.com/event-photo.jpg"


### PR DESCRIPTION
## Summary
- expand `try_set_fest_cover_from_program` to collect cover candidates from linked events and preserve existing photo order
- ensure new covers prepend existing festival photos and optionally promote the first new URL as the active cover when forcing updates
- add a regression test covering fallback to event media when no festival program is available

## Testing
- pytest tests/test_telegraph_cover.py

------
https://chatgpt.com/codex/tasks/task_e_68dc425f49d8833284c7ea7c1890a46a