### PR TITLE
Refine phone-tail handling for action verbs

### DIFF
--- a/tests/test_vk_intake_keywords_dates.py
+++ b/tests/test_vk_intake_keywords_dates.py
@@ -213,6 +213,12 @@ def test_extract_event_ts_hint_phone_block_with_guidance_tail():
     assert extract_event_ts_hint(text, publish_ts=publish_dt) is None
 
 
+def test_extract_event_ts_hint_phone_block_with_action_only():
+    publish_dt = real_datetime(2024, 10, 1, tzinfo=main.LOCAL_TZ)
+    text = "Телефон: 27-01-26 — встречаемся"
+    assert extract_event_ts_hint(text, publish_ts=publish_dt) is None
+
+
 def test_extract_event_ts_hint_phone_block_then_real_date():
     publish_dt = real_datetime(2024, 10, 1, tzinfo=main.LOCAL_TZ)
     text = "Телефон: 27-01-26 — 29-03-44, встречаемся 20-10-24"
@@ -225,6 +231,15 @@ def test_extract_event_ts_hint_phone_block_then_real_date():
 def test_extract_event_ts_hint_phone_guidance_then_text_date():
     publish_dt = real_datetime(2024, 10, 1, tzinfo=main.LOCAL_TZ)
     text = "Телефон: 27-01-26 — концерт 20-10-24"
+    ts = extract_event_ts_hint(text, publish_ts=publish_dt)
+    assert ts is not None
+    dt = real_datetime.fromtimestamp(ts, tz=main.LOCAL_TZ)
+    assert (dt.year, dt.month, dt.day) == (2024, 10, 20)
+
+
+def test_extract_event_ts_hint_phone_action_then_text_date():
+    publish_dt = real_datetime(2024, 10, 1, tzinfo=main.LOCAL_TZ)
+    text = "Телефон: 27-01-26 — встречаемся 20-10-24"
     ts = extract_event_ts_hint(text, publish_ts=publish_dt)
     assert ts is not None
     dt = real_datetime.fromtimestamp(ts, tz=main.LOCAL_TZ)


### PR DESCRIPTION
## Summary
- require phone-like matches followed by action verbs to skip unless the action tail includes a real date/time and continue scanning to the next date candidate
- relax the phone-context filter so that phone-prefixed posts can still surface the actual event date when descriptive text follows
- add regressions around "Телефон" cases to ensure phone numbers without a trailing date are ignored

## Testing
- pytest tests/test_vk_intake_keywords_dates.py

------
https://chatgpt.com/codex/tasks/task_e_68e25c4a6c3c8332bc1ff54ac8343054