### PR TITLE
Handle event text after phone-like dates

### DIFF
--- a/tests/test_vk_intake_keywords_dates.py
+++ b/tests/test_vk_intake_keywords_dates.py
@@ -186,6 +186,15 @@ def test_extract_event_ts_hint_ignores_phone_number_segments():
     assert (dt.year, dt.month, dt.day) == (2024, 4, 5)
 
 
+def test_extract_event_ts_hint_phone_like_sequence_with_event_tail():
+    publish_dt = real_datetime(2024, 4, 1, tzinfo=main.LOCAL_TZ)
+    text = "Запись по телефону 8 (4012) 27-01-26 — 20-10-24 собираемся в клубе"
+    ts = extract_event_ts_hint(text, publish_ts=publish_dt)
+    assert ts is not None
+    dt = real_datetime.fromtimestamp(ts, tz=main.LOCAL_TZ)
+    assert (dt.year, dt.month, dt.day) == (2024, 10, 20)
+
+
 def test_extract_event_ts_hint_phone_like_sequence_only():
     publish_dt = real_datetime(2024, 4, 1, tzinfo=main.LOCAL_TZ)
     text = "Запись по телефону 8 (4012) 27-01-26"
@@ -219,7 +228,10 @@ def test_extract_event_ts_hint_phone_then_date_on_newline():
 def test_extract_event_ts_hint_phone_then_date_with_spaced_dash():
     publish_dt = real_datetime(2024, 10, 1, tzinfo=main.LOCAL_TZ)
     text = "Запись по телефону 8 (4012) 27-01-26 — 20-10-24 собираемся в клубе"
-    assert extract_event_ts_hint(text, publish_ts=publish_dt) is None
+    ts = extract_event_ts_hint(text, publish_ts=publish_dt)
+    assert ts is not None
+    dt = real_datetime.fromtimestamp(ts, tz=main.LOCAL_TZ)
+    assert (dt.year, dt.month, dt.day) == (2024, 10, 20)
 
 
 def test_extract_event_ts_hint_phone_prefix_numbers_only():


### PR DESCRIPTION
## Summary
- refine the phone-like date guard in `extract_event_ts_hint` to detect event text or times following the candidate before skipping it as a phone number
- extend the VK intake keyword/date tests to cover mixed phone/event strings while keeping pure phone sequences ignored

## Testing
- pytest tests/test_vk_intake_keywords_dates.py -k phone

------
https://chatgpt.com/codex/tasks/task_e_68e250d419b48332b12b1da3fa47a44c