### PR TITLE
Document VK weekday date inference fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - Telegraph event source pages now include a “Быстрые факты” block with date/time, location, and ticket/free status, hiding each line when the underlying data is missing so operators know it’s conditional.
 - Системный промпт автоклассификации запрещает выбирать темы `FAMILY` и `KIDS_SCHOOL`, когда у события задан возрастной ценз; см. обновления в `main.py` (`EVENT_TOPIC_SYSTEM_PROMPT`) и документации `docs/llm_topics.md`.
 - Уведомления в админ-чат для партнёров теперь включают первую фотографию события и ссылки на Telegraph и исходный VK-пост, чтобы операторы могли оперативно проверить публикацию.
+- Fixed VK weekday-based date inference so it anchors on the post’s publish date and skips phone-number fragments like `474-30-04`, preventing false matches in review notes.
 
 - Запустили научпоп-дайджест: в `/digest` появилась отдельная кнопка, а кандидаты отбираются по тематике `SCIENCE_POP`, чтобы операторы могли быстро собрать подборку.
 


### PR DESCRIPTION
## Summary
- document that VK weekday-based date inference now anchors on the publish date and ignores phone-number fragments such as 474-30-04

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e134892e688332a7eab52c8902affc