### PR TITLE
Skip phone-like sequences when extracting VK dates

### DIFF
--- a/tests/test_vk_intake_keywords_dates.py
+++ b/tests/test_vk_intake_keywords_dates.py
@@ -180,6 +180,12 @@ def test_extract_event_ts_hint_ignores_phone_number_segments():
     assert (dt.year, dt.month, dt.day) == (2024, 4, 5)
 
 
+def test_extract_event_ts_hint_phone_like_sequence_only():
+    publish_dt = real_datetime(2024, 4, 1, tzinfo=main.LOCAL_TZ)
+    text = "Запись по телефону 8 (4012) 27-01-26"
+    assert extract_event_ts_hint(text, publish_ts=publish_dt) is None
+
+
 def test_extract_event_ts_hint_weekday_uses_publish_week(monkeypatch):
     class FixedDatetime(real_datetime):
         @classmethod

--- a/vk_intake.py
+++ b/vk_intake.py
@@ -207,6 +207,11 @@ HISTORICAL_TOPONYMS = [
 HISTORICAL_YEAR_RE = re.compile(r"\b(1\d{3})\b")
 
 NUM_DATE_RE = re.compile(r"\b(\d{1,2})[./-](\d{1,2})(?:[./-](\d{2,4}))?\b")
+PHONE_LIKE_RE = re.compile(r"^(?:\d{2}-){2,}\d{2}$")
+PHONE_CONTEXT_RE = re.compile(
+    r"(тел(?:\.|:)?|телефон\w*|звоните|звонок\w*)",
+    re.I | re.U,
+)
 DATE_RANGE_RE = re.compile(r"\b(\d{1,2})[–-](\d{1,2})(?:[./](\d{1,2}))\b")
 MONTH_NAME_RE = re.compile(r"\b(\d{1,2})\s+([а-яё.]+)\b", re.I)
 TIME_RE = re.compile(r"\b([01]?\d|2[0-3])[:.][0-5]\d\b")
@@ -332,6 +337,12 @@ def extract_event_ts_hint(
                 digit_count += 1
                 check_idx -= 1
             if digit_count >= 3:
+                continue
+        if PHONE_LIKE_RE.match(candidate.group(0)):
+            context_start = max(0, start - 30)
+            context_end = min(len(text_low), candidate.end() + 10)
+            context_slice = text_low[context_start:context_end]
+            if PHONE_CONTEXT_RE.search(context_slice):
                 continue
         m = candidate
         break


### PR DESCRIPTION
## Summary
- ignore numeric sequences that look like phone numbers when scanning VK posts for dates
- add a regression test covering a phone-number-only post

## Testing
- pytest tests/test_vk_intake_keywords_dates.py::test_extract_event_ts_hint_phone_like_sequence_only

------
https://chatgpt.com/codex/tasks/task_e_68e22531f554833297e0be0d3d740991