### PR TITLE
Refine phone detection around event timestamp extraction

### DIFF
--- a/tests/test_vk_intake_keywords_dates.py
+++ b/tests/test_vk_intake_keywords_dates.py
@@ -192,6 +192,15 @@ def test_extract_event_ts_hint_phone_like_sequence_only():
     assert extract_event_ts_hint(text, publish_ts=publish_dt) is None
 
 
+def test_extract_event_ts_hint_phone_then_date_on_newline():
+    publish_dt = real_datetime(2024, 10, 1, tzinfo=main.LOCAL_TZ)
+    text = "Запись по телефону 8 (4012) 27-01-26\n20-10-24 в 19:00"
+    ts = extract_event_ts_hint(text, publish_ts=publish_dt)
+    assert ts is not None
+    dt = real_datetime.fromtimestamp(ts, tz=main.LOCAL_TZ)
+    assert (dt.year, dt.month, dt.day, dt.hour, dt.minute) == (2024, 10, 20, 19, 0)
+
+
 def test_extract_event_ts_hint_phone_prefix_numbers_only():
     publish_dt = real_datetime(2024, 10, 1, tzinfo=main.LOCAL_TZ)
     text = "тел8-921-12-34-56"

--- a/vk_intake.py
+++ b/vk_intake.py
@@ -359,8 +359,13 @@ def extract_event_ts_hint(
                 if match_end <= start:
                     intervening = text_low[match_end:start]
                     if not re.search(r"[a-zа-яё]", intervening):
-                        skip_candidate = True
-                        break
+                        if "\n" in intervening or "\r" in intervening:
+                            continue
+                        normalized = intervening.replace(" ", "")
+                        normalized = normalized.lstrip(".,:;-–—")
+                        if not normalized or re.fullmatch(r"[\d()+\-–—]*", normalized):
+                            skip_candidate = True
+                            break
             if skip_candidate:
                 continue
         m = candidate


### PR DESCRIPTION
## Summary
- refine the phone context detection so newline-separated dates are still considered
- add a regression test covering the phone number followed by a newline-delimited date

## Testing
- pytest tests/test_vk_intake_keywords_dates.py

------
https://chatgpt.com/codex/tasks/task_e_68e241dac90c8332a0e127f365b40cc6