### PR TITLE
Add holiday metadata to base prompt

### DIFF
--- a/docs/FOUR_O_REQUEST.md
+++ b/docs/FOUR_O_REQUEST.md
@@ -26,6 +26,12 @@ If `docs/LOCATIONS.md` exists, its lines are appended to the system prompt as a
 list of known venues. This helps the model normalise `location_name` to a
 standard form.
 
+If `docs/HOLIDAYS.md` exists, a "Known holidays" list is appended with the
+canonical names of seasonal festivals, their alias hints and short
+descriptions. The model should rely on these entries when filling the
+`festival` field so that holiday-related events converge on the same canonical
+records even when the source text uses synonyms.
+
 When the database stores festival metadata, the system prompt receives an extra
 JSON payload with canonical `festival_names` and normalised
 `festival_alias_pairs`. Each pair is `[alias_norm, festival_index]` where

--- a/docs/PROMPTS.md
+++ b/docs/PROMPTS.md
@@ -43,6 +43,11 @@ The bot adds these markers automatically on the opening and closing dates.
 Lines from `docs/LOCATIONS.md` are appended to the system prompt so the model
 can normalise venue names. Please keep that file up to date.
 
+When `docs/HOLIDAYS.md` is present, the prompt gains a "Known holidays" section
+listing canonical seasonal festivals together with their alias hints and short
+descriptions. Treat these names as the preferred targets for the `festival`
+field and use the hints to match synonym spellings in announcements.
+
 When the database exposes festival metadata, the prompt also appends a compact
 JSON block with `{"festival_names": [...], "festival_alias_pairs": [["alias_norm", index], ...]}`.
 The system instructions explain how to compute `norm(text)` (casefold, trim,

--- a/main.py
+++ b/main.py
@@ -16,6 +16,8 @@ import tempfile
 import calendar
 import math
 from collections import Counter
+from dataclasses import dataclass
+from types import MappingProxyType
 
 
 class DeduplicateFilter(logging.Filter):
@@ -5812,6 +5814,83 @@ async def tg_ics_post(event_id: int, db: Database, bot: Bot, progress=None) -> b
 
         return True
 
+@dataclass(frozen=True)
+class HolidayRecord:
+    date: str
+    canonical_name: str
+    aliases: tuple[str, ...]
+    description: str
+
+
+@lru_cache(maxsize=1)
+def _read_holidays() -> tuple[tuple[HolidayRecord, ...], tuple[str, ...], Mapping[str, str]]:
+    path = os.path.join("docs", "HOLIDAYS.md")
+    if not os.path.exists(path):
+        return (), (), {}
+
+    holidays: list[HolidayRecord] = []
+    canonical_names: list[str] = []
+    alias_map: dict[str, str] = {}
+
+    with open(path, "r", encoding="utf-8") as f:
+        for raw_line in f:
+            if "|" not in raw_line:
+                continue
+            line = raw_line.strip()
+            if not line or line.startswith("#"):
+                continue
+
+            parts = [part.strip() for part in raw_line.split("|")]
+            if len(parts) < 3:
+                continue
+
+            date_token = parts[0]
+            canonical_name = parts[1]
+            if not canonical_name:
+                continue
+
+            if len(parts) == 3:
+                alias_field = ""
+                description_field = parts[2]
+            else:
+                alias_field = parts[2]
+                description_field = "|".join(parts[3:]).strip()
+
+            aliases = tuple(
+                alias.strip()
+                for alias in alias_field.split(",")
+                if alias.strip()
+            )
+            description = description_field.strip()
+
+            record = HolidayRecord(
+                date=date_token,
+                canonical_name=canonical_name,
+                aliases=aliases,
+                description=description,
+            )
+            holidays.append(record)
+            canonical_names.append(canonical_name)
+
+            canonical_norm = normalize_alias(canonical_name)
+            if canonical_norm:
+                alias_map[canonical_norm] = canonical_name
+            for alias in aliases:
+                alias_norm = normalize_alias(alias)
+                if alias_norm:
+                    alias_map[alias_norm] = canonical_name
+
+    return tuple(holidays), tuple(canonical_names), MappingProxyType(alias_map)
+
+
+def _holiday_canonical_names() -> tuple[str, ...]:
+    return _read_holidays()[1]
+
+
+def _holiday_alias_map() -> Mapping[str, str]:
+    return _read_holidays()[2]
+
+
 @lru_cache(maxsize=1)
 def _read_base_prompt() -> str:
     prompt_path = os.path.join("docs", "PROMPTS.md")
@@ -5825,6 +5904,18 @@ def _read_base_prompt() -> str:
             ]
         if locations:
             prompt += "\nKnown venues:\n" + "\n".join(locations)
+
+    holidays, _, _ = _read_holidays()
+    if holidays:
+        entries = []
+        for holiday in holidays:
+            alias_hint = (
+                f" (aliases: {', '.join(holiday.aliases)})" if holiday.aliases else ""
+            )
+            entries.append(
+                f"- {holiday.canonical_name}{alias_hint} — {holiday.description}"
+            )
+        prompt += "\nKnown holidays:\n" + "\n".join(entries)
     return prompt
 
 

--- a/tests/test_prompt_json.py
+++ b/tests/test_prompt_json.py
@@ -48,3 +48,14 @@ def test_aliases_bypass_cache_layer():
     ])
     data_updated = _extract_prompt_json(prompt_updated)
     assert data_updated["festival_alias_pairs"] == [["new-alias", 0]]
+
+
+def test_base_prompt_includes_known_holidays():
+    main._read_base_prompt.cache_clear()
+    main._read_holidays.cache_clear()
+    prompt = main._read_base_prompt()
+    assert "Known holidays:" in prompt
+    assert (
+        "- Хеллоуин (aliases: хэллоуин, halloween) — Костюмированное празднование с тыквами и сладостями."
+        in prompt
+    )


### PR DESCRIPTION
## Summary
- parse docs/HOLIDAYS.md into cached holiday records with canonical names and alias map
- extend the base prompt with a Known holidays section and document the behaviour
- cover the new prompt behaviour with a unit test

## Testing
- pytest tests/test_prompt_json.py

------
https://chatgpt.com/codex/tasks/task_e_68e38f33704c8332b31a384e95b90b10