### PR TITLE
Add pricing heuristics to VK event filter

### DIFF
--- a/tests/test_vk_intake_keywords_dates.py
+++ b/tests/test_vk_intake_keywords_dates.py
@@ -20,6 +20,20 @@ def test_match_keywords_lead_host_variants():
     assert any("ведущ" in k for k in kws_hash)
 
 
+def test_match_keywords_cost_variants():
+    ok_free, kws_free = match_keywords("Вход свободный, приходите 12 мая")
+    assert ok_free
+    assert any("вход свободн" in k for k in kws_free)
+
+    ok_paid, kws_paid = match_keywords("Билеты по 500 руб. и регистрация обязательна")
+    assert ok_paid
+    assert any("500 руб" in k or "руб." in k for k in kws_paid)
+
+    ok_symbol, kws_symbol = match_keywords("Стоимость участия — 1 200₽")
+    assert ok_symbol
+    assert any("₽" in k for k in kws_symbol)
+
+
 def test_detect_date_and_extract(monkeypatch):
     text = "Мастер-классы 14–15.09, регистрация по ссылке"
     assert detect_date(text)


### PR DESCRIPTION
## Summary
- add regex patterns covering common pricing phrases and currency formats to the VK intake filter
- include pricing matches alongside keyword hits when classifying posts
- extend keyword detection tests with free/paid/₽ pricing scenarios

## Testing
- pytest tests/test_vk_intake_keywords_dates.py

------
https://chatgpt.com/codex/tasks/task_e_68dfd700fd8483328c58f7fa555c18f2