### PR TITLE
Fix phone context detection to avoid telegram false positives

### DIFF
--- a/tests/test_vk_intake_keywords_dates.py
+++ b/tests/test_vk_intake_keywords_dates.py
@@ -192,6 +192,15 @@ def test_extract_event_ts_hint_phone_like_sequence_only():
     assert extract_event_ts_hint(text, publish_ts=publish_dt) is None
 
 
+def test_extract_event_ts_hint_telegram_phrase_keeps_date():
+    publish_dt = real_datetime(2024, 10, 1, tzinfo=main.LOCAL_TZ)
+    text = "Наш телеграм-канал расскажет 10-12-24"
+    ts = extract_event_ts_hint(text, publish_ts=publish_dt)
+    assert ts is not None
+    dt = real_datetime.fromtimestamp(ts, tz=main.LOCAL_TZ)
+    assert (dt.year, dt.month, dt.day) == (2024, 12, 10)
+
+
 def test_extract_event_ts_hint_weekday_uses_publish_week(monkeypatch):
     class FixedDatetime(real_datetime):
         @classmethod

--- a/vk_intake.py
+++ b/vk_intake.py
@@ -220,7 +220,7 @@ HISTORICAL_YEAR_RE = re.compile(r"\b(1\d{3})\b")
 NUM_DATE_RE = re.compile(r"\b(\d{1,2})[./-](\d{1,2})(?:[./-](\d{2,4}))?\b")
 PHONE_LIKE_RE = re.compile(r"^(?:\d{2}-){2,}\d{2}$")
 PHONE_CONTEXT_RE = re.compile(
-    r"(тел(?:\.|:)?|телефон\w*|звоните|звонок\w*)",
+    r"(\bтел(?:[.:]|ефон\w*|\b)|\bзвоните\b|\bзвонок\w*)",
     re.I | re.U,
 )
 DATE_RANGE_RE = re.compile(r"\b(\d{1,2})[–-](\d{1,2})(?:[./](\d{1,2}))\b")


### PR DESCRIPTION
## Summary
- tighten the phone context regex so phone-like dates next to "тел" are only skipped when a real phone hint is present
- add a regression test covering telegram phrasing to keep extracting the numeric date

## Testing
- pytest tests/test_vk_intake_keywords_dates.py::test_extract_event_ts_hint_telegram_phrase_keeps_date

------
https://chatgpt.com/codex/tasks/task_e_68e23a8892b483329d5a60af97fb39df