### PR TITLE
Distribute inline source images evenly throughout text

### DIFF
--- a/main.py
+++ b/main.py
@@ -23984,18 +23984,29 @@ async def build_source_page_content(
 
         paragraphs = [anchor_re.sub(_replace_anchor, para) for para in paragraphs]
     if paragraphs:
-        body_blocks: list[str] = [paragraphs[0]]
         if image_mode == "inline" and tail:
-            for para in paragraphs[1:]:
-                if inline_used < len(tail):
-                    body_blocks.append(f'<img src="{html.escape(tail[inline_used])}"/>')
-                    inline_used += 1
+            paragraph_count = len(paragraphs)
+            image_count = len(tail)
+            base_count = min(image_count, paragraph_count)
+            positions: list[int] = []
+            if base_count:
+                step = paragraph_count / (base_count + 1)
+                positions = [math.ceil((idx + 1) * step) for idx in range(base_count)]
+            body_blocks: list[str] = []
+            base_index = 0
+            for idx, para in enumerate(paragraphs, start=1):
                 body_blocks.append(para)
+                while base_index < base_count and positions[base_index] == idx:
+                    body_blocks.append(
+                        f'<img src="{html.escape(tail[base_index])}"/>'
+                    )
+                    base_index += 1
+            inline_used = base_index
             for extra_url in tail[inline_used:]:
                 body_blocks.append(f'<img src="{html.escape(extra_url)}"/>')
                 inline_used += 1
         else:
-            body_blocks.extend(paragraphs[1:])
+            body_blocks = list(paragraphs)
         html_content += "".join(body_blocks)
     elif image_mode == "inline" and tail:
         for extra_url in tail:

--- a/tests/test_source_images.py
+++ b/tests/test_source_images.py
@@ -132,9 +132,10 @@ async def test_build_source_page_content_cleans_tg_tags():
 
 @pytest.mark.asyncio
 async def test_build_source_page_content_inline_images():
+    text = "\n\n".join(f"paragraph {idx}" for idx in range(1, 7))
     html, _, uploaded = await main.build_source_page_content(
         "T",
-        "line1\nline2\nline3",
+        text,
         None,
         None,
         None,
@@ -144,18 +145,23 @@ async def test_build_source_page_content_inline_images():
             "http://cat/0.jpg",
             "http://cat/1.jpg",
             "http://cat/2.jpg",
+            "http://cat/3.jpg",
+            "http://cat/4.jpg",
         ],
         image_mode="inline",
     )
-    assert uploaded == 3
-    assert html.count('<img src="http://cat/') == 3
-    first_paragraph = html.index("<p>line1</p>")
-    second_paragraph = html.index("<p>line2</p>")
-    third_paragraph = html.index("<p>line3</p>")
-    tail1 = html.index('<img src="http://cat/1.jpg"/>')
-    tail2 = html.index('<img src="http://cat/2.jpg"/>')
-    assert first_paragraph < tail1 < second_paragraph
-    assert second_paragraph < tail2 < third_paragraph
+    assert uploaded == 5
+    assert html.count('<img src="http://cat/') == 5
+    paragraph_positions = [
+        html.index(f"<p>paragraph {idx}</p>") for idx in range(1, 7)
+    ]
+    image_positions = [
+        html.index(f'<img src="http://cat/{idx}.jpg"/>') for idx in range(1, 5)
+    ]
+    assert paragraph_positions[1] < image_positions[0] < paragraph_positions[2]
+    assert paragraph_positions[2] < image_positions[1] < paragraph_positions[3]
+    assert paragraph_positions[3] < image_positions[2] < paragraph_positions[4]
+    assert paragraph_positions[4] < image_positions[3] < paragraph_positions[5]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- distribute inline tail images across paragraph blocks using evenly spaced insertion points
- update inline image placement test to verify images are spread through the article

## Testing
- pytest tests/test_source_images.py

------
https://chatgpt.com/codex/tasks/task_e_68e0ce506fc08332b9dd15868fde2f71