### PR TITLE
Add topic hashtag mapping to short VK tag builder

### DIFF
--- a/main.py
+++ b/main.py
@@ -21624,6 +21624,12 @@ VK_LOCATION_TAG_OVERRIDES: dict[str, str] = {
 }
 
 
+VK_TOPIC_HASHTAGS: Mapping[str, str] = {
+    "FASHION": "#мода",
+    "KIDS_SCHOOL": "#дети",
+}
+
+
 async def build_short_vk_tags(
     event: Event, summary: str, used_type_hashtag: str | None = None
 ) -> list[str]:
@@ -21701,6 +21707,27 @@ async def build_short_vk_tags(
                         and hyphen_tag.lower() == used_type_hashtag_normalized
                     ):
                         add_tag(hyphen_tag)
+    topic_values = getattr(event, "topics", None) or []
+    for topic in topic_values:
+        if len(tags) >= 7:
+            break
+        normalized_topic = (topic or "").strip().upper()
+        if not normalized_topic:
+            continue
+        topic_tag = VK_TOPIC_HASHTAGS.get(normalized_topic)
+        if not topic_tag:
+            continue
+        topic_tag_clean = topic_tag.strip()
+        if not topic_tag_clean:
+            continue
+        if not topic_tag_clean.startswith("#"):
+            topic_tag_clean = "#" + topic_tag_clean.lstrip("#")
+        if (
+            used_type_hashtag_normalized
+            and topic_tag_clean.lower() == used_type_hashtag_normalized
+        ):
+            continue
+        add_tag(topic_tag_clean)
     needed = 7 - len(tags)
     if needed > 0:
         prompt = (

--- a/tests/test_vk_shortpost.py
+++ b/tests/test_vk_shortpost.py
@@ -139,6 +139,30 @@ async def test_build_short_vk_text_curiosity_hook_and_ban(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_build_short_vk_tags_include_topics(monkeypatch):
+    async def fake_ask(*args, **kwargs):
+        return "#экстра #тег"
+
+    monkeypatch.setattr(main, "ask_4o", fake_ask)
+
+    event = SimpleNamespace(
+        date="2025-01-15",
+        city="Калининград",
+        location_name="",
+        location_address="",
+        event_type="",
+        topics=["FASHION", "KIDS_SCHOOL"],
+        title="Показ и школа",
+    )
+
+    tags = await main.build_short_vk_tags(event, "Короткое описание")
+
+    assert "#мода" in tags
+    assert "#дети" in tags
+    assert 5 <= len(tags) <= 7
+
+
+@pytest.mark.asyncio
 async def test_shortpost_wall_post(tmp_path, monkeypatch):
     db = Database(str(tmp_path / "db.sqlite"))
     await db.init()


### PR DESCRIPTION
## Summary
- add a canonical mapping from event topics to VK hashtags for short posts
- include mapped topic hashtags when assembling VK short post tags without exceeding the tag limit
- extend the VK short post test suite to assert topic hashtags are included

## Testing
- pytest tests/test_vk_shortpost.py

------
https://chatgpt.com/codex/tasks/task_e_68e12e8cf3388332acc86319cdea39a2