### PR TITLE
Add tribute keyword detection

### DIFF
--- a/tests/test_vk_intake_keywords_dates.py
+++ b/tests/test_vk_intake_keywords_dates.py
@@ -49,6 +49,13 @@ def test_match_keywords_prazdnik():
     assert any(k.startswith("праздник") for k in normalized)
 
 
+def test_match_keywords_tribute():
+    ok, kws = match_keywords("Сегодня трибьют группы Queen 1 сентября 20:00")
+    assert ok
+    normalized = {k.lower() for k in kws}
+    assert "трибьют" in normalized
+
+
 def test_match_keywords_poetry_songs_play():
     ok, kws = match_keywords("стихи по кругу, сыграем песни 5 октября")
     assert ok

--- a/vk_intake.py
+++ b/vk_intake.py
@@ -73,6 +73,7 @@ KEYWORD_PATTERNS = [
     r"бронировани(е|я|ю|ем)|билет(ы|а|ов)|регистраци(я|и|ю|ей)|афиш(а|и|е|у)",
     r"ведущ(ий|ая|ее|ие|его|ему|ем|им|их|ими|ую|ей)",
     r"караок[её]",
+    r"трибь?ют|трибут|tribute",
 ]
 KEYWORD_RE = re.compile(r"\b#?(?:" + "|".join(KEYWORD_PATTERNS) + r")\b", re.I | re.U)
 
@@ -124,6 +125,9 @@ KEYWORD_LEMMAS = {
     "афиша",
     "ведущий",
     "караоке",
+    "трибьют",
+    "трибут",
+    "tribute",
 }
 
 # Date/time patterns used for quick detection


### PR DESCRIPTION
## Summary
- extend VK keyword patterns and lemmas to recognize tribute events
- cover tribute phrasing with a dedicated keyword detection test

## Testing
- pytest tests/test_vk_intake_keywords_dates.py

------
https://chatgpt.com/codex/tasks/task_e_68dfe18eb9548332bf2ceb2dfe415d21