### PR TITLE
Document partner admin chat notification enhancements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 - Системный промпт автоклассификации запрещает выбирать темы `FAMILY` и `KIDS_SCHOOL`, когда у события задан возрастной ценз; см. обновления в `main.py` (`EVENT_TOPIC_SYSTEM_PROMPT`) и документации `docs/llm_topics.md`.
+- Уведомления в админ-чат для партнёров теперь включают первую фотографию события и ссылки на Telegraph и исходный VK-пост, чтобы операторы могли оперативно проверить публикацию.
 
 - Expanded THEATRE_CLASSIC and THEATRE_MODERN criteria to include canonical playwrights and contemporary production formats.
 


### PR DESCRIPTION
## Summary
- note that partner admin chat notifications now include the first event photo plus Telegraph and VK source links for quick verification

## Testing
- not run (documentation only)


------
https://chatgpt.com/codex/tasks/task_e_68e1125dd758833292f6c779e6def5c8