### PR TITLE
Build Telegraph summary addresses without VK helper

### DIFF
--- a/main.py
+++ b/main.py
@@ -24569,10 +24569,7 @@ async def _build_source_summary_block(
 
     location_line = ""
     if location_parts:
-        try:
-            location_text = await build_short_vk_location(location_parts)
-        except Exception:
-            location_text = ", ".join(part.strip() for part in location_parts if part.strip())
+        location_text = ", ".join(part.strip() for part in location_parts if part.strip())
         if location_text.strip():
             location_line = f"📍 {location_text.strip()}"
     if location_line:

--- a/tests/test_source_images.py
+++ b/tests/test_source_images.py
@@ -246,14 +246,11 @@ async def test_build_source_page_content_summary_block(monkeypatch):
 
 @pytest.mark.asyncio
 async def test_build_source_page_content_summary_block_free(monkeypatch):
-    async def fake_location(parts):
-        return "Локация"
-
-    monkeypatch.setattr(main, "build_short_vk_location", fake_location)
-
     summary = main.SourcePageEventSummary(
         date="2024-05-02",
         location_name="Локация",
+        location_address="Адрес",
+        city="Город",
         ticket_link="https://example.org/register",
         is_free=True,
     )
@@ -268,7 +265,7 @@ async def test_build_source_page_content_summary_block_free(monkeypatch):
         event_summary=summary,
     )
     assert (
-        '<p>🗓 2 мая<br/>📍 Локация<br/>🆓 '
+        '<p>🗓 2 мая<br/>📍 Локация, Адрес, Город<br/>🆓 '
         '<a href="https://example.org/register">Бесплатно, по регистрации</a></p>'
         in html
     )


### PR DESCRIPTION
## Summary
- stop using the VK short location helper when building Telegraph source summaries
- assemble the location string from name, address, and city in order while skipping duplicates
- update the Telegraph summary test fixture to expect the new formatted location string

## Testing
- pytest tests/test_source_images.py::test_build_source_page_content_summary_block tests/test_source_images.py::test_build_source_page_content_summary_block_free


------
https://chatgpt.com/codex/tasks/task_e_68e223a06e1c83329f3aa90732a220cb