### PR TITLE
Update changelog for VK review cards

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@
 
 - Fixed VK review queue issue where `vk_review.pick_next` recalculates `event_ts_hint` and auto-rejects posts whose event date
   disappeared or fell into the past (e.g., a 7 September announcement shown on 19 September).
+- Карточки отзывов VK теперь показывают совпавшие события Telegraph для распознанной даты и времени.
 
 ## v0.3.10 – 2025-09-21
 This release ships the updates that were previously listed under “Unreleased.”


### PR DESCRIPTION
## Summary
- document that VK review cards now show matched Telegraph events for the detected datetime

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e00e1011b483329f9c40b4b938034c