### PR TITLE
Handle festival full name fallback in VK review import

### DIFF
--- a/main.py
+++ b/main.py
@@ -22801,7 +22801,9 @@ async def _vkrev_import_flow(
     if isinstance(festival_info_raw, dict):
         fest_data = festival_info_raw
         fest_name = clean_optional_str(
-            fest_data.get("name") or fest_data.get("festival")
+            fest_data.get("name")
+            or fest_data.get("festival")
+            or fest_data.get("full_name")
         )
     else:
         fest_name = None


### PR DESCRIPTION
## Summary
- fall back to the festival full name when force-importing vk review posts
- add a regression test that ensures the fallback prevents the forced-festival error

## Testing
- pytest tests/test_vkrev_import_flow.py -k full_name

------
https://chatgpt.com/codex/tasks/task_e_68e3cf43006c8332acadba8d40585c0a