### PR TITLE
Add Supabase token usage logging for LLM requests

### DIFF
--- a/main.py
+++ b/main.py
@@ -113,6 +113,7 @@ from typing import (
     Collection,
     Sequence,
     Mapping,
+    cast,
 )
 from urllib.parse import urlparse, parse_qs, ParseResult
 import uuid
@@ -408,6 +409,7 @@ def _week_vk_lock(start: str) -> asyncio.Lock:
 
 DB_PATH = os.getenv("DB_PATH", "/data/db.sqlite")
 db: Database | None = None
+BOT_CODE = os.getenv("BOT_CODE", "announcements")
 TELEGRAPH_TOKEN_FILE = os.getenv("TELEGRAPH_TOKEN_FILE", "/data/telegraph_token.txt")
 TELEGRAPH_AUTHOR_NAME = os.getenv(
     "TELEGRAPH_AUTHOR_NAME", "Полюбить Калининград Анонсы"
@@ -1687,6 +1689,64 @@ def _record_four_o_usage(
         int(total_tokens or 0),
     )
     return remaining
+
+
+async def log_token_usage(
+    bot: str,
+    model: str,
+    usage: Mapping[str, Any] | None,
+    *,
+    endpoint: str,
+    request_id: str | None,
+    meta: Mapping[str, Any] | None = None,
+) -> None:
+    client = get_supabase_client()
+    if client is None:
+        return
+
+    usage_data: Mapping[str, Any] = usage or {}
+
+    def _coerce_int(value: Any) -> int | None:
+        try:
+            if value is None:
+                return None
+            return int(value)
+        except (TypeError, ValueError):
+            return None
+
+    prompt_tokens = _coerce_int(usage_data.get("prompt_tokens"))
+    completion_tokens = _coerce_int(usage_data.get("completion_tokens"))
+    total_tokens = _coerce_int(usage_data.get("total_tokens"))
+
+    if prompt_tokens is None:
+        prompt_tokens = _coerce_int(usage_data.get("input_tokens"))
+    if completion_tokens is None:
+        completion_tokens = _coerce_int(usage_data.get("output_tokens"))
+    if total_tokens is None and None not in (prompt_tokens, completion_tokens):
+        total_tokens = cast(int, prompt_tokens) + cast(int, completion_tokens)
+
+    row = {
+        "bot": bot,
+        "model": model,
+        "prompt_tokens": prompt_tokens,
+        "completion_tokens": completion_tokens,
+        "total_tokens": total_tokens,
+        "endpoint": endpoint,
+        "request_id": request_id,
+        "meta": dict(meta) if meta else None,
+        "at": datetime.utcnow(),
+    }
+
+    async def _log() -> None:
+        try:
+            def _insert() -> None:
+                client.table("token_usage").insert(row).execute()
+
+            await asyncio.to_thread(_insert)
+        except Exception as exc:  # pragma: no cover - network logging failure
+            logging.warning("log_token_usage failed: %s", exc, exc_info=True)
+
+    asyncio.create_task(_log())
 
 
 # Run blocking Telegraph API calls with a timeout and simple retries
@@ -5858,10 +5918,25 @@ async def parse_event_via_4o(
         )
         raise
     usage = data_raw.get("usage") or {}
+    model_name = str(payload.get("model", "unknown"))
     _record_four_o_usage(
         "parse",
-        str(payload.get("model", "unknown")),
+        model_name,
         usage,
+    )
+    request_id = data_raw.get("id")
+    meta_payload = {
+        key: extra[key]
+        for key in ("feature", "version")
+        if extra.get(key) is not None
+    }
+    await log_token_usage(
+        BOT_CODE,
+        model_name,
+        usage,
+        endpoint="chat.completions",
+        request_id=request_id,
+        meta=meta_payload or None,
     )
     content = (
         data_raw.get("choices", [{}])[0]
@@ -6022,6 +6097,7 @@ async def ask_4o(
     response_format: dict | None = None,
     max_tokens: int = FOUR_O_RESPONSE_LIMIT,
     model: str | None = None,
+    meta: Mapping[str, Any] | None = None,
 ) -> str:
     token = os.getenv("FOUR_O_TOKEN")
     if not token:
@@ -6057,10 +6133,19 @@ async def ask_4o(
 
     data = await asyncio.wait_for(_call(), FOUR_O_TIMEOUT)
     usage = data.get("usage") or {}
+    model_name = str(payload.get("model", "unknown"))
     _record_four_o_usage(
         "ask",
-        str(payload.get("model", "unknown")),
+        model_name,
         usage,
+    )
+    await log_token_usage(
+        BOT_CODE,
+        model_name,
+        usage,
+        endpoint="chat.completions",
+        request_id=data.get("id"),
+        meta=meta,
     )
     logging.debug("4o response: %s", data)
     content = (

--- a/tests/test_bot.py
+++ b/tests/test_bot.py
@@ -1243,6 +1243,10 @@ async def test_ask4o_not_admin(tmp_path: Path, monkeypatch):
 @pytest.mark.asyncio
 async def test_parse_event_includes_date(monkeypatch):
     called = {}
+    calls: list[tuple] = []
+
+    async def fake_log(bot, model, usage, *, endpoint, request_id, meta=None):
+        calls.append((bot, model, usage, endpoint, request_id, meta))
 
     class DummySession:
         async def __aenter__(self):
@@ -1265,15 +1269,23 @@ async def test_parse_event_includes_date(monkeypatch):
 
     monkeypatch.setenv("FOUR_O_TOKEN", "x")
     monkeypatch.setattr("main.ClientSession", DummySession)
+    monkeypatch.setattr(main, "log_token_usage", fake_log)
 
     await parse_event_via_4o("text")
 
     assert "Today is" in called["payload"]["messages"][1]["content"]
+    assert calls == [
+        (main.BOT_CODE, "gpt-4o", {}, "chat.completions", None, None)
+    ]
 
 
 @pytest.mark.asyncio
 async def test_parse_event_includes_poster_hint(monkeypatch):
     called = {}
+    calls: list[tuple] = []
+
+    async def fake_log(bot, model, usage, *, endpoint, request_id, meta=None):
+        calls.append((bot, model, usage, endpoint, request_id, meta))
 
     class DummySession:
         async def __aenter__(self):
@@ -1296,6 +1308,7 @@ async def test_parse_event_includes_poster_hint(monkeypatch):
 
     monkeypatch.setenv("FOUR_O_TOKEN", "x")
     monkeypatch.setattr("main.ClientSession", DummySession)
+    monkeypatch.setattr(main, "log_token_usage", fake_log)
 
     await parse_event_via_4o("text", poster_texts=["Poster line"])
 
@@ -1305,6 +1318,9 @@ async def test_parse_event_includes_poster_hint(monkeypatch):
         in user_content
     )
     assert "Poster OCR:\n[1] Poster line" in user_content
+    assert calls == [
+        (main.BOT_CODE, "gpt-4o", {}, "chat.completions", None, None)
+    ]
 
 
 @pytest.mark.asyncio
@@ -2683,6 +2699,10 @@ async def test_forward_reports_ocr_usage(tmp_path: Path, monkeypatch):
 @pytest.mark.asyncio
 async def test_parse_event_alias_channel_title(monkeypatch):
     seen = {}
+    calls: list[tuple] = []
+
+    async def fake_log(bot, model, usage, *, endpoint, request_id, meta=None):
+        calls.append((bot, model, usage, endpoint, request_id, meta))
 
     class DummySession:
         async def __aenter__(self):
@@ -2705,10 +2725,14 @@ async def test_parse_event_alias_channel_title(monkeypatch):
 
     monkeypatch.setenv("FOUR_O_TOKEN", "x")
     monkeypatch.setattr("main.ClientSession", DummySession)
+    monkeypatch.setattr(main, "log_token_usage", fake_log)
 
     await main.parse_event_via_4o("t", channel_title="Name")
 
     assert "Name" in seen["payload"]["messages"][1]["content"]
+    assert calls == [
+        (main.BOT_CODE, "gpt-4o", {}, "chat.completions", None, None)
+    ]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- add a BOT_CODE environment default and asynchronous log_token_usage helper that stores OpenAI usage stats in Supabase
- capture chat completion request identifiers and usage data from parse_event_via_4o/ask_4o and forward them to the helper

## Testing
- pytest tests/test_ask_4o.py tests/test_bot.py::test_parse_event_includes_date tests/test_bot.py::test_parse_event_includes_poster_hint tests/test_bot.py::test_parse_event_alias_channel_title

------
https://chatgpt.com/codex/tasks/task_e_68e25abdb32c8332b12e02eefac7743d