### PR TITLE
Handle address tails in phone-like date filtering

### DIFF
--- a/tests/test_vk_intake_keywords_dates.py
+++ b/tests/test_vk_intake_keywords_dates.py
@@ -225,6 +225,12 @@ def test_extract_event_ts_hint_phone_then_location_only():
     assert extract_event_ts_hint(text, publish_ts=publish_dt) is None
 
 
+def test_extract_event_ts_hint_phone_then_address_without_date():
+    publish_dt = real_datetime(2024, 10, 1, tzinfo=main.LOCAL_TZ)
+    text = "Телефон: 27-01-26 — ул. Ленина, 5"
+    assert extract_event_ts_hint(text, publish_ts=publish_dt) is None
+
+
 def test_extract_event_ts_hint_phone_then_location_and_date():
     publish_dt = real_datetime(2024, 10, 1, tzinfo=main.LOCAL_TZ)
     text = "Телефон: 27-01-26 — в клубе концерт 20-10-24"
@@ -255,6 +261,15 @@ def test_extract_event_ts_hint_phone_guidance_then_text_date():
 def test_extract_event_ts_hint_phone_action_then_text_date():
     publish_dt = real_datetime(2024, 10, 1, tzinfo=main.LOCAL_TZ)
     text = "Телефон: 27-01-26 — встречаемся 20-10-24"
+    ts = extract_event_ts_hint(text, publish_ts=publish_dt)
+    assert ts is not None
+    dt = real_datetime.fromtimestamp(ts, tz=main.LOCAL_TZ)
+    assert (dt.year, dt.month, dt.day) == (2024, 10, 20)
+
+
+def test_extract_event_ts_hint_phone_address_then_text_date():
+    publish_dt = real_datetime(2024, 10, 1, tzinfo=main.LOCAL_TZ)
+    text = "Телефон: 27-01-26 — ул. Ленина, 5, встречаемся 20-10-24"
     ts = extract_event_ts_hint(text, publish_ts=publish_dt)
     assert ts is not None
     dt = real_datetime.fromtimestamp(ts, tz=main.LOCAL_TZ)

--- a/vk_intake.py
+++ b/vk_intake.py
@@ -485,8 +485,16 @@ def extract_event_ts_hint(
                             )
                             if _tail_has_datetime(after_location):
                                 skip_due_to_location_tail = True
-                        elif next_alpha_word and next_alpha_word.startswith(EVENT_ADDRESS_PREFIXES):
-                            has_event_tail = True
+                        elif next_alpha_word and next_alpha_word.startswith(
+                            EVENT_ADDRESS_PREFIXES
+                        ):
+                            address_tail = remainder[len(next_alpha_word) :]
+                            address_tail = address_tail.lstrip(
+                                " \t\r\n.;:!?()[]{}«»\"'—–-"
+                            )
+                            if _tail_has_datetime(address_tail):
+                                has_event_tail = True
+                                skip_due_to_location_tail = True
                         else:
                             loc_match = re.match(r"(?:в|на)\s+([a-zа-яё.]+)", remainder)
                             if loc_match:


### PR DESCRIPTION
## Summary
- ensure address prefixes following phone-like sequences only disable filtering when a real date or time follows
- add regression coverage for address tails without dates and with explicit event dates

## Testing
- pytest tests/test_vk_intake_keywords_dates.py

------
https://chatgpt.com/codex/tasks/task_e_68e268d168348332a5e9229c2866cbf0