### PR TITLE
Add VK crawl schedule to queue command output

### DIFF
--- a/main.py
+++ b/main.py
@@ -21390,6 +21390,16 @@ async def handle_vk_queue(message: types.Message, db: Database, bot: Bot) -> Non
         f"imported: {counts.get('imported', 0)}",
         f"rejected: {counts.get('rejected', 0)}",
     ]
+    schedule_raw = os.getenv(
+        "VK_CRAWL_TIMES_LOCAL", "05:15,09:15,13:15,17:15,21:15,22:45"
+    )
+    schedule_times = [part.strip() for part in schedule_raw.split(",") if part.strip()]
+    schedule_line = ", ".join(schedule_times)
+    schedule_tz = os.getenv("VK_CRAWL_TZ")
+    if schedule_tz:
+        schedule_line = f"{schedule_line} ({schedule_tz})"
+    if schedule_line:
+        lines.insert(0, f"Обновление базы: {schedule_line}")
     markup = types.ReplyKeyboardMarkup(
         keyboard=[[types.KeyboardButton(text=VK_BTN_CHECK_EVENTS)]],
         resize_keyboard=True,

--- a/tests/test_vk_queue_command.py
+++ b/tests/test_vk_queue_command.py
@@ -64,6 +64,8 @@ async def test_handle_vk_queue_shows_counts_and_button(tmp_path):
     await main.handle_vk_queue(msg, db, bot)
     assert bot.messages, "no message sent"
     sent = bot.messages[0]
+    assert sent.text.splitlines()[0].startswith("Обновление базы: ")
+    assert "05:15, 09:15, 13:15, 17:15, 21:15, 22:45" in sent.text
     assert "pending: 2" in sent.text
     assert "locked: 1" in sent.text
     assert sent.reply_markup.keyboard[0][0].text == main.VK_BTN_CHECK_EVENTS


### PR DESCRIPTION
## Summary
- show the VK crawl schedule (with optional timezone) in the /vk_queue response
- update the vk queue command test to assert the schedule information

## Testing
- pytest tests/test_vk_queue_command.py

------
https://chatgpt.com/codex/tasks/task_e_68e16a8414248332b93b5e5c8871430f