### PR TITLE
Refine source summary block layout

### DIFF
--- a/main.py
+++ b/main.py
@@ -24501,7 +24501,7 @@ async def _build_source_summary_block(
     if not event_summary:
         return ""
 
-    parts: list[str] = []
+    lines: list[str] = []
 
     start_date: date | None = None
     try:
@@ -24550,7 +24550,7 @@ async def _build_source_summary_block(
         date_line = ""
 
     if date_line.strip():
-        parts.append(f"<p>{html.escape(date_line.strip())}</p>")
+        lines.append(html.escape(date_line.strip()))
 
     location_parts: list[str] = []
     existing_normalized: set[str] = set()
@@ -24576,7 +24576,7 @@ async def _build_source_summary_block(
         if location_text.strip():
             location_line = f"📍 {location_text.strip()}"
     if location_line:
-        parts.append(f"<p>{html.escape(location_line)}</p>")
+        lines.append(html.escape(location_line))
 
     ticket_segments: list[str] = []
     link_value = (event_summary.ticket_link or "").strip()
@@ -24601,9 +24601,12 @@ async def _build_source_summary_block(
             ticket_segments.append(html.escape(f"🎟 Билеты {price_text}"))
 
     if ticket_segments:
-        parts.append(f"<p>{''.join(ticket_segments)}</p>")
+        lines.append("".join(ticket_segments).strip())
 
-    return "".join(parts)
+    if not lines:
+        return ""
+
+    return f"<p>{'<br/>'.join(lines)}</p>"
 
 
 async def build_source_page_content(

--- a/tests/test_source_images.py
+++ b/tests/test_source_images.py
@@ -237,10 +237,9 @@ async def test_build_source_page_content_summary_block(monkeypatch):
         None,
         event_summary=summary,
     )
-    assert '<p>🗓 1 мая ⏰ 19:00</p>' in html
-    assert '<p>📍 Дом, Улица, Калининград</p>' in html
     assert (
-        '<p>🎟 <a href="https://tickets.example.com/show">Билеты</a> '
+        '<p>🗓 1 мая ⏰ 19:00<br/>📍 Дом, Улица, Калининград<br/>🎟 '
+        '<a href="https://tickets.example.com/show">Билеты</a> '
         "от 500 до 1000 руб.</p>" in html
     )
 
@@ -268,10 +267,9 @@ async def test_build_source_page_content_summary_block_free(monkeypatch):
         None,
         event_summary=summary,
     )
-    assert '<p>🗓 2 мая</p>' in html
-    assert '<p>📍 Локация</p>' in html
     assert (
-        '<p>🆓 <a href="https://example.org/register">Бесплатно, по регистрации</a></p>'
+        '<p>🗓 2 мая<br/>📍 Локация<br/>🆓 '
+        '<a href="https://example.org/register">Бесплатно, по регистрации</a></p>'
         in html
     )
 


### PR DESCRIPTION
## Summary
- collapse source summary block lines into a single paragraph with `<br/>` separators while still omitting the block when no details are available
- update source image tests to reflect the compact summary block markup

## Testing
- pytest tests/test_source_images.py


------
https://chatgpt.com/codex/tasks/task_e_68e1a28e0594833295744af5198b9db4