### PR TITLE
Normalize phone-like fragments before extracting VK dates

### DIFF
--- a/tests/test_vk_intake_keywords_dates.py
+++ b/tests/test_vk_intake_keywords_dates.py
@@ -201,6 +201,12 @@ def test_extract_event_ts_hint_phone_like_sequence_only():
     assert extract_event_ts_hint(text, publish_ts=publish_dt) is None
 
 
+def test_extract_event_ts_hint_raw_city_phone_only():
+    publish_dt = real_datetime(2024, 4, 1, tzinfo=main.LOCAL_TZ)
+    text = "8 (4012) 27-01-26"
+    assert extract_event_ts_hint(text, publish_ts=publish_dt) is None
+
+
 def test_extract_event_ts_hint_phone_block_with_dash():
     publish_dt = real_datetime(2024, 4, 1, tzinfo=main.LOCAL_TZ)
     text = "Телефон: 27-01-26 — 29-03-44"
@@ -338,6 +344,15 @@ def test_extract_event_ts_hint_weekday_uses_publish_week(monkeypatch):
     assert ts is not None
     dt = real_datetime.fromtimestamp(ts, tz=main.LOCAL_TZ)
     assert (dt.year, dt.month, dt.day) == (2024, 5, 8)
+
+
+def test_extract_event_ts_hint_numeric_date_survives_phone_normalization():
+    publish_dt = real_datetime(2024, 10, 1, tzinfo=main.LOCAL_TZ)
+    text = "20-10-24 собираемся"
+    ts = extract_event_ts_hint(text, publish_ts=publish_dt)
+    assert ts is not None
+    dt = real_datetime.fromtimestamp(ts, tz=main.LOCAL_TZ)
+    assert (dt.year, dt.month, dt.day) == (2024, 10, 20)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- add phone candidate normalization to strip separators while keeping valid calendar dates intact
- update extract_event_ts_hint to use the normalized text and ensure plain phone strings no longer resemble dates
- extend date-related tests with new phone scenarios and a regression that keeps numeric dates discoverable

## Testing
- pytest tests/test_vk_intake_keywords_dates.py

------
https://chatgpt.com/codex/tasks/task_e_68e274b47020833288cbbb526db08214