### PR TITLE
Add Unreleased note about theatre showtime parsing rule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## [Unreleased]
+- Clarified the 4o parsing prompt and docs for same-day theatre showtimes: posters with one date and multiple start times now yield separate theatre events instead of a single merged entry.
+
 ## [x.y.z+3] – 2025-09-23
 - Нормализованы HTML-заголовки и абзацы историй перед публикацией.
 - Равномерно распределяем inline-изображения в исторических текстах.


### PR DESCRIPTION
## Summary
- add an "Unreleased" section to the changelog
- document that same-day theatre posters with multiple showtimes now yield separate events

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e0d45a1598833286967d0082eeea5c