### PR TITLE
Use ISO timestamp for token usage logging

### DIFF
--- a/main.py
+++ b/main.py
@@ -1745,7 +1745,7 @@ async def log_token_usage(
         "endpoint": endpoint,
         "request_id": request_id,
         "meta": dict(meta) if meta else None,
-        "at": datetime.utcnow(),
+        "at": datetime.now(timezone.utc).isoformat(),
     }
 
     logging.debug(


### PR DESCRIPTION
## Summary
- convert the `log_token_usage` timestamp to an ISO 8601 UTC string so Supabase accepts the value

## Testing
- pytest tests/test_ask_4o.py

------
https://chatgpt.com/codex/tasks/task_e_68e29cbf54bc8332bff4c14b987796d3