### PR TITLE
Anchor VK event hints to publish timestamps

### DIFF
--- a/tests/test_vk_intake_future.py
+++ b/tests/test_vk_intake_future.py
@@ -111,7 +111,8 @@ async def test_forced_backfill_respects_clamped_horizon(
     monkeypatch.setattr(
         vk_intake,
         "extract_event_ts_hint",
-        lambda text, default_time=None, *, tz=None: int(time.time()) + 86400,
+        lambda text, default_time=None, *, tz=None, publish_ts=None: int(time.time())
+        + 86400,
     )
 
     async def no_sleep(_):
@@ -190,7 +191,8 @@ async def test_incremental_pagination_processes_full_backlog(
     monkeypatch.setattr(
         vk_intake,
         "extract_event_ts_hint",
-        lambda text, default_time=None, *, tz=None: int(time.time()) + 86400,
+        lambda text, default_time=None, *, tz=None, publish_ts=None: int(time.time())
+        + 86400,
     )
 
     base_ts = int(time.time()) - 900
@@ -274,7 +276,8 @@ async def test_hard_cap_triggers_backfill(tmp_path, monkeypatch, caplog):
     monkeypatch.setattr(
         vk_intake,
         "extract_event_ts_hint",
-        lambda text, default_time=None, *, tz=None: int(time.time()) + 86400,
+        lambda text, default_time=None, *, tz=None, publish_ts=None: int(time.time())
+        + 86400,
     )
 
     base_ts = int(time.time()) - 900

--- a/vk_review.py
+++ b/vk_review.py
@@ -156,7 +156,12 @@ async def pick_next(db: Database, operator_id: int, batch_id: str) -> Optional[I
             matched_kw = row[5]
             has_date = row[6]
             skip_hint_recalc = matched_kw == OCR_PENDING_SENTINEL and has_date == 0
-            ts_hint = None if skip_hint_recalc else extract_event_ts_hint(text)
+            publish_ts = row[3]
+            ts_hint = (
+                None
+                if skip_hint_recalc
+                else extract_event_ts_hint(text, publish_ts=publish_ts)
+            )
             if not skip_hint_recalc and (ts_hint is None or ts_hint < reject_cutoff):
                 await conn.execute(
                     "UPDATE vk_inbox SET status='rejected', locked_by=NULL, locked_at=NULL, review_batch=NULL WHERE id=?",
@@ -399,7 +404,12 @@ async def pick_next(db: Database, operator_id: int, batch_id: str) -> Optional[I
             matched_kw = row[5]
             has_date = row[6]
             skip_hint_recalc = matched_kw == OCR_PENDING_SENTINEL and has_date == 0
-            ts_hint = None if skip_hint_recalc else extract_event_ts_hint(text)
+            publish_ts = row[3]
+            ts_hint = (
+                None
+                if skip_hint_recalc
+                else extract_event_ts_hint(text, publish_ts=publish_ts)
+            )
             if not skip_hint_recalc and (ts_hint is None or ts_hint < reject_cutoff):
                 await conn.execute(
                     "UPDATE vk_inbox SET status='rejected', locked_by=NULL, locked_at=NULL, review_batch=NULL WHERE id=?",


### PR DESCRIPTION
## Summary
- extend `extract_event_ts_hint` with an optional publish timestamp anchor and reuse it for all relative calculations
- pass VK post publish times when computing event hints in the crawler and review flows
- update VK intake/review tests to provide deterministic publish times, cover weekday-relative wording, and adapt mocks

## Testing
- pytest tests/test_vk_intake_keywords_dates.py tests/test_vk_review.py

------
https://chatgpt.com/codex/tasks/task_e_68e12f612bac8332a55e0b7488021c94