### PR TITLE
Refine VK intake phone-tail detection for date parsing

### DIFF
--- a/tests/test_vk_intake_keywords_dates.py
+++ b/tests/test_vk_intake_keywords_dates.py
@@ -207,9 +207,24 @@ def test_extract_event_ts_hint_phone_block_with_dash():
     assert extract_event_ts_hint(text, publish_ts=publish_dt) is None
 
 
+def test_extract_event_ts_hint_phone_block_with_guidance_tail():
+    publish_dt = real_datetime(2024, 4, 1, tzinfo=main.LOCAL_TZ)
+    text = "Телефон: 27-01-26 — звоните"
+    assert extract_event_ts_hint(text, publish_ts=publish_dt) is None
+
+
 def test_extract_event_ts_hint_phone_block_then_real_date():
     publish_dt = real_datetime(2024, 10, 1, tzinfo=main.LOCAL_TZ)
     text = "Телефон: 27-01-26 — 29-03-44, встречаемся 20-10-24"
+    ts = extract_event_ts_hint(text, publish_ts=publish_dt)
+    assert ts is not None
+    dt = real_datetime.fromtimestamp(ts, tz=main.LOCAL_TZ)
+    assert (dt.year, dt.month, dt.day) == (2024, 10, 20)
+
+
+def test_extract_event_ts_hint_phone_guidance_then_text_date():
+    publish_dt = real_datetime(2024, 10, 1, tzinfo=main.LOCAL_TZ)
+    text = "Телефон: 27-01-26 — концерт 20-10-24"
     ts = extract_event_ts_hint(text, publish_ts=publish_dt)
     assert ts is not None
     dt = real_datetime.fromtimestamp(ts, tz=main.LOCAL_TZ)


### PR DESCRIPTION
## Summary
- refine phone tail detection in `extract_event_ts_hint` by recognising phone-guidance tails and flagging venue/time cues
- extend the heuristic with action/location prefixes to keep genuine event dates after phone blocks
- add regression coverage for phone guidance without dates and for phone blocks followed by a real date

## Testing
- pytest tests/test_vk_intake_keywords_dates.py

------
https://chatgpt.com/codex/tasks/task_e_68e2555f6d948332bea77c55f9b0d82c