### PR TITLE
Add VK stats text to event and exhibition messages

### DIFF
--- a/main.py
+++ b/main.py
@@ -17155,6 +17155,10 @@ async def build_events_message(db: Database, target_date: date, tz: timezone, cr
                 lines.append("-".join(price_parts))
         if e.telegraph_url:
             lines.append(f"исходное: {e.telegraph_url}")
+        if e.vk_ticket_short_key:
+            lines.append(
+                f"Статистика VK: https://vk.com/cc?act=stats&key={e.vk_ticket_short_key}"
+            )
         lines.append("")
     if not lines:
         lines.append("No events")
@@ -17175,13 +17179,6 @@ async def build_events_message(db: Database, target_date: date, tz: timezone, cr
                 callback_data=f"vkrev:shortpost:{e.id}",
             ),
         ]
-        if e.vk_ticket_short_key:
-            row.append(
-                types.InlineKeyboardButton(
-                    text="Статистика Вк ссылки",
-                    url=f"https://vk.com/cc?act=stats&key={e.vk_ticket_short_key}",
-                )
-            )
         keyboard.append(row)
 
     today = datetime.now(tz).date()
@@ -17269,6 +17266,10 @@ async def build_exhibitions_message(
                 lines.append("-".join(price_parts))
         if e.telegraph_url:
             lines.append(f"исходное: {e.telegraph_url}")
+        if e.vk_ticket_short_key:
+            lines.append(
+                f"Статистика VK: https://vk.com/cc?act=stats&key={e.vk_ticket_short_key}"
+            )
         lines.append("")
 
     if not lines:
@@ -17287,13 +17288,6 @@ async def build_exhibitions_message(
                 text=f"\u270e {e.id}", callback_data=f"edit:{e.id}"
             ),
         ]
-        if e.vk_ticket_short_key:
-            row.append(
-                types.InlineKeyboardButton(
-                    text="Статистика Вк ссылки",
-                    url=f"https://vk.com/cc?act=stats&key={e.vk_ticket_short_key}",
-                )
-            )
         keyboard.append(row)
     markup = types.InlineKeyboardMarkup(inline_keyboard=keyboard) if events else None
     chunks: list[str] = []

--- a/tests/test_bot.py
+++ b/tests/test_bot.py
@@ -5734,7 +5734,7 @@ async def test_events_markup_includes_rewrite_status(tmp_path: Path):
 
 
 @pytest.mark.asyncio
-async def test_events_markup_includes_vk_stats_button(tmp_path: Path):
+async def test_events_message_includes_vk_stats_text(tmp_path: Path):
     db = Database(str(tmp_path / "db.sqlite"))
     await db.init()
 
@@ -5760,16 +5760,15 @@ async def test_events_markup_includes_vk_stats_button(tmp_path: Path):
         session.add_all([plain, with_key])
         await session.commit()
 
-    _, markup = await main.build_events_message(db, target, timezone.utc)
+    text, markup = await main.build_events_message(db, target, timezone.utc)
+
+    assert "Статистика VK: https://vk.com/cc?act=stats&key=abcd" in text
 
     first_row = markup.inline_keyboard[0]
     assert len(first_row) == 3
 
     second_row = markup.inline_keyboard[1]
-    assert len(second_row) == 4
-    stats_button = second_row[-1]
-    assert stats_button.text == "Статистика Вк ссылки"
-    assert stats_button.url == "https://vk.com/cc?act=stats&key=abcd"
+    assert len(second_row) == 3
 
 
 @pytest.mark.asyncio
@@ -6907,7 +6906,7 @@ async def test_build_exhibitions_message_filters_past_end(tmp_path: Path, monkey
 
 
 @pytest.mark.asyncio
-async def test_exhibitions_markup_includes_vk_stats_button(tmp_path: Path):
+async def test_exhibitions_message_includes_vk_stats_text(tmp_path: Path):
     db = Database(str(tmp_path / "db.sqlite"))
     await db.init()
 
@@ -6938,17 +6937,17 @@ async def test_exhibitions_markup_includes_vk_stats_button(tmp_path: Path):
         session.add_all([without_key, with_key])
         await session.commit()
 
-    _, markup = await main.build_exhibitions_message(db, timezone.utc)
+    chunks, markup = await main.build_exhibitions_message(db, timezone.utc)
     assert markup is not None
+
+    combined = "\n".join(chunks)
+    assert "Статистика VK: https://vk.com/cc?act=stats&key=qwer" in combined
 
     first_row = markup.inline_keyboard[0]
     assert len(first_row) == 2
 
     second_row = markup.inline_keyboard[1]
-    assert len(second_row) == 3
-    stats_button = second_row[-1]
-    assert stats_button.text == "Статистика Вк ссылки"
-    assert stats_button.url == "https://vk.com/cc?act=stats&key=qwer"
+    assert len(second_row) == 2
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- add a textual VK stats link to event messages when a short key is available
- apply the same VK stats text output to exhibitions messages and drop the inline buttons
- adjust tests to verify the new message text and keyboard layout

## Testing
- pytest tests/test_bot.py::test_events_message_includes_vk_stats_text tests/test_bot.py::test_exhibitions_message_includes_vk_stats_text

------
https://chatgpt.com/codex/tasks/task_e_68df6dc388648332a2af2564c95e7fc6