### PR TITLE
Add festival link button to daily posts keyboard

### DIFF
--- a/main.py
+++ b/main.py
@@ -15576,6 +15576,8 @@ async def build_daily_posts(
         lines2.append(" ".join(recent_festival_entries))
     section2 = "\n".join(lines2)
 
+    fest_index_url = await get_setting_value(db, "fest_index_url")
+
     buttons = []
     if wpage:
         sunday = w_start + timedelta(days=1)
@@ -15599,6 +15601,10 @@ async def build_daily_posts(
                 text=f"{prefix}Мероприятия на {month_name_nominative(next_month(cur_month))}",
                 url=mp_next.url,
             )
+        )
+    if fest_index_url:
+        buttons.append(
+            types.InlineKeyboardButton(text="Фестивали", url=fest_index_url)
         )
     markup = None
     if buttons:

--- a/tests/test_bot.py
+++ b/tests/test_bot.py
@@ -7257,6 +7257,8 @@ async def test_build_daily_posts(tmp_path: Path, monkeypatch):
         session.add(WeekendPage(start=start.isoformat(), url="w", path="wp"))
         await session.commit()
 
+    await main.set_setting_value(db, "fest_index_url", "https://fest.example")
+
     posts = await main.build_daily_posts(db, timezone.utc)
     assert posts
     text, markup = posts[0]
@@ -7265,6 +7267,9 @@ async def test_build_daily_posts(tmp_path: Path, monkeypatch):
     assert text.count("\U0001f449") == 2
     first_btn = markup.inline_keyboard[0][0].text
     assert first_btn.startswith("(+1)")
+    fest_btn = markup.inline_keyboard[-1][0]
+    assert fest_btn.text == "Фестивали"
+    assert fest_btn.url == "https://fest.example"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- fetch the festival landing page URL before constructing the daily post keyboard
- add a "Фестивали" button when the setting is present so it appears fourth
- extend the daily post test to set the URL and verify the button contents

## Testing
- pytest tests/test_bot.py::test_build_daily_posts

------
https://chatgpt.com/codex/tasks/task_e_68dccb25e5c08332825e8dd3782da61d