### PR TITLE
Ensure token usage meta defaults to object

### DIFF
--- a/main.py
+++ b/main.py
@@ -1744,7 +1744,7 @@ async def log_token_usage(
         "total_tokens": total_tokens,
         "endpoint": endpoint,
         "request_id": request_id,
-        "meta": dict(meta) if meta else None,
+        "meta": dict(meta) if meta else {},
         "at": datetime.now(timezone.utc).isoformat(),
     }
 

--- a/tests/test_ask_4o.py
+++ b/tests/test_ask_4o.py
@@ -49,7 +49,7 @@ async def test_ask_4o_keeps_long_response(monkeypatch):
     calls: list[tuple] = []
 
     async def fake_log(bot, model, usage, *, endpoint, request_id, meta=None):
-        calls.append((bot, model, usage, endpoint, request_id, meta))
+        calls.append((bot, model, usage, endpoint, request_id, {} if meta is None else meta))
 
     monkeypatch.setattr(main, "log_token_usage", fake_log)
 
@@ -65,6 +65,6 @@ async def test_ask_4o_keeps_long_response(monkeypatch):
             payload["usage"],
             "chat.completions",
             payload["id"],
-            None,
+            {},
         )
     ]

--- a/tests/test_bot.py
+++ b/tests/test_bot.py
@@ -1353,7 +1353,7 @@ async def test_parse_event_includes_date(monkeypatch):
     calls: list[tuple] = []
 
     async def fake_log(bot, model, usage, *, endpoint, request_id, meta=None):
-        calls.append((bot, model, usage, endpoint, request_id, meta))
+        calls.append((bot, model, usage, endpoint, request_id, {} if meta is None else meta))
 
     class DummySession:
         async def __aenter__(self):
@@ -1382,7 +1382,7 @@ async def test_parse_event_includes_date(monkeypatch):
 
     assert "Today is" in called["payload"]["messages"][1]["content"]
     assert calls == [
-        (main.BOT_CODE, "gpt-4o", {}, "chat.completions", None, None)
+        (main.BOT_CODE, "gpt-4o", {}, "chat.completions", None, {})
     ]
 
 
@@ -1392,7 +1392,7 @@ async def test_parse_event_includes_poster_hint(monkeypatch):
     calls: list[tuple] = []
 
     async def fake_log(bot, model, usage, *, endpoint, request_id, meta=None):
-        calls.append((bot, model, usage, endpoint, request_id, meta))
+        calls.append((bot, model, usage, endpoint, request_id, {} if meta is None else meta))
 
     class DummySession:
         async def __aenter__(self):
@@ -1426,7 +1426,7 @@ async def test_parse_event_includes_poster_hint(monkeypatch):
     )
     assert "Poster OCR:\n[1] Poster line" in user_content
     assert calls == [
-        (main.BOT_CODE, "gpt-4o", {}, "chat.completions", None, None)
+        (main.BOT_CODE, "gpt-4o", {}, "chat.completions", None, {})
     ]
 
 
@@ -2809,7 +2809,7 @@ async def test_parse_event_alias_channel_title(monkeypatch):
     calls: list[tuple] = []
 
     async def fake_log(bot, model, usage, *, endpoint, request_id, meta=None):
-        calls.append((bot, model, usage, endpoint, request_id, meta))
+        calls.append((bot, model, usage, endpoint, request_id, {} if meta is None else meta))
 
     class DummySession:
         async def __aenter__(self):
@@ -2838,7 +2838,7 @@ async def test_parse_event_alias_channel_title(monkeypatch):
 
     assert "Name" in seen["payload"]["messages"][1]["content"]
     assert calls == [
-        (main.BOT_CODE, "gpt-4o", {}, "chat.completions", None, None)
+        (main.BOT_CODE, "gpt-4o", {}, "chat.completions", None, {})
     ]
 
 


### PR DESCRIPTION
## Summary
- ensure `log_token_usage` always serialises `meta` to an object so Supabase NOT NULL constraints are satisfied
- update tests that inspect token usage logging to expect `{}` metadata and mimic the conversion in fakes

## Testing
- pytest tests/test_ask_4o.py::test_ask_4o_keeps_long_response tests/test_bot.py::test_parse_event_includes_date tests/test_bot.py::test_parse_event_includes_poster_hint tests/test_bot.py::test_parse_event_alias_channel_title

------
https://chatgpt.com/codex/tasks/task_e_68e2a9c602508332bf59372f1956e2e4