### PR TITLE
Avoid treating phone numbers as dates in VK intake

### DIFF
--- a/tests/test_vk_intake_keywords_dates.py
+++ b/tests/test_vk_intake_keywords_dates.py
@@ -191,6 +191,22 @@ def test_extract_event_ts_hint_explicit_year_past(monkeypatch):
     assert extract_event_ts_hint(text) is None
 
 
+def test_extract_event_ts_hint_ignores_phone_number_segments(monkeypatch):
+    class FixedDatetime(real_datetime):
+        @classmethod
+        def now(cls, tz=None):
+            tzinfo = tz or timezone.utc
+            return real_datetime(2024, 4, 1, tzinfo=tzinfo)
+
+    monkeypatch.setattr("vk_intake.datetime", FixedDatetime)
+
+    text = "Встречаемся в пт, звоните 474-30-04"
+    ts = extract_event_ts_hint(text)
+    assert ts is not None
+    dt = real_datetime.fromtimestamp(ts, tz=main.LOCAL_TZ)
+    assert (dt.year, dt.month, dt.day) == (2024, 4, 5)
+
+
 @pytest.mark.asyncio
 async def test_build_drafts_library_defaults_to_free(monkeypatch):
     async def fake_parse(*args, **kwargs):

--- a/vk_intake.py
+++ b/vk_intake.py
@@ -310,7 +310,23 @@ def extract_event_ts_hint(
     text_low = text.lower()
 
     day = month = year = None
-    m = NUM_DATE_RE.search(text_low)
+    m = None
+    for candidate in NUM_DATE_RE.finditer(text_low):
+        start = candidate.start()
+        prev_idx = start - 1
+        while prev_idx >= 0 and text_low[prev_idx].isspace():
+            prev_idx -= 1
+        if prev_idx >= 0 and text_low[prev_idx] in "./-":
+            digit_count = 0
+            check_idx = prev_idx - 1
+            while check_idx >= 0 and text_low[check_idx].isdigit():
+                digit_count += 1
+                check_idx -= 1
+            if digit_count >= 3:
+                continue
+        m = candidate
+        break
+
     if m:
         day, month = int(m.group(1)), int(m.group(2))
         if m.group(3):


### PR DESCRIPTION
## Summary
- skip numeric date matches that are part of longer phone number patterns when extracting VK timestamps
- add a regression test ensuring weekday hints win over embedded phone numbers

## Testing
- pytest tests/test_vk_intake_keywords_dates.py

------
https://chatgpt.com/codex/tasks/task_e_68e12e23230483328aa945a79f27798f