### PR TITLE
Handle dates separated from phone hints by spaced dashes

### DIFF
--- a/tests/test_vk_intake_keywords_dates.py
+++ b/tests/test_vk_intake_keywords_dates.py
@@ -201,6 +201,15 @@ def test_extract_event_ts_hint_phone_then_date_on_newline():
     assert (dt.year, dt.month, dt.day, dt.hour, dt.minute) == (2024, 10, 20, 19, 0)
 
 
+def test_extract_event_ts_hint_phone_then_date_with_spaced_dash():
+    publish_dt = real_datetime(2024, 10, 1, tzinfo=main.LOCAL_TZ)
+    text = "Запись по телефону 8 (4012) 27-01-26 — 20-10-24 собираемся в клубе"
+    ts = extract_event_ts_hint(text, publish_ts=publish_dt)
+    assert ts is not None
+    dt = real_datetime.fromtimestamp(ts, tz=main.LOCAL_TZ)
+    assert (dt.year, dt.month, dt.day) == (2024, 10, 20)
+
+
 def test_extract_event_ts_hint_phone_prefix_numbers_only():
     publish_dt = real_datetime(2024, 10, 1, tzinfo=main.LOCAL_TZ)
     text = "тел8-921-12-34-56"

--- a/vk_intake.py
+++ b/vk_intake.py
@@ -358,6 +358,8 @@ def extract_event_ts_hint(
                 match_end = context_start + phone_match.end()
                 if match_end <= start:
                     intervening = text_low[match_end:start]
+                    if re.search(r"\s[–—-]\s", intervening):
+                        break
                     if not re.search(r"[a-zа-яё]", intervening):
                         if "\n" in intervening or "\r" in intervening:
                             continue


### PR DESCRIPTION
## Summary
- ensure phone context filters ignore candidates separated by spaced dashes so dates are still detected
- add a regression test confirming extract_event_ts_hint handles spaced dashes between phone-like numbers and dates

## Testing
- pytest tests/test_vk_intake_keywords_dates.py

------
https://chatgpt.com/codex/tasks/task_e_68e24983d2b88332a1d98a9be766604f