### PR TITLE
Stop truncating 4o responses and add regression test

### DIFF
--- a/tests/test_ask_4o.py
+++ b/tests/test_ask_4o.py
@@ -1,0 +1,52 @@
+import pytest
+
+import main
+
+
+class DummyResponse:
+    def __init__(self, payload):
+        self._payload = payload
+
+    async def json(self):
+        return self._payload
+
+    def raise_for_status(self):
+        return None
+
+
+class DummySession:
+    def __init__(self, payload):
+        self._payload = payload
+        self.post_calls = []
+
+    async def post(self, url, json, headers):
+        self.post_calls.append((url, json, headers))
+        return DummyResponse(self._payload)
+
+
+@pytest.mark.asyncio
+async def test_ask_4o_keeps_long_response(monkeypatch):
+    monkeypatch.setenv("FOUR_O_TOKEN", "test-token")
+    long_content = "L" * (main.FOUR_O_RESPONSE_LIMIT + 200)
+    payload = {
+        "choices": [
+            {
+                "message": {
+                    "content": long_content,
+                }
+            }
+        ],
+        "usage": {
+            "prompt_tokens": 10,
+            "completion_tokens": len(long_content) // 2,
+            "total_tokens": len(long_content),
+        },
+    }
+    session = DummySession(payload)
+    monkeypatch.setattr(main, "get_http_session", lambda: session)
+
+    result = await main.ask_4o("prompt", max_tokens=len(long_content))
+
+    assert result == long_content
+    assert session.post_calls, "session.post should be invoked"
+    assert session.post_calls[0][1]["max_tokens"] == len(long_content)


### PR DESCRIPTION
## Summary
- stop clipping 4o responses manually and rely on the API max_tokens parameter
- introduce a dedicated editor token limit and keep defaults for smaller tasks
- cover long 4o outputs with a regression test to ensure no truncation occurs

## Testing
- pytest tests/test_ask_4o.py

------
https://chatgpt.com/codex/tasks/task_e_68e02465e618833293359c6183205851