### PR TITLE
Update changelog with topic prompt restriction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## [Unreleased]
+- Системный промпт автоклассификации запрещает выбирать темы `FAMILY` и `KIDS_SCHOOL`, когда у события задан возрастной ценз; см. обновления в `main.py` (`EVENT_TOPIC_SYSTEM_PROMPT`) и документации `docs/llm_topics.md`.
 
 ## [x.y.z+4] – 2025-10-04
 - Clarified the 4o parsing prompt and docs for same-day theatre showtimes: posters with one date and multiple start times now yield separate theatre events instead of a single merged entry.


### PR DESCRIPTION
## Summary
- document in the changelog that the event-topic system prompt now blocks FAMILY and KIDS_SCHOOL when an age limit is present, pointing to the relevant code and docs updates

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e10b4246ec8332af948f786b239019