### PR TITLE
Use VK short ticket link in source header

### DIFF
--- a/main.py
+++ b/main.py
@@ -16203,10 +16203,16 @@ def build_vk_source_header(event: Event, festival: Festival | None = None) -> li
     if event.pushkin_card:
         lines.append("\u2705 Пушкинская карта")
 
+    ticket_link_display = (
+        format_vk_short_url(event.vk_ticket_short_url)
+        if event.vk_ticket_short_url
+        else event.ticket_link
+    )
+
     if event.is_free:
         lines.append("🟡 Бесплатно")
         if event.ticket_link:
-            lines.append(f"\U0001f39f по регистрации {event.ticket_link}")
+            lines.append(f"\U0001f39f по регистрации {ticket_link_display}")
     elif event.ticket_link and (
         event.ticket_price_min is not None or event.ticket_price_max is not None
     ):
@@ -16220,9 +16226,9 @@ def build_vk_source_header(event: Event, festival: Festival | None = None) -> li
             )
             price = f"{val} руб." if val is not None else ""
         info = f"Билеты в источнике {price}".strip()
-        lines.append(f"\U0001f39f {info} {event.ticket_link}".strip())
+        lines.append(f"\U0001f39f {info} {ticket_link_display}".strip())
     elif event.ticket_link:
-        lines.append(f"\U0001f39f по регистрации {event.ticket_link}")
+        lines.append(f"\U0001f39f по регистрации {ticket_link_display}")
     else:
         price = ""
         if (
@@ -16381,6 +16387,9 @@ async def sync_vk_source_post(
         url = event.source_vk_post_url
         logging.info("sync_vk_source_post updated %s", url)
     else:
+        _short_link_result = await ensure_vk_short_ticket_link(
+            event, db, vk_api_fn=_vk_api, bot=bot
+        )
         message = build_vk_source_message(
             event, text, festival=festival, ics_url=ics_url
         )

--- a/tests/test_vk_daily.py
+++ b/tests/test_vk_daily.py
@@ -198,3 +198,26 @@ async def test_build_daily_sections_vk_short_link_reuse(tmp_path: Path, monkeypa
         db, timezone.utc, now=datetime(2025, 7, 10, tzinfo=timezone.utc)
     )
     assert "vk.cc/short" in sec1_again
+
+
+def test_build_vk_source_header_uses_short_ticket_link():
+    event = main.Event(
+        title="Concert",
+        description="desc",
+        source_text="src",
+        date="2025-07-07",
+        time="19:00",
+        location_name="Club",
+        ticket_link="https://tickets",
+        is_free=True,
+    )
+    event.vk_ticket_short_url = "https://vk.cc/short"
+
+    lines = main.build_vk_source_header(event)
+
+    registration_line = next(
+        line for line in lines if "по регистрации" in line
+    )
+
+    assert "vk.cc/short" in registration_line
+    assert "https://vk.cc/short" not in registration_line


### PR DESCRIPTION
## Summary
- ensure the VK short ticket link is generated before composing a new source post
- show vk.cc ticket links without the URL scheme in the VK source header
- add a regression test covering the short ticket link formatting

## Testing
- pytest tests/test_vk_daily.py::test_build_vk_source_header_uses_short_ticket_link


------
https://chatgpt.com/codex/tasks/task_e_68df87160eb883328abb1d3d7035c7a6