### PR TITLE
Adjust ICS link placement in source pages

### DIFF
--- a/main.py
+++ b/main.py
@@ -4877,14 +4877,24 @@ def parse_time_range(value: str) -> tuple[time, time | None] | None:
 
 def apply_ics_link(html_content: str, url: str | None) -> str:
     """Insert or remove the ICS link block in Telegraph HTML."""
-    idx = html_content.find(ICS_LABEL)
-    if idx != -1:
-        start = html_content.rfind("<p", 0, idx)
-        end = html_content.find("</p>", idx)
-        if start != -1 and end != -1:
-            html_content = html_content[:start] + html_content[end + 4 :]
+    removal_pattern = re.compile(
+        r"\s*\U0001f4c5\s*<a\b[^>]*>\s*"
+        + re.escape(ICS_LABEL)
+        + r"\s*</a>",
+        flags=re.IGNORECASE,
+    )
+    html_content = removal_pattern.sub("", html_content)
+    html_content = re.sub(r"<p>\s*</p>", "", html_content)
     if not url:
         return html_content
+    tail_html = (
+        f' \U0001f4c5 <a href="{html.escape(url)}">{ICS_LABEL}</a>'
+    )
+    date_paragraph_re = re.compile(r"(<p[^>]*>.*?🗓.*?)(</p>)", re.DOTALL)
+    match = date_paragraph_re.search(html_content)
+    if match:
+        updated = match.group(1) + tail_html + match.group(2)
+        return html_content[: match.start()] + updated + html_content[match.end() :]
     link_html = (
         f'<p>\U0001f4c5 <a href="{html.escape(url)}">{ICS_LABEL}</a></p>'
     )
@@ -24497,6 +24507,8 @@ def _format_ticket_price(min_price: int | None, max_price: int | None) -> str:
 
 async def _build_source_summary_block(
     event_summary: SourcePageEventSummary | None,
+    *,
+    ics_url: str | None = None,
 ) -> str:
     if not event_summary:
         return ""
@@ -24549,8 +24561,14 @@ async def _build_source_summary_block(
     else:
         date_line = ""
 
-    if date_line.strip():
-        lines.append(html.escape(date_line.strip()))
+    date_line = date_line.strip()
+    if date_line:
+        escaped_date = html.escape(date_line)
+        if ics_url:
+            escaped_date += (
+                f' \U0001f4c5 <a href="{html.escape(ics_url)}">{ICS_LABEL}</a>'
+            )
+        lines.append(escaped_date)
 
     location_parts: list[str] = []
     existing_normalized: set[str] = set()
@@ -24650,19 +24668,16 @@ async def build_source_page_content(
     tail = urls[1:]
     if cover:
         html_content += f'<figure><img src="{html.escape(cover[0])}"/></figure>'
-        if ics_url:
-            html_content += (
-                f'<p>\U0001f4c5 <a href="{html.escape(ics_url)}">Добавить в календарь</a></p>'
-            )
-    else:
-        if ics_url:
-            html_content += (
-                f'<p>\U0001f4c5 <a href="{html.escape(ics_url)}">Добавить в календарь</a></p>'
-            )
-    summary_html = await _build_source_summary_block(event_summary)
+    summary_html = await _build_source_summary_block(
+        event_summary, ics_url=ics_url
+    )
     summary_added = bool(summary_html)
     if summary_html:
         html_content += summary_html
+    elif ics_url:
+        html_content += (
+            f'<p>\U0001f4c5 <a href="{html.escape(ics_url)}">{ICS_LABEL}</a></p>'
+        )
     emoji_pat = re.compile(r"<tg-emoji[^>]*>(.*?)</tg-emoji>", re.DOTALL)
     spoiler_pat = re.compile(r"<tg-spoiler[^>]*>(.*?)</tg-spoiler>", re.DOTALL)
     tg_emoji_cleaned = 0

--- a/tests/test_source_images.py
+++ b/tests/test_source_images.py
@@ -75,6 +75,15 @@ def test_apply_ics_link_after_figure():
     assert res.index(main.ICS_LABEL) > res.index("</figure>")
 
 
+def test_apply_ics_link_appends_to_date_paragraph():
+    html = "<p>🗓 1 мая ⏰ 19:00</p><p>body</p>"
+    res = main.apply_ics_link(html, "http://ics")
+    assert (
+        '<p>🗓 1 мая ⏰ 19:00 📅 <a href="http://ics">Добавить в календарь</a></p>'
+        in res
+    )
+
+
 @pytest.mark.asyncio
 async def test_build_source_page_content_ics_with_cover():
     html, _, _ = await main.build_source_page_content(
@@ -100,6 +109,30 @@ async def test_build_source_page_content_ics_no_cover():
     )
     assert html.startswith('<p>📅 <a href="http://ics">Добавить в календарь</a></p>')
     assert html.index('http://ics') < html.index('<p>text</p>')
+
+
+@pytest.mark.asyncio
+async def test_build_source_page_content_summary_block_with_ics():
+    summary = main.SourcePageEventSummary(
+        date="2024-06-01",
+        time="18:30",
+        location_name="Место",
+    )
+    html, _, _ = await main.build_source_page_content(
+        "Title",
+        "Body",
+        None,
+        None,
+        None,
+        "http://ics",
+        None,
+        event_summary=summary,
+    )
+    assert (
+        '🗓 1 июня ⏰ 18:30 📅 <a href="http://ics">Добавить в календарь</a>'
+        in html
+    )
+    assert '<br/>📍 Место' in html
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- pass the ICS URL into the source summary builder so the calendar link appears after the date/time when available
- update `apply_ics_link` to augment the first date paragraph or fall back to the legacy placement when needed
- extend the source image tests to cover the new calendar link placement

## Testing
- pytest tests/test_source_images.py
- pytest tests/test_bot.py::test_apply_ics_link_insert_and_remove

------
https://chatgpt.com/codex/tasks/task_e_68e23397bf30833298cb7e8fa3b81fef