### PR TITLE
Refresh VK inbox hints on timezone change

### DIFF
--- a/main.py
+++ b/main.py
@@ -2097,6 +2097,7 @@ async def set_tz_offset(db: Database, value: str):
         await conn.commit()
     global LOCAL_TZ
     LOCAL_TZ = offset_to_timezone(value)
+    await vk_review.refresh_vk_event_ts_hints(db)
 
 
 async def get_catbox_enabled(db: Database) -> bool:


### PR DESCRIPTION
## Summary
- add a helper that recomputes event timestamp hints for queued VK inbox rows
- trigger the helper when the timezone offset is updated so existing rows stay in sync
- cover the behaviour with a regression test that simulates a timezone change in vk_review

## Testing
- pytest tests/test_vk_review.py::test_refresh_hints_after_timezone_change

------
https://chatgpt.com/codex/tasks/task_e_68e2340f0aa48332ab96355eb1afca11