### PR TITLE
Update changelog with VK source fallback note

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 - Список сообществ ВК показывает статусы `Pending | Skipped | Imported | Rejected` и поддерживает пагинацию.
 - Ежедневный Telegram-анонс теперь ссылается на Telegraph-страницу для событий из VK-очереди (кроме партнёрских авторов).
 - «✂️ Сокращённый рерайт» сохраняет разбивку на абзацы вместо склеивания всего текста в один блок.
+- VK source settings now store default ticket-link button text and prompt; ingestion applies the saved link only when a post lacks its own ticket or registration URL, keeping operator-provided links untouched.
 - Запустили психологический дайджест: в `/digest` появилась отдельная кнопка, подбор идёт по тематике и автоматически создаётся интро.
 
 - Introduced automatic topic classification with a closed topic list, editor display, and `/backfill_topics` command.


### PR DESCRIPTION
## Summary
- document the new VK source defaults for ticket link button text and prompt
- note that ingestion only reuses the stored link when posts lack their own URLs

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dfb350a4d08332a842a3f5accb92b9