### PR TITLE
Show event matches when reviewing VK inbox posts

### DIFF
--- a/tests/test_vk_review_show_next.py
+++ b/tests/test_vk_review_show_next.py
@@ -3,6 +3,7 @@ sys.path.append(os.path.dirname(os.path.dirname(__file__)))
 
 import pytest
 from types import SimpleNamespace
+from datetime import datetime, timezone
 
 from aiogram import types
 from aiogram.exceptions import TelegramBadRequest
@@ -11,6 +12,7 @@ import main
 import vk_intake
 import vk_review
 from main import Database, User
+from models import Event
 
 
 class DummyBot:
@@ -65,6 +67,7 @@ async def test_vkrev_show_next_adds_blank_line_and_group_name(tmp_path, monkeypa
             text="text",
             matched_kw=None,
             has_date=True,
+            event_ts_hint=None,
         )
 
     monkeypatch.setattr(main, "_vkrev_fetch_photos", fake_fetch)
@@ -76,6 +79,66 @@ async def test_vkrev_show_next_adds_blank_line_and_group_name(tmp_path, monkeypa
     assert lines[1] == "Test Community"
     assert lines[2] == ""  # blank line before the link
     assert lines[3] == "https://vk.com/wall-1_10"
+
+
+@pytest.mark.asyncio
+async def test_vkrev_show_next_includes_event_matches(tmp_path, monkeypatch):
+    db = Database(str(tmp_path / "db.sqlite"))
+    await db.init()
+    dt = datetime(2025, 5, 17, 15, 30, tzinfo=timezone.utc)
+    async with db.get_session() as session:
+        session.add(User(user_id=1))
+        session.add(
+            Event(
+                title="Совпадающее событие",
+                description="desc",
+                date=dt.date().isoformat(),
+                time=dt.strftime("%H:%M"),
+                location_name="loc",
+                source_text="src",
+                telegraph_url="https://telegra.ph/test-page",
+            )
+        )
+        await session.commit()
+    async with db.raw_conn() as conn:
+        await conn.execute(
+            "INSERT INTO vk_source(group_id, screen_name, name, location, default_time, default_ticket_link) VALUES(?,?,?,?,?,?)",
+            (1, "club1", "Test Community", "", None, None),
+        )
+        await conn.commit()
+
+    async def fake_fetch(*args, **kwargs):
+        return []
+
+    ts_hint = int(dt.timestamp())
+
+    async def fake_pick_next(db_obj, operator_id_arg, batch_id_arg):
+        return SimpleNamespace(
+            id=1,
+            group_id=1,
+            post_id=10,
+            text="text",
+            matched_kw=None,
+            has_date=True,
+            event_ts_hint=ts_hint,
+        )
+
+    monkeypatch.setattr(main, "_vkrev_fetch_photos", fake_fetch)
+    monkeypatch.setattr(vk_review, "pick_next", fake_pick_next)
+    bot = DummyBot()
+    await main._vkrev_show_next(1, "batch1", 1, db, bot)
+
+    assert bot.messages, "no message sent"
+    lines = bot.messages[0].text.splitlines()
+    heading = f"{dt.day:02d} {main.MONTHS[dt.month - 1]} {dt.strftime('%H:%M')}"
+    assert heading in lines
+    heading_index = lines.index(heading)
+    assert lines[heading_index - 1] == ""
+    assert (
+        lines[heading_index + 1]
+        == "Совпадающее событие — https://telegra.ph/test-page"
+    )
+    assert lines[heading_index + 2] == ""
 
 
 @pytest.mark.asyncio
@@ -116,6 +179,7 @@ async def test_vkrev_show_next_truncates_long_text(tmp_path, monkeypatch):
             text="x" * 6000,
             matched_kw=None,
             has_date=True,
+            event_ts_hint=None,
         )
 
     monkeypatch.setattr(main, "_vkrev_fetch_photos", fake_fetch)
@@ -161,6 +225,7 @@ async def test_vkrev_show_next_handles_blank_text(tmp_path, monkeypatch):
             text="",
             matched_kw=vk_intake.OCR_PENDING_SENTINEL,
             has_date=0,
+            event_ts_hint=None,
         )
 
     monkeypatch.setattr(main, "_vkrev_fetch_photos", fake_fetch)


### PR DESCRIPTION
## Summary
- add the event timestamp hint to `InboxPost` selections so it is available to the reviewer
- show a formatted timestamp block with matching Telegraph events in the VK review message
- cover the new output with dedicated unit tests and updated mocks

## Testing
- pytest tests/test_vk_review_show_next.py tests/test_vk_review.py

------
https://chatgpt.com/codex/tasks/task_e_68dff9f2978c8332929a3312952b7683