### PR TITLE
Handle phone-prefixed numeric dates

### DIFF
--- a/tests/test_vk_intake_keywords_dates.py
+++ b/tests/test_vk_intake_keywords_dates.py
@@ -192,6 +192,21 @@ def test_extract_event_ts_hint_phone_like_sequence_only():
     assert extract_event_ts_hint(text, publish_ts=publish_dt) is None
 
 
+def test_extract_event_ts_hint_phone_prefix_numbers_only():
+    publish_dt = real_datetime(2024, 10, 1, tzinfo=main.LOCAL_TZ)
+    text = "тел8-921-12-34-56"
+    assert extract_event_ts_hint(text, publish_ts=publish_dt) is None
+
+
+def test_extract_event_ts_hint_phone_prefix_with_date():
+    publish_dt = real_datetime(2024, 10, 1, tzinfo=main.LOCAL_TZ)
+    text = "тел8-921-12-34-56, концерт 10-12-24"
+    ts = extract_event_ts_hint(text, publish_ts=publish_dt)
+    assert ts is not None
+    dt = real_datetime.fromtimestamp(ts, tz=main.LOCAL_TZ)
+    assert (dt.year, dt.month, dt.day) == (2024, 12, 10)
+
+
 def test_extract_event_ts_hint_telegram_phrase_keeps_date():
     publish_dt = real_datetime(2024, 10, 1, tzinfo=main.LOCAL_TZ)
     text = "Наш телеграм-канал расскажет 10-12-24"


### PR DESCRIPTION
## Summary
- extend the telephone context detection to recognize digits that follow the "тел" prefix directly
- only treat numeric date candidates as phone numbers when no textual separator occurs between the telephone cue and the candidate
- add regressions ensuring standalone phone strings are ignored while nearby event dates are still parsed

## Testing
- pytest tests/test_vk_intake_keywords_dates.py

------
https://chatgpt.com/codex/tasks/task_e_68e23d7ce0d88332a2762ef1645087d7