### PR TITLE
Prepare changelog for v0.3.16 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 
 ## [Unreleased]
+
+- _No unreleased changes._
+
+## v0.3.16 – 2025-10-05
 - Telegraph event source pages now include a “Быстрые факты” block with date/time, location, and ticket/free status, hiding each line when the underlying data is missing so operators know it’s conditional.
 - Системный промпт автоклассификации запрещает выбирать темы `FAMILY` и `KIDS_SCHOOL`, когда у события задан возрастной ценз; см. обновления в `main.py` (`EVENT_TOPIC_SYSTEM_PROMPT`) и документации `docs/llm_topics.md`.
 - Уведомления в админ-чат для партнёров теперь включают первую фотографию события и ссылки на Telegraph и исходный VK-пост, чтобы операторы могли оперативно проверить публикацию.


### PR DESCRIPTION
## Summary
- add a v0.3.16 section dated 2025-10-05 and move the previous unreleased entries into it
- leave an unreleased placeholder noting that no pending changes remain

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e25e83e5848332be2f0b93aef9a71c