### PR TITLE
Document psychology digest launch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 - Список сообществ ВК показывает статусы `Pending | Skipped | Imported | Rejected` и поддерживает пагинацию.
 - Ежедневный Telegram-анонс теперь ссылается на Telegraph-страницу для событий из VK-очереди (кроме партнёрских авторов).
 - «✂️ Сокращённый рерайт» сохраняет разбивку на абзацы вместо склеивания всего текста в один блок.
+- Запустили психологический дайджест: в `/digest` появилась отдельная кнопка, подбор идёт по тематике и автоматически создаётся интро.
 
 - Introduced automatic topic classification with a closed topic list, editor display, and `/backfill_topics` command.
 - Classifier/digest topic list now includes the `PSYCHOLOGY`, `THEATRE_CLASSIC`, and `THEATRE_MODERN` categories.


### PR DESCRIPTION
## Summary
- note the addition of the psychology digest button, topic filtering, and intro generation in the latest changelog section

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dee3d50d4083328db04616a335efe1