### PR TITLE
Inline ticket link within source summary block

### DIFF
--- a/main.py
+++ b/main.py
@@ -24463,7 +24463,7 @@ def _format_summary_anchor_text(url: str) -> str:
     return display or url
 
 
-def _render_summary_anchor(url: str) -> str:
+def _render_summary_anchor(url: str, text: str | None = None) -> str:
     cleaned = (url or "").strip()
     if not cleaned:
         return ""
@@ -24477,8 +24477,8 @@ def _render_summary_anchor(url: str) -> str:
             href = "https:" + cleaned
         else:
             href = "https://" + cleaned.lstrip("/")
-    text = _format_summary_anchor_text(href)
-    return f'<a href="{html.escape(href)}">{html.escape(text)}</a>'
+    display_text = text or _format_summary_anchor_text(href)
+    return f'<a href="{html.escape(href)}">{html.escape(display_text)}</a>'
 
 
 def _format_ticket_price(min_price: int | None, max_price: int | None) -> str:
@@ -24578,30 +24578,30 @@ async def _build_source_summary_block(
     if location_line:
         parts.append(f"<p>{html.escape(location_line)}</p>")
 
-    ticket_line = ""
-    anchor_html = ""
+    ticket_segments: list[str] = []
     link_value = (event_summary.ticket_link or "").strip()
     price_text = _format_ticket_price(
         event_summary.ticket_price_min, event_summary.ticket_price_max
     )
     if event_summary.is_free:
-        ticket_line = "🆓 Бесплатно"
         if link_value:
-            ticket_line += ", по регистрации"
-            anchor_html = _render_summary_anchor(link_value)
-    elif link_value:
-        if price_text:
-            ticket_line = f"🎟 Билеты {price_text}"
+            ticket_segments.append(html.escape("🆓 "))
+            ticket_segments.append(
+                _render_summary_anchor(link_value, "Бесплатно, по регистрации")
+            )
         else:
-            ticket_line = "🎟 Билеты"
-        anchor_html = _render_summary_anchor(link_value)
-    elif price_text:
-        ticket_line = f"🎟 Билеты {price_text}"
+            ticket_segments.append(html.escape("🆓 Бесплатно"))
+    else:
+        if link_value:
+            ticket_segments.append(html.escape("🎟 "))
+            ticket_segments.append(_render_summary_anchor(link_value, "Билеты"))
+            if price_text:
+                ticket_segments.append(html.escape(f" {price_text}"))
+        elif price_text:
+            ticket_segments.append(html.escape(f"🎟 Билеты {price_text}"))
 
-    if ticket_line:
-        parts.append(f"<p>{html.escape(ticket_line)}</p>")
-    if anchor_html:
-        parts.append(f"<p>{anchor_html}</p>")
+    if ticket_segments:
+        parts.append(f"<p>{''.join(ticket_segments)}</p>")
 
     return "".join(parts)
 

--- a/tests/test_source_images.py
+++ b/tests/test_source_images.py
@@ -239,10 +239,9 @@ async def test_build_source_page_content_summary_block(monkeypatch):
     )
     assert '<p>🗓 1 мая ⏰ 19:00</p>' in html
     assert '<p>📍 Дом, Улица, Калининград</p>' in html
-    assert '<p>🎟 Билеты от 500 до 1000 руб.</p>' in html
     assert (
-        '<p><a href="https://tickets.example.com/show">tickets.example.com/show</a></p>'
-        in html
+        '<p>🎟 <a href="https://tickets.example.com/show">Билеты</a> '
+        "от 500 до 1000 руб.</p>" in html
     )
 
 
@@ -271,9 +270,8 @@ async def test_build_source_page_content_summary_block_free(monkeypatch):
     )
     assert '<p>🗓 2 мая</p>' in html
     assert '<p>📍 Локация</p>' in html
-    assert '<p>🆓 Бесплатно, по регистрации</p>' in html
     assert (
-        '<p><a href="https://example.org/register">example.org/register</a></p>'
+        '<p>🆓 <a href="https://example.org/register">Бесплатно, по регистрации</a></p>'
         in html
     )
 


### PR DESCRIPTION
## Summary
- wrap ticket labels in inline anchors when a ticket link is available
- keep HTML escaping intact for ticket pricing and other text
- update source summary tests to expect inline links

## Testing
- pytest tests/test_source_images.py

------
https://chatgpt.com/codex/tasks/task_e_68e1a0a8247483328a07d37af6e8372d