### PR TITLE
Support forced VK crawl backfill with override

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Commands:
 
 - `/vk` — add/list sources, check/review events, and open queue summary.
 - `/vk_queue` — show VK inbox summary (pending/locked/skipped/imported/rejected) and a "🔎 Проверить события" button to start the review flow.
-- `/vk_crawl_now` — run VK crawling now (admin only); reports "добавлено N, всего постов M" to the admin chat.
+- `/vk_crawl_now [--backfill-days=N]` — run VK crawling now (admin only); reports "добавлено N, всего постов M" to the admin chat. Passing `--backfill-days=N` forces a full backfill with a horizon of up to `N` days (capped at 60 to avoid excessive API calls); without the option the incremental mode is used.
 
 Background crawling collects posts from configured VK communities and filters
 them by event keywords and date patterns. Matching posts land in the persistent


### PR DESCRIPTION
## Summary
- allow superadmins to pass `--backfill-days=N` to `/vk_crawl_now`, enforcing validation and surfacing the forced backfill information in the command reply
- let `vk_intake.crawl_once` force backfill with an optional horizon override, including updated broadcast text and clamped days
- document the new syntax in the README and add a regression test that ensures forced backfill uses `since=0` and respects the cap

## Testing
- pytest tests/test_vk_intake_future.py


------
https://chatgpt.com/codex/tasks/task_e_68dfeda0d88c8332a98ce1968217b88c