### PR TITLE
Strip VK link markup from story titles

### DIFF
--- a/tests/test_vk_review.py
+++ b/tests/test_vk_review.py
@@ -9,6 +9,7 @@ sys.path.append(os.path.dirname(os.path.dirname(__file__)))
 
 import time as _time
 
+import main
 import vk_review
 import vk_intake
 from db import Database
@@ -616,3 +617,17 @@ async def test_pick_next_unlocks_stale_rows(tmp_path):
         )
         status, locked_by, review_batch = await cur.fetchone()
     assert status == "locked" and locked_by == 10 and review_batch == "batch"
+
+
+def test_vkrev_story_title_strips_vk_links() -> None:
+    text = (
+        "Орган в гумбинненской [https://vk.com/organ_school|Фридрихшуле] приглашает "
+        "на вечерний концерт в субботу"
+    )
+    result = main._vkrev_story_title(text, 1773, 204)
+    expected = (
+        "Орган в гумбинненской Фридрихшуле приглашает на вечерний концерт в субботу"
+    )
+    assert result == expected[:64]
+    assert "[" not in result
+    assert "vk.com" not in result


### PR DESCRIPTION
## Summary
- replace VK-style [target|label] markup with the visible label before truncating VK review story titles
- normalize whitespace in titles after link cleanup and fall back to the default label when empty
- cover the helper with a unit test that ensures bracket links are removed while respecting the length cap

## Testing
- pytest tests/test_vk_review.py::test_vkrev_story_title_strips_vk_links

------
https://chatgpt.com/codex/tasks/task_e_68e01da1fef483328ccf6c562caa5c58