### PR TITLE
Handle fallback token usage metrics in four-o tracking

### DIFF
--- a/tests/test_four_o_usage.py
+++ b/tests/test_four_o_usage.py
@@ -30,13 +30,21 @@ def test_four_o_usage_resets_on_new_day(load_main, monkeypatch):
     day_one = date(2024, 5, 1)
     day_two = day_one + timedelta(days=1)
     monkeypatch.setattr(main, "_current_utc_date", lambda: day_one)
-    remaining = main._record_four_o_usage("test", "gpt-4o", 10, 5, 15)
+    remaining = main._record_four_o_usage(
+        "test",
+        "gpt-4o",
+        {"prompt_tokens": 10, "completion_tokens": 5, "total_tokens": 15},
+    )
     assert remaining == 85
     assert main._four_o_usage_state["used"] == 15
     assert main._four_o_usage_state["total"] == 15
     assert main._four_o_usage_state["models"]["gpt-4o"] == 15
     monkeypatch.setattr(main, "_current_utc_date", lambda: day_two)
-    remaining = main._record_four_o_usage("test", "gpt-4o", 2, 3, 5)
+    remaining = main._record_four_o_usage(
+        "test",
+        "gpt-4o",
+        {"prompt_tokens": 2, "completion_tokens": 3, "total_tokens": 5},
+    )
     assert remaining == 95
     assert main._four_o_usage_state["used"] == 5
     assert main._four_o_usage_state["total"] == 5
@@ -49,9 +57,17 @@ def test_four_o_usage_remaining_is_never_negative(load_main, monkeypatch, caplog
     monkeypatch.setattr(main, "_current_utc_date", lambda: today)
     caplog.set_level(logging.INFO)
     caplog.clear()
-    remaining = main._record_four_o_usage("ask", "gpt-4o", 30, 10, 40)
+    remaining = main._record_four_o_usage(
+        "ask",
+        "gpt-4o",
+        {"prompt_tokens": 30, "completion_tokens": 10, "total_tokens": 40},
+    )
     assert remaining == 10
-    remaining = main._record_four_o_usage("ask", "gpt-4o", 30, 20, 50)
+    remaining = main._record_four_o_usage(
+        "ask",
+        "gpt-4o",
+        {"prompt_tokens": 30, "completion_tokens": 20, "total_tokens": 50},
+    )
     assert remaining == 0
     assert main._four_o_usage_state["used"] == 50
     assert main._four_o_usage_state["total"] == 90
@@ -80,8 +96,16 @@ async def test_stats_reports_four_o_usage(load_main, tmp_path, monkeypatch):
 
     today = date(2024, 5, 4)
     monkeypatch.setattr(main, "_current_utc_date", lambda: today)
-    main._record_four_o_usage("stats", "gpt-4o", 10, 0, 10)
-    main._record_four_o_usage("stats", "gpt-4o-mini", 2, 3, 5)
+    main._record_four_o_usage(
+        "stats",
+        "gpt-4o",
+        {"prompt_tokens": 10, "completion_tokens": 0, "total_tokens": 10},
+    )
+    main._record_four_o_usage(
+        "stats",
+        "gpt-4o-mini",
+        {"prompt_tokens": 2, "completion_tokens": 3, "total_tokens": 5},
+    )
 
     msg = types.Message.model_validate(
         {
@@ -99,3 +123,49 @@ async def test_stats_reports_four_o_usage(load_main, tmp_path, monkeypatch):
     lines = bot.messages[-1][1].splitlines()
     assert lines[-2] == "Tokens gpt-4o: 10"
     assert lines[-1] == "Tokens gpt-4o-mini: 5"
+
+
+@pytest.mark.asyncio
+async def test_stats_reports_four_o_usage_with_input_output_tokens(
+    load_main, tmp_path, monkeypatch
+):
+    main = load_main(1000)
+    db = main.Database(str(tmp_path / "db.sqlite"))
+    await db.init()
+
+    class DummyBot:
+        def __init__(self):
+            self.messages = []
+
+        async def send_message(self, chat_id, text, **kwargs):
+            self.messages.append((chat_id, text, kwargs))
+
+    bot = DummyBot()
+
+    async with db.get_session() as session:
+        session.add(main.User(user_id=1, is_superadmin=True))
+        await session.commit()
+
+    today = date(2024, 5, 5)
+    monkeypatch.setattr(main, "_current_utc_date", lambda: today)
+    main._record_four_o_usage(
+        "stats",
+        "gpt-4o",
+        {"input_tokens": 12, "output_tokens": 8, "cache_creation_input_tokens": 3},
+    )
+
+    msg = types.Message.model_validate(
+        {
+            "message_id": 1,
+            "date": 0,
+            "chat": {"id": 1, "type": "private"},
+            "from": {"id": 1, "is_bot": False, "first_name": "Admin"},
+            "text": "/stats",
+        }
+    )
+
+    await main.handle_stats(msg, db, bot)
+
+    assert bot.messages
+    lines = bot.messages[-1][1].splitlines()
+    assert any(line == "Tokens gpt-4o: 23" for line in lines)


### PR DESCRIPTION
## Summary
- add fallback token accounting in `_record_four_o_usage` so we sum input/output/cache token counters when totals are missing
- pass the raw usage payload from the 4o callers into the tracker for richer accounting
- extend the four-o usage tests to cover the new fallback paths

## Testing
- pytest tests/test_four_o_usage.py

------
https://chatgpt.com/codex/tasks/task_e_68e11f2fc8b0833290c37692213bda94