### PR TITLE
Handle city code phone tails when extracting event dates

### DIFF
--- a/tests/test_vk_intake_keywords_dates.py
+++ b/tests/test_vk_intake_keywords_dates.py
@@ -225,6 +225,12 @@ def test_extract_event_ts_hint_phone_then_location_only():
     assert extract_event_ts_hint(text, publish_ts=publish_dt) is None
 
 
+def test_extract_event_ts_hint_city_code_with_location_tail():
+    publish_dt = real_datetime(2024, 10, 1, tzinfo=main.LOCAL_TZ)
+    text = "Запись по телефону 8 (4012) 27-01-26 — в клубе «Мечта»"
+    assert extract_event_ts_hint(text, publish_ts=publish_dt) is None
+
+
 def test_extract_event_ts_hint_phone_then_address_without_date():
     publish_dt = real_datetime(2024, 10, 1, tzinfo=main.LOCAL_TZ)
     text = "Телефон: 27-01-26 — ул. Ленина, 5"

--- a/vk_intake.py
+++ b/vk_intake.py
@@ -551,7 +551,8 @@ def extract_event_ts_hint(
                             and re.search(r"[a-zа-яё]", remainder)
                             and not re.search(r"\d", remainder)
                         ):
-                            break
+                            skip_candidate = True
+                            continue
                         compact = trimmed.replace(" ", "")
                         compact = re.sub(r"^[.,:;-–—]+", "", compact)
                         if not compact or re.fullmatch(r"[\d()+\-–—]*", compact):


### PR DESCRIPTION
## Summary
- ensure phone number segments that end in a city code followed by text do not stop date scanning in extract_event_ts_hint
- add regression coverage for city-code phone entries without dates

## Testing
- pytest tests/test_vk_intake_keywords_dates.py -k city_code

------
https://chatgpt.com/codex/tasks/task_e_68e26f377bac833295a0a856ae3572bb