### PR TITLE
Fix OCR token totals in stats command

### DIFF
--- a/main.py
+++ b/main.py
@@ -19977,14 +19977,11 @@ async def handle_stats(message: types.Message, db: Database, bot: Bot):
         ocr_usage = await session.get(OcrUsage, today_key)
         if ocr_usage and ocr_usage.spent_tokens:
             ocr_tokens = max(int(ocr_usage.spent_tokens), 0)
-            usage_models["gpt-4o-mini"] = mini_snapshot + ocr_tokens
+    new_mini_total = mini_snapshot + ocr_tokens
+    usage_models["gpt-4o-mini"] = new_mini_total
 
     snapshot_total = _coerce_int(usage_snapshot.get("total", 0))
-    if ocr_tokens:
-        extra_total = max(ocr_tokens - mini_snapshot, 0)
-        tokens_total = snapshot_total + extra_total
-    else:
-        tokens_total = snapshot_total
+    tokens_total = snapshot_total - mini_snapshot + new_mini_total
 
     lines.extend(
         [

--- a/tests/test_bot.py
+++ b/tests/test_bot.py
@@ -4291,7 +4291,7 @@ async def test_stats_events(tmp_path: Path, monkeypatch):
     assert "5" in lines[1]
     assert lines[-3] == "Tokens gpt-4o: 5"
     assert lines[-2] == "Tokens gpt-4o-mini: 450"
-    assert lines[-1] == "Tokens total: 1050"
+    assert lines[-1] == "Tokens total: 1250"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- ensure the /stats handler replaces the gpt-4o-mini total with the snapshot plus stored OCR usage so the reported total includes both
- update the stats test to cover non-zero mini snapshot usage and assert the combined total is displayed

## Testing
- pytest tests/test_bot.py::test_stats_events

------
https://chatgpt.com/codex/tasks/task_e_68e23f819e88833293d9b321238dd3f1