### PR TITLE
Propagate VK default ticket link through intake

### DIFF
--- a/main.py
+++ b/main.py
@@ -21416,7 +21416,7 @@ async def _vkrev_import_flow(
     group_id, post_id, text = row
     async with db.raw_conn() as conn:
         cur = await conn.execute(
-            "SELECT name, location, default_time FROM vk_source WHERE group_id=?",
+            "SELECT name, location, default_time, default_ticket_link FROM vk_source WHERE group_id=?",
             (group_id,),
         )
         source = await cur.fetchone()
@@ -21458,12 +21458,20 @@ async def _vkrev_import_flow(
             festival_alias_pairs = deduped
     if festival_hint is None:
         festival_hint = force_festival
+    source_name_val: str | None = None
+    location_hint_val: str | None = None
+    default_time_val: str | None = None
+    default_ticket_link_val: str | None = None
+    if source:
+        source_name_val, location_hint_val, default_time_val, default_ticket_link_val = source
+
     drafts = await vk_intake.build_event_drafts(
         text,
         photos=photos,
-        source_name=source[0] if source else None,
-        location_hint=source[1] if source else None,
-        default_time=source[2] if source else None,
+        source_name=source_name_val,
+        location_hint=location_hint_val,
+        default_time=default_time_val,
+        default_ticket_link=default_ticket_link_val,
         operator_extra=operator_extra,
         festival_names=festival_names,
         festival_alias_pairs=festival_alias_pairs or None,

--- a/tests/test_vkrev_import_flow.py
+++ b/tests/test_vkrev_import_flow.py
@@ -169,7 +169,7 @@ async def test_vkrev_import_flow_persists_url_and_skips_vk_sync(tmp_path, monkey
     async with db.raw_conn() as conn:
         await conn.execute(
             "INSERT INTO vk_source(group_id, screen_name, name, location, default_time, default_ticket_link) VALUES(?,?,?,?,?,?)",
-            (1, "club1", "Test Community", "", None, None),
+            (1, "club1", "Test Community", "", None, "https://fallback.local"),
         )
         await conn.execute(
             "INSERT INTO vk_inbox(id, group_id, post_id, date, text, matched_kw, has_date, event_ts_hint, status) VALUES(?,?,?,?,?,?,?,?,?)",
@@ -189,6 +189,7 @@ async def test_vkrev_import_flow_persists_url_and_skips_vk_sync(tmp_path, monkey
         source_name=None,
         location_hint=None,
         default_time=None,
+        default_ticket_link=None,
         operator_extra=None,
         festival_names=None,
         festival_alias_pairs=None,
@@ -198,6 +199,7 @@ async def test_vkrev_import_flow_persists_url_and_skips_vk_sync(tmp_path, monkey
         captured["festival_names"] = festival_names
         captured["festival_alias_pairs"] = festival_alias_pairs
         captured["festival_hint"] = festival_hint
+        captured["default_ticket_link"] = default_ticket_link
         return [draft]
 
     captured = {}
@@ -231,6 +233,7 @@ async def test_vkrev_import_flow_persists_url_and_skips_vk_sync(tmp_path, monkey
     assert captured["festival_names"] == ["Fest One"]
     assert captured["festival_alias_pairs"] is None
     assert captured["festival_hint"] is False
+    assert captured["default_ticket_link"] == "https://fallback.local"
     assert JobTask.vk_sync not in tasks
     message_lines = bot.messages[-1].text.splitlines()
     assert message_lines[0] == "Импортировано"
@@ -289,6 +292,7 @@ async def test_vkrev_import_flow_reports_ocr_usage(tmp_path, monkeypatch):
         source_name=None,
         location_hint=None,
         default_time=None,
+        default_ticket_link=None,
         operator_extra=None,
         festival_names=None,
         festival_alias_pairs=None,


### PR DESCRIPTION
## Summary
- pass the saved default ticket link through vk intake helpers and instruct the LLM how to use it
- fall back to the default link only when no ticket URL is parsed from the VK post
- cover the new behaviour with regression tests for the intake helper and vk review import flow

## Testing
- pytest tests/test_vk_default_time.py tests/test_vkrev_import_flow.py

------
https://chatgpt.com/codex/tasks/task_e_68dfb036aa78833287ab7d17ec403e54