### PR TITLE
Add historical immersion topic to 4o prompt

### DIFF
--- a/docs/PROMPTS.md
+++ b/docs/PROMPTS.md
@@ -165,6 +165,7 @@ Edit this file to tweak how requests are sent to 4o.
 - NETWORKING — «Нетворкинг и карьера»
 - ACTIVE — «Активный отдых и спорт»
 - PERSONALITIES — «Личности и встречи»
+- HISTORICAL_IMMERSION — «Исторические реконструкции и погружение»
 - KIDS_SCHOOL — «Дети и школа»
 - FAMILY — «Семейные события»
 Если ни одна тема не подходит, верни пустой массив.


### PR DESCRIPTION
## Summary
- add the HISTORICAL_IMMERSION topic to the event topic list in the 4o classifier prompt so it matches the llm_topics documentation

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e11f4e97f48332b173b48fb61cd8ee