### PR TITLE
Add free-event prefix to VK shortpost header

### DIFF
--- a/main.py
+++ b/main.py
@@ -22372,8 +22372,11 @@ async def _vkrev_build_shortpost(
                     type_line_used_tag = type_line
 
     tags = await build_short_vk_tags(ev, summary, used_type_hashtag=type_line_used_tag)
+    title_line = ev.title.upper() if ev.title else ""
+    if getattr(ev, "is_free", False):
+        title_line = f"🆓 {title_line}".strip()
     lines = [
-        ev.title.upper(),
+        title_line,
         "",
     ]
     lines.append(date_line)

--- a/tests/test_vk_shortpost.py
+++ b/tests/test_vk_shortpost.py
@@ -667,6 +667,7 @@ async def test_shortpost_free_event_ticket_line(monkeypatch):
     )
 
     msg, _ = await main._vkrev_build_shortpost(ev, "https://vk.com/wall-1_1")
+    assert msg.splitlines()[0] == "🆓 T"
     assert "🆓 Бесплатно, по регистрации vk.cc/short" in msg
     assert "🎟 Билеты:" not in msg
     assert ev.vk_ticket_short_url == "https://vk.cc/short"
@@ -704,6 +705,7 @@ async def test_shortpost_short_link_fallback_on_error(monkeypatch):
     )
 
     msg, _ = await main._vkrev_build_shortpost(ev, "https://vk.com/wall-1_1")
+    assert msg.splitlines()[0] == "T"
     assert "https://tickets" in msg
     assert ev.vk_ticket_short_url is None
 


### PR DESCRIPTION
## Summary
- prefix VK shortpost titles with an emoji for free events
- update shortpost tests to cover free and paid title prefixes

## Testing
- pytest tests/test_vk_shortpost.py -k "shortpost_free_event_ticket_line or shortpost_short_link_fallback_on_error" -q

------
https://chatgpt.com/codex/tasks/task_e_68e0ce4730cc83329133b8986b6c0d1f