### PR TITLE
Update changelog for partner event notification details

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## [Unreleased]
+- Partner event notifications in the admin chat now include the first event photo plus Telegraph and VK links so operators know to review or edit the VK post.
 
 ## [x.y.z+4] – 2025-10-04
 - Clarified the 4o parsing prompt and docs for same-day theatre showtimes: posters with one date and multiple start times now yield separate theatre events instead of a single merged entry.


### PR DESCRIPTION
## Summary
- document that partner event admin notifications include the first photo and Telegraph/VK links in the changelog

## Testing
- not run (documentation only)


------
https://chatgpt.com/codex/tasks/task_e_68e109f15a0483329c869b2c4653c1e8