### PR TITLE
Enhance VK keyword detection for concert phrasing

### DIFF
--- a/tests/test_vk_intake_keywords_dates.py
+++ b/tests/test_vk_intake_keywords_dates.py
@@ -56,6 +56,20 @@ def test_match_keywords_tribute():
     assert "трибьют" in normalized
 
 
+def test_match_keywords_concert_phrases():
+    text = (
+        "Все хиты группы Лучшие песни в исполнении группы Мечта "
+        "два часа живого звука 3 сентября"
+    )
+    ok, kws = match_keywords(text)
+    assert ok
+    normalized = {k.lower() for k in kws}
+    assert any("хит" in k for k in normalized)
+    assert any(k.startswith("групп") for k in normalized)
+    assert any("исполнен" in k for k in normalized)
+    assert any("жив" in k and "звук" in k for k in normalized)
+
+
 def test_match_keywords_poetry_songs_play():
     ok, kws = match_keywords("стихи по кругу, сыграем песни 5 октября")
     assert ok

--- a/vk_intake.py
+++ b/vk_intake.py
@@ -70,6 +70,10 @@ KEYWORD_PATTERNS = [
     r"стих(?:и|отворен\w*)",
     r"песн(?:я|и|ей|е|ю|ями|ях|ью)",
     r"сыгра\w*",
+    r"жив(ой|ого|ым)\s+звук(а|ом|у|и|ов)?",
+    r"хит(ы|ов|ам|ами)?",
+    r"в\s+исполнен(?:ии|ием|ию)",
+    r"групп(а|ы|е|ой|у|ами|ах)",
     r"бронировани(е|я|ю|ем)|билет(ы|а|ов)|регистраци(я|и|ю|ей)|афиш(а|и|е|у)",
     r"ведущ(ий|ая|ее|ие|его|ему|ем|им|их|ими|ую|ей)",
     r"караок[её]",
@@ -119,6 +123,9 @@ KEYWORD_LEMMAS = {
     "поэзия",
     "песня",
     "сыграть",
+    "хит",
+    "исполнение",
+    "группа",
     "бронирование",
     "билет",
     "регистрация",
@@ -198,10 +205,17 @@ def match_keywords(text: str) -> tuple[bool, list[str]]:
     if VK_USE_PYMORPHY and MORPH:
         tokens = re.findall(r"\w+", text_low)
         matched: list[str] = []
+        lemmas: list[str] = []
         for t in tokens:
             lemma = MORPH.parse(t)[0].normal_form
+            lemmas.append(lemma)
             if lemma in KEYWORD_LEMMAS and lemma not in matched:
                 matched.append(lemma)
+        for first, second in zip(lemmas, lemmas[1:]):
+            if first == "живой" and second == "звук":
+                if "живой звук" not in matched:
+                    matched.append("живой звук")
+                break
         for hint in price_matches:
             if hint and hint not in matched:
                 matched.append(hint)


### PR DESCRIPTION
## Summary
- expand the VK keyword regex patterns to capture typical concert phrases such as "живой звук", "хиты", "в исполнении" and "группа"
- extend the pymorphy keyword lemmas and add a bigram check so "живой звук" is detected in morphological mode
- add a regression test covering the new concert announcement phrasing

## Testing
- pytest tests/test_vk_intake_keywords_dates.py

------
https://chatgpt.com/codex/tasks/task_e_68dfe29352708332b51f987f2f0051ad