### PR TITLE
Add fallback to strip month details for large splits

### DIFF
--- a/tests/test_month_page_links.py
+++ b/tests/test_month_page_links.py
@@ -79,3 +79,100 @@ async def test_month_page_updated_after_telegraph_build(tmp_path, monkeypatch):
     assert html.count("подробнее") == 2
     assert "https://tg/1" in html
     assert "https://tg/2" in html
+
+
+@pytest.mark.asyncio
+async def test_split_month_until_ok_strips_details_when_needed(tmp_path, monkeypatch):
+    m = importlib.reload(orig_main)
+
+    db = m.Database(str(tmp_path / "db.sqlite"))
+    await db.init()
+
+    month = "2025-08"
+
+    async with db.get_session() as session:
+        session.add(m.MonthPage(month=month, url="", path=""))
+        await session.commit()
+
+    events = []
+    for idx in range(4):
+        events.append(
+            m.Event(
+                title=f"Event {idx}",
+                description="Description",
+                source_text="Source text",
+                date=f"{month}-{10 + idx:02d}",
+                time="18:00",
+                location_name="Hall",
+                telegraph_url=f"https://telegra.ph/event{idx}",
+                ics_url=f"https://example.com/event{idx}.ics",
+            )
+        )
+
+    combos = []
+    original_build = m.build_month_page_content
+
+    async def tracked_build_month_page_content(
+        db_obj,
+        month_str,
+        events_list,
+        exhibitions_list,
+        continuation_url=None,
+        size_limit=None,
+        *,
+        include_ics=True,
+        include_details=True,
+    ):
+        combos.append((include_ics, include_details))
+        result = await original_build(
+            db_obj,
+            month_str,
+            events_list,
+            exhibitions_list,
+            continuation_url=continuation_url,
+            size_limit=size_limit,
+            include_ics=include_ics,
+            include_details=include_details,
+        )
+        if include_ics or include_details:
+            raise m.TelegraphException("CONTENT_TOO_BIG")
+        return result
+
+    monkeypatch.setattr(m, "build_month_page_content", tracked_build_month_page_content)
+
+    created_html = []
+
+    async def fake_create_page(tg, *, title, html_content, caller="event_pipeline", **kwargs):
+        created_html.append(html_content.lower())
+        idx = len(created_html)
+        return {"url": f"https://telegra.ph/page{idx}", "path": f"path{idx}"}
+
+    async def fake_edit_page(
+        tg,
+        path,
+        *,
+        title,
+        html_content,
+        caller="event_pipeline",
+        **kwargs,
+    ):
+        created_html.append(html_content.lower())
+        return {"url": f"https://telegra.ph/{path}", "path": path}
+
+    monkeypatch.setattr(m, "telegraph_create_page", fake_create_page)
+    monkeypatch.setattr(m, "telegraph_edit_page", fake_edit_page)
+
+    tg = object()
+    nav_block = "<nav>links</nav>"
+
+    async with db.get_session() as session:
+        page_obj = await session.get(m.MonthPage, month)
+
+    await m.split_month_until_ok(db, tg, page_obj, month, events, [], nav_block)
+
+    assert (True, True) in combos
+    assert (False, True) in combos
+    assert combos[-1] == (False, False)
+    assert created_html, "expected successful html content"
+    assert all("подробнее" not in html for html in created_html)
+    assert all("добавить в календарь" not in html for html in created_html)

--- a/tests/test_pages_rebuild_months.py
+++ b/tests/test_pages_rebuild_months.py
@@ -361,6 +361,7 @@ async def test_month_nav_update_falls_back_to_full_rebuild(tmp_path, monkeypatch
         size_limit=None,
         *,
         include_ics=True,
+        include_details=True,
     ):
         nonlocal full_render_called
         full_render_called = True


### PR DESCRIPTION
## Summary
- add an `include_details` flag to the month rendering helpers so the "Подробнее" block can be omitted while keeping the rest of the layout
- update `split_month_until_ok` to try a third time without ICS links and details when Telegraph still reports CONTENT_TOO_BIG
- add regression coverage ensuring the final split output drops the "Подробнее" text when required

## Testing
- pytest tests/test_month_page_links.py -q
- pytest tests/test_month_split_fallback.py::test_split_month_until_ok_fallback_without_ics -q

------
https://chatgpt.com/codex/tasks/task_e_68e19542fe808332b5e85844a1e858b2