### PR TITLE
Add LLM-generated pitch to VK story workflow

### DIFF
--- a/tests/test_source_images.py
+++ b/tests/test_source_images.py
@@ -339,9 +339,13 @@ async def test_vkrev_story_editor_fallback(monkeypatch):
     async def fake_editor(*_args, **_kwargs):
         raise RuntimeError("boom")
 
+    async def fake_pitch(*_args, **_kwargs):
+        return "Заманчивое предложение"
+
     monkeypatch.setattr(main, "create_source_page", fake_create_source_page)
     monkeypatch.setattr(main, "_vkrev_fetch_photos", fake_fetch_photos)
     monkeypatch.setattr(main, "compose_story_editorial_via_4o", fake_editor)
+    monkeypatch.setattr(main, "compose_story_pitch_via_4o", fake_pitch)
 
     bot = DummyBot()
     await main._vkrev_handle_story_choice(callback, "end", inbox_id, dummy_db, bot)
@@ -349,5 +353,102 @@ async def test_vkrev_story_editor_fallback(monkeypatch):
     assert "args" in captured
     args = captured["args"]
     assert args[1] == text
-    assert args[3] is None
+    assert args[3] == "<p><i>Заманчивое предложение</i></p>"
+    assert bot.messages
+    assert bot.messages[-1][1].splitlines()[-1] == "Заманчивое предложение"
+    assert main.vk_review_story_sessions.get(operator_id) is None
+
+
+@pytest.mark.asyncio
+async def test_vkrev_story_editor_includes_pitch(monkeypatch):
+    operator_id = 456
+    inbox_id = 789
+    text = "Первый абзац\nВторой абзац"
+    main.vk_review_story_sessions[operator_id] = main.VkReviewStorySession(
+        inbox_id=inbox_id,
+        batch_id="batch2",
+    )
+
+    class DummyCursor:
+        def __init__(self, row):
+            self._row = row
+
+        async def fetchone(self):
+            return self._row
+
+    class DummyRawConn:
+        def __init__(self, row):
+            self._row = row
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb):
+            return False
+
+        async def execute(self, *_args):
+            return DummyCursor(self._row)
+
+    class DummyDB:
+        def __init__(self, row):
+            self._row = row
+
+        def raw_conn(self):
+            return DummyRawConn(self._row)
+
+    dummy_db = DummyDB((-inbox_id, inbox_id, text))
+
+    class DummyBot:
+        def __init__(self):
+            self.messages: list[tuple[int, str]] = []
+
+        async def send_message(self, chat_id, message):
+            self.messages.append((chat_id, message))
+
+    class DummyMessage:
+        def __init__(self, chat_id):
+            self.chat = SimpleNamespace(id=chat_id)
+            self.edited = False
+
+        async def edit_reply_markup(self):
+            self.edited = True
+
+    callback = SimpleNamespace(
+        from_user=SimpleNamespace(id=operator_id),
+        message=DummyMessage(555),
+    )
+
+    captured: dict[str, object] = {}
+
+    async def fake_create_source_page(*args, **kwargs):
+        captured["args"] = args
+        captured["kwargs"] = kwargs
+        return ("https://telegraph", "/path", "", 0)
+
+    async def fake_fetch_photos(*_args, **_kwargs):
+        return []
+
+    async def fake_editor(*_args, **_kwargs):
+        return "<p>Отредактированный текст</p>"
+
+    async def fake_pitch(*_args, **_kwargs):
+        return "Приходите на главное событие недели"
+
+    monkeypatch.setattr(main, "create_source_page", fake_create_source_page)
+    monkeypatch.setattr(main, "_vkrev_fetch_photos", fake_fetch_photos)
+    monkeypatch.setattr(main, "compose_story_editorial_via_4o", fake_editor)
+    monkeypatch.setattr(main, "compose_story_pitch_via_4o", fake_pitch)
+
+    bot = DummyBot()
+    await main._vkrev_handle_story_choice(callback, "middle", inbox_id, dummy_db, bot)
+
+    args = captured["args"]
+    assert args[1] == text
+    assert args[3] == (
+        "<p><i>Приходите на главное событие недели</i></p>\n"
+        "<p>Отредактированный текст</p>"
+    )
+    assert bot.messages
+    message_lines = bot.messages[-1][1].splitlines()
+    assert message_lines[-1] == "Приходите на главное событие недели"
     assert main.vk_review_story_sessions.get(operator_id) is None

--- a/tests/test_story_pitch.py
+++ b/tests/test_story_pitch.py
@@ -1,0 +1,29 @@
+import pytest
+
+import main
+
+
+@pytest.mark.asyncio
+async def test_compose_story_pitch_via_4o_fallback_on_error(monkeypatch):
+    async def fake_ask(*_args, **_kwargs):
+        raise RuntimeError("fail")
+
+    monkeypatch.setattr(main, "ask_4o", fake_ask)
+    text = "Первая строка\nВторая строка"
+
+    result = await main.compose_story_pitch_via_4o(text, title="История")
+
+    assert result == "Первая строка"
+
+
+@pytest.mark.asyncio
+async def test_compose_story_pitch_via_4o_fallback_on_empty(monkeypatch):
+    async def fake_ask(*_args, **_kwargs):
+        return "  \n  "
+
+    monkeypatch.setattr(main, "ask_4o", fake_ask)
+    text = "\n Лидовая строка\nПродолжение"
+
+    result = await main.compose_story_pitch_via_4o(text)
+
+    assert result == "Лидовая строка"


### PR DESCRIPTION
## Summary
- add a compose_story_pitch_via_4o helper with graceful fallback
- include the generated pitch in VK story editor HTML and operator messages
- extend story tests to cover pitch rendering and fallback logic

## Testing
- pytest tests/test_source_images.py tests/test_story_pitch.py

------
https://chatgpt.com/codex/tasks/task_e_68e0f92c079c83328208a188f8f19628