### PR TITLE
Add usage test command for superadmins

### DIFF
--- a/main.py
+++ b/main.py
@@ -1582,6 +1582,7 @@ _four_o_usage_state = {
     "used": 0,
     "models": {model: 0 for model in FOUR_O_TRACKED_MODELS},
 }
+_last_ask_4o_request_id: str | None = None
 
 
 def _reset_four_o_usage_state(today: date) -> None:
@@ -1608,6 +1609,10 @@ def _get_four_o_usage_snapshot() -> dict[str, Any]:
         "used": _four_o_usage_state.get("used", 0),
         "models": models,
     }
+
+
+def get_last_ask_4o_request_id() -> str | None:
+    return _last_ask_4o_request_id
 
 
 def _record_four_o_usage(
@@ -6056,6 +6061,10 @@ async def ask_4o(
                 return await resp.json()
 
     data = await asyncio.wait_for(_call(), FOUR_O_TIMEOUT)
+    global _last_ask_4o_request_id
+    request_id = data.get("id")
+    if isinstance(request_id, str):
+        _last_ask_4o_request_id = request_id
     usage = data.get("usage") or {}
     _record_four_o_usage(
         "ask",
@@ -20006,6 +20015,71 @@ async def handle_mem(message: types.Message, db: Database, bot: Bot):
     await bot.send_message(message.chat.id, f"RSS: {rss / (1024**2):.1f} MB")
 
 
+async def handle_usage_test(message: types.Message, db: Database, bot: Bot):
+    async with db.get_session() as session:
+        user = await session.get(User, message.from_user.id)
+    if not user or not user.is_superadmin:
+        await bot.send_message(message.chat.id, "Not authorized")
+        return
+
+    model_name = "gpt-4o-mini"
+    try:
+        await ask_4o("usage probe", model=model_name)
+    except Exception as exc:  # pragma: no cover - network failure
+        logging.exception("usage_test ask_4o failed")
+        await bot.send_message(message.chat.id, f"ask_4o failed: {exc}")
+        return
+
+    request_id = get_last_ask_4o_request_id()
+    if not request_id:
+        await bot.send_message(message.chat.id, "No request ID returned")
+        return
+
+    client = get_supabase_client()
+    if client is None:
+        await bot.send_message(message.chat.id, "Supabase disabled")
+        return
+
+    try:
+        response = (
+            client.table("token_usage")
+            .select("prompt_tokens,completion_tokens,total_tokens")
+            .eq("request_id", request_id)
+            .order("created_at", desc=True)
+            .limit(1)
+            .execute()
+        )
+        records = getattr(response, "data", response)
+        row = (records or [{}])[0]
+        prompt_tokens = int(row.get("prompt_tokens") or 0)
+        completion_tokens = int(row.get("completion_tokens") or 0)
+        total_tokens = int(row.get("total_tokens") or (prompt_tokens + completion_tokens))
+    except Exception as exc:  # pragma: no cover - supabase failure
+        logging.exception("usage_test supabase query failed")
+        await bot.send_message(message.chat.id, f"Supabase query failed: {exc}")
+        return
+
+    bot_label = getattr(bot, "id", None)
+    if bot_label is None:
+        bot_label = bot.__class__.__name__
+    logging.info(
+        "usage_test trace bot=%s model=%s request_id=%s",
+        bot_label,
+        model_name,
+        request_id,
+    )
+
+    payload = {
+        "prompt": prompt_tokens,
+        "completion": completion_tokens,
+        "total": total_tokens,
+    }
+    await bot.send_message(
+        message.chat.id,
+        json.dumps(payload, ensure_ascii=False),
+    )
+
+
 async def handle_dumpdb(message: types.Message, db: Database, bot: Bot):
     async with db.get_session() as session:
         user = await session.get(User, message.from_user.id)
@@ -25025,6 +25099,9 @@ def create_app() -> web.Application:
     async def requests_wrapper(message: types.Message):
         await handle_requests(message, db, bot)
 
+    async def usage_test_wrapper(message: types.Message):
+        await handle_usage_test(message, db, bot)
+
     async def tz_wrapper(message: types.Message):
         await handle_tz(message, db, bot)
 
@@ -25368,6 +25445,7 @@ def create_app() -> web.Application:
     dp.message.register(start_wrapper, Command("start"))
     dp.message.register(register_wrapper, Command("register"))
     dp.message.register(requests_wrapper, Command("requests"))
+    dp.message.register(usage_test_wrapper, Command("usage_test"))
     dp.callback_query.register(
         callback_wrapper,
         lambda c: c.data.startswith("approve")

--- a/tests/test_bot.py
+++ b/tests/test_bot.py
@@ -5,6 +5,7 @@ sys.path.append(os.path.dirname(os.path.dirname(__file__)))
 from pathlib import Path
 
 import hashlib
+import json
 
 import pytest
 from aiogram import Bot, types
@@ -14,6 +15,7 @@ from datetime import date, timedelta, timezone, datetime, time
 from typing import Any
 import asyncio
 import time as _time
+from types import SimpleNamespace
 import main
 from telegraph.api import json_dumps
 from telegraph import TelegraphException
@@ -49,6 +51,7 @@ from main import (
     handle_exhibitions,
     handle_stats,
     handle_edit_message,
+    handle_usage_test,
     process_request,
     parse_event_via_4o,
     telegraph_test,
@@ -263,6 +266,92 @@ async def test_start_superadmin(tmp_path: Path):
     async with db.get_session() as session:
         user = await session.get(User, 1)
     assert user and user.is_superadmin
+
+
+@pytest.mark.asyncio
+async def test_usage_test_queries_supabase(tmp_path: Path, monkeypatch):
+    db = Database(str(tmp_path / "db.sqlite"))
+    await db.init()
+    bot = DummyBot("123:abc")
+
+    async with db.get_session() as session:
+        session.add(User(user_id=42, username="admin", is_superadmin=True))
+        await session.commit()
+
+    captured: dict[str, Any] = {}
+
+    async def fake_ask(prompt: str, **kwargs):
+        captured["prompt"] = prompt
+        captured["kwargs"] = kwargs
+        return "ok"
+
+    monkeypatch.setattr(main, "ask_4o", fake_ask)
+    monkeypatch.setattr(main, "get_last_ask_4o_request_id", lambda: "req-usage")
+
+    class FakeQuery:
+        def __init__(self, parent):
+            self.parent = parent
+            self.steps: list[tuple] = []
+
+        def select(self, fields):
+            self.steps.append(("select", fields))
+            return self
+
+        def eq(self, column, value):
+            self.steps.append(("eq", column, value))
+            return self
+
+        def order(self, column, desc=False):
+            self.steps.append(("order", column, desc))
+            return self
+
+        def limit(self, value):
+            self.steps.append(("limit", value))
+            return self
+
+        def execute(self):
+            self.parent.last_steps = list(self.steps)
+            return SimpleNamespace(
+                data=[
+                    {
+                        "prompt_tokens": 11,
+                        "completion_tokens": 5,
+                        "total_tokens": 16,
+                    }
+                ]
+            )
+
+    class FakeSupabase:
+        def __init__(self):
+            self.tables: list[str] = []
+            self.last_steps: list[tuple] = []
+
+        def table(self, name: str):
+            self.tables.append(name)
+            return FakeQuery(self)
+
+    fake_client = FakeSupabase()
+    monkeypatch.setattr(main, "get_supabase_client", lambda: fake_client)
+
+    msg = types.Message.model_validate(
+        {
+            "message_id": 1,
+            "date": 0,
+            "chat": {"id": 42, "type": "private"},
+            "from": {"id": 42, "is_bot": False, "first_name": "Admin"},
+            "text": "/usage_test",
+        }
+    )
+
+    await handle_usage_test(msg, db, bot)
+
+    assert captured["kwargs"]["model"] == "gpt-4o-mini"
+    assert fake_client.tables == ["token_usage"]
+    assert ("eq", "request_id", "req-usage") in fake_client.last_steps
+
+    assert bot.messages, "admin should receive usage summary"
+    payload = json.loads(bot.messages[-1][1])
+    assert payload == {"prompt": 11, "completion": 5, "total": 16}
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- capture the last ask_4o request id for traceability
- add a /usage_test superadmin command that verifies Supabase token usage logging
- cover the new command with a regression test that stubs OpenAI and Supabase

## Testing
- pytest tests/test_bot.py::test_usage_test_queries_supabase

------
https://chatgpt.com/codex/tasks/task_e_68e25b176acc8332892777867fd37a06