### PR TITLE
Add richer meetups digest intro payload and tests

### DIFF
--- a/digests.py
+++ b/digests.py
@@ -670,6 +670,42 @@ async def compose_digest_intro_via_4o(
     return text
 
 
+def _detect_meetup_formats(event: Event, normalized: dict[str, str]) -> List[str]:
+    """Return a list of human-friendly meetup formats derived from text."""
+
+    haystack_parts = [
+        normalized.get("title_clean") or event.title,
+        event.description or "",
+        event.event_type or "",
+    ]
+    haystack = " ".join(haystack_parts).lower()
+
+    formats: List[str] = []
+
+    def add_format(condition: bool, label: str) -> None:
+        if condition and label not in formats:
+            formats.append(label)
+
+    add_format("клуб" in haystack or "club" in haystack, "клуб")
+    add_format(
+        re.search(r"\bвстреч", haystack) is not None
+        or "meetup" in haystack
+        or "meeting" in haystack,
+        "встреча",
+    )
+    add_format(
+        ("творчес" in haystack and "вечер" in haystack)
+        or "creative evening" in haystack,
+        "творческий вечер",
+    )
+    add_format("нетворкин" in haystack or "network" in haystack, "нетворкинг")
+    add_format("q&a" in haystack or "q & a" in haystack, "Q&A")
+    add_format("дискус" in haystack or "discussion" in haystack, "дискуссия")
+    add_format("форум" in haystack or "forum" in haystack, "форум")
+
+    return formats
+
+
 async def compose_masterclasses_intro_via_4o(
     n: int, horizon_days: int, masterclasses: List[dict[str, str]]
 ) -> str:
@@ -838,6 +874,71 @@ async def compose_psychology_intro_via_4o(
     text = text.strip()
     logging.info(
         "digest.intro.llm.response run_id=%s kind=psychology ok=ok text_len=%s took_ms=%s",
+        run_id,
+        len(text),
+        took_ms,
+    )
+    return text
+
+
+async def compose_meetups_intro_via_4o(
+    n: int, horizon_days: int, meetups: List[dict[str, object]]
+) -> str:
+    """Generate intro phrase for meetup digest via model 4o."""
+
+    from main import ask_4o  # local import to avoid cycle
+    import json
+    import uuid
+
+    run_id = uuid.uuid4().hex
+    horizon_word = "неделю" if horizon_days == 7 else "две недели"
+    data_json = json.dumps(meetups[:9], ensure_ascii=False)
+    has_club = any(
+        "клуб" in [fmt.casefold() for fmt in item.get("formats", [])]
+        for item in meetups
+    )
+    has_club_flag = "true" if has_club else "false"
+
+    prompt = (
+        "Ты помогаешь телеграм-дайджесту мероприятий."
+        f" Сформулируй живое интро на 1–2 предложения до ~200 символов к подборке из {n} встреч"
+        f" и клубов на ближайшую {horizon_word}."
+        " Добавь 1–2 уместных эмодзи, избегай приветствий и списков."
+        " Опирайся на поля title, description, event_type и formats каждого события,"
+        " чтобы выделить ключевые темы и форматы."
+        f" Метаданные: has_club={has_club_flag}."
+        " Если has_club=false, сделай акцент на живом общении: знакомстве с интересными людьми,"
+        " Q&A и нетворкинге."
+        " Не выдумывай фактов, используй только данные из JSON ниже."
+        f" Данные о встречах в JSON: {data_json}"
+    )
+
+    logging.info(
+        "digest.intro.llm.request run_id=%s kind=meetups n=%s horizon=%s items_count=%s prompt_len=%s has_club=%s",
+        run_id,
+        n,
+        horizon_days,
+        len(meetups),
+        len(prompt),
+        int(has_club),
+    )
+
+    start = time.monotonic()
+    try:
+        text = await ask_4o(prompt, max_tokens=160)
+    except Exception:
+        took_ms = int((time.monotonic() - start) * 1000)
+        logging.info(
+            "digest.intro.llm.response run_id=%s kind=meetups ok=error text_len=0 took_ms=%s",
+            run_id,
+            took_ms,
+        )
+        raise
+
+    took_ms = int((time.monotonic() - start) * 1000)
+    text = text.strip()
+    logging.info(
+        "digest.intro.llm.response run_id=%s kind=meetups ok=ok text_len=%s took_ms=%s",
         run_id,
         len(text),
         took_ms,
@@ -1313,6 +1414,21 @@ async def _build_digest_preview(
             )
         intro = await compose_psychology_intro_via_4o(
             len(events), horizon, psychology_payload
+        )
+    elif event_kind == "meetups":
+        meetups_payload: List[dict[str, object]] = []
+        for ev, norm in zip(events, normalized):
+            title_clean = norm.get("title_clean") or ev.title
+            meetups_payload.append(
+                {
+                    "title": title_clean,
+                    "description": (ev.description or "").strip(),
+                    "event_type": (ev.event_type or "").strip(),
+                    "formats": _detect_meetup_formats(ev, norm),
+                }
+            )
+        intro = await compose_meetups_intro_via_4o(
+            len(events), horizon, meetups_payload
         )
     else:
         intro = await compose_digest_intro_via_4o(

--- a/tests/test_lecture_digest.py
+++ b/tests/test_lecture_digest.py
@@ -21,10 +21,12 @@ from digests import (
     build_theatre_classic_digest_candidates,
     build_theatre_modern_digest_candidates,
     build_meetups_digest_candidates,
+    build_meetups_digest_preview,
     build_movies_digest_candidates,
     compose_digest_intro_via_4o,
     compose_masterclasses_intro_via_4o,
     compose_exhibitions_intro_via_4o,
+    compose_meetups_intro_via_4o,
     aggregate_digest_topics,
     normalize_topics,
     format_event_line_html,
@@ -830,6 +832,118 @@ async def test_compose_intro_via_4o_exhibition(monkeypatch):
     assert norm_titles == ["Акварель"]
     assert len(lines) == 1
     assert events == [event]
+
+
+@pytest.mark.asyncio
+async def test_build_meetups_digest_preview_payload(monkeypatch):
+    event = SimpleNamespace(
+        id=5,
+        title="🎬 Киноклуб «Весна»",
+        description="Творческий вечер с режиссёром и обсуждением фильма.",
+        date="2025-05-05",
+        time="19:00",
+        location_name="Дом культуры",
+        source_post_url="https://example.com/meetup",
+        telegraph_url=None,
+        telegraph_path=None,
+        event_type="клуб",
+    )
+
+    captured_payload: dict[str, list] = {}
+
+    async def fake_compose_meetups_intro(n, horizon_days, meetups):
+        captured_payload["value"] = meetups
+        return "интро про встречи"
+
+    async def fake_candidates(db, now, digest_id=None):
+        return [event], 7
+
+    async def fake_normalize_titles(titles, event_kind="lecture"):
+        return [{"emoji": "🎬", "title_clean": "Киноклуб «Весна»"}]
+
+    monkeypatch.setattr(
+        "digests.compose_meetups_intro_via_4o", fake_compose_meetups_intro
+    )
+    monkeypatch.setattr(
+        "digests.build_meetups_digest_candidates", fake_candidates
+    )
+    monkeypatch.setattr(
+        "digests.normalize_titles_via_4o", fake_normalize_titles
+    )
+    monkeypatch.setattr("digests.pick_display_link", lambda ev: ev.source_post_url)
+
+    now = datetime(2025, 5, 1, 12, 0)
+    intro, lines, horizon, events, norm_titles = await build_meetups_digest_preview(
+        "digest-meetups", None, now
+    )
+
+    assert intro == "интро про встречи"
+    assert captured_payload["value"] == [
+        {
+            "title": "Киноклуб «Весна»",
+            "description": "Творческий вечер с режиссёром и обсуждением фильма.",
+            "event_type": "клуб",
+            "formats": ["клуб", "творческий вечер"],
+        }
+    ]
+    assert horizon == 7
+    assert norm_titles == ["Киноклуб «Весна»"]
+    assert len(lines) == 1
+    assert events == [event]
+
+
+@pytest.mark.asyncio
+async def test_compose_meetups_intro_without_clubs_emphasises_people(monkeypatch):
+    captured_prompt: dict[str, str] = {}
+
+    async def fake_ask(prompt, max_tokens=0):
+        captured_prompt["value"] = prompt
+        return "интро"
+
+    monkeypatch.setattr("main.ask_4o", fake_ask)
+
+    payload = [
+        {
+            "title": "Встреча с автором",
+            "description": "Обсуждаем новую книгу и задаём вопросы.",
+            "event_type": "встреча",
+            "formats": ["встреча"],
+        }
+    ]
+
+    text = await compose_meetups_intro_via_4o(1, 7, payload)
+    assert text == "интро"
+
+    prompt = captured_prompt["value"]
+    assert "has_club=false" in prompt
+    assert "живом общении" in prompt or "интересными людьми" in prompt
+    assert "q&a" in prompt.lower()
+
+
+@pytest.mark.asyncio
+async def test_compose_meetups_intro_with_club_sets_flag(monkeypatch):
+    captured_prompt: dict[str, str] = {}
+
+    async def fake_ask(prompt, max_tokens=0):
+        captured_prompt["value"] = prompt
+        return "интро"
+
+    monkeypatch.setattr("main.ask_4o", fake_ask)
+
+    payload = [
+        {
+            "title": "Киноклуб",
+            "description": "Просмотр фильма",
+            "event_type": "клуб",
+            "formats": ["клуб"],
+        }
+    ]
+
+    text = await compose_meetups_intro_via_4o(1, 14, payload)
+    assert text == "интро"
+
+    prompt = captured_prompt["value"]
+    assert "has_club=true" in prompt
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- add meetup format detection and dedicated intro composer that highlights interpersonal value when clubs are absent
- include richer meetup payload assembly in digest preview builder
- extend lecture digest tests to cover meetup payloads and intro prompting logic

## Testing
- pytest tests/test_lecture_digest.py

------
https://chatgpt.com/codex/tasks/task_e_68e10e502b908332a4ae1d276378ce33