### PR TITLE
Expand meetup intro anti-cliche guidance

### DIFF
--- a/digests.py
+++ b/digests.py
@@ -128,6 +128,26 @@ _REVERSE_SYNONYMS = {
 }
 
 
+MEETUPS_INTRO_FORBIDDEN_WORDINGS: tuple[str, ...] = (
+    "«Погрузитесь»",
+    "«не упустите шанс»",
+    "конструкции с «мир …»",
+    "«Откройте для себя»",
+    "любые упоминания «горизонтов»",
+)
+
+
+def _format_forbidden_wordings(wordings: Iterable[str]) -> str:
+    items = list(wordings)
+    if not items:
+        return ""
+    if len(items) == 1:
+        return items[0]
+    if len(items) == 2:
+        return f"{items[0]} и {items[1]}"
+    return ", ".join(items[:-1]) + f" и {items[-1]}"
+
+
 def parse_start_time(raw: str) -> tuple[int, int] | None:
     """Вернёт (hh, mm) из строки времени.
 
@@ -970,6 +990,10 @@ async def compose_meetups_intro_via_4o(
     else:
         tone_instruction = ""
 
+    forbidden_guidance = _format_forbidden_wordings(
+        MEETUPS_INTRO_FORBIDDEN_WORDINGS
+    )
+
     prompt = (
         "Ты помогаешь телеграм-дайджесту мероприятий."
         f" Сформулируй живое интро на 1–2 предложения до ~200 символов к подборке из {n} встреч"
@@ -979,8 +1003,7 @@ async def compose_meetups_intro_via_4o(
         " чтобы выделить ключевые темы и форматы."
         f" Метаданные: has_club={has_club_flag}."
         f"{tone_instruction}"
-        " Избегай рекламных клише: не используй фразы вроде «Погрузитесь»,"
-        " «не упустите шанс» и конструкции с «мир …»."
+        f" Избегай рекламных клише: не используй {forbidden_guidance}."
         " Обязательно подчеркни живое общение: знакомство с интересными людьми, живое Q&A"
         " и нетворкинг."
         " Если has_club=false, сделай на этом акцент ещё заметнее."

--- a/tests/test_lecture_digest.py
+++ b/tests/test_lecture_digest.py
@@ -65,9 +65,8 @@ async def test_compose_meetups_intro_prompt_mentions_anti_cliche(monkeypatch):
     await compose_meetups_intro_via_4o(1, 7, [meetup])
 
     prompt = captured["prompt"]
-    assert "«Погрузитесь»" in prompt
-    assert "«не упустите шанс»" in prompt
-    assert "«мир …»" in prompt
+    for wording in digests.MEETUPS_INTRO_FORBIDDEN_WORDINGS:
+        assert wording in prompt
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- centralize the meetup intro anti-cliché list and extend it with the newly banned phrases
- have the prompt reference the expanded list via a formatter for consistent wording
- update the meetup intro prompt unit test to check for every forbidden phrase

## Testing
- pytest tests/test_lecture_digest.py::test_compose_meetups_intro_prompt_mentions_anti_cliche

------
https://chatgpt.com/codex/tasks/task_e_68e133382e808332a53153a18b70f889