### PR TITLE
Handle editor instructions in VK story review

### DIFF
--- a/tests/test_story_pitch.py
+++ b/tests/test_story_pitch.py
@@ -8,6 +8,12 @@ def test_four_o_pitch_prompt_contains_new_guidance():
     assert "любопыт" in prompt
     assert "гипербол" in prompt
     assert "эмодзи" in prompt
+    assert "огранич" in prompt
+
+
+def test_four_o_editor_prompt_mentions_constraints():
+    prompt = main.FOUR_O_EDITOR_PROMPT
+    assert "инструкц" in prompt
 
 
 @pytest.mark.asyncio
@@ -34,3 +40,43 @@ async def test_compose_story_pitch_via_4o_fallback_on_empty(monkeypatch):
     result = await main.compose_story_pitch_via_4o(text)
 
     assert result == "Лидовая строка"
+
+
+@pytest.mark.asyncio
+async def test_compose_story_pitch_via_4o_includes_instructions(monkeypatch):
+    captured: dict[str, str] = {}
+
+    async def fake_ask(prompt_text, *, system_prompt=None, max_tokens=None, **_kwargs):
+        captured["prompt"] = prompt_text
+        return "Готовый ответ"
+
+    monkeypatch.setattr(main, "ask_4o", fake_ask)
+
+    result = await main.compose_story_pitch_via_4o(
+        "Первый абзац", instructions="Не использовать эмодзи"
+    )
+
+    assert result == "Готовый ответ"
+    prompt = captured["prompt"]
+    assert "Дополнительные инструкции редактору" in prompt
+    assert "Не использовать эмодзи" in prompt
+
+
+@pytest.mark.asyncio
+async def test_compose_story_editorial_via_4o_includes_instructions(monkeypatch):
+    captured: dict[str, str] = {}
+
+    async def fake_ask(prompt_text, *, system_prompt=None, max_tokens=None, **_kwargs):
+        captured["prompt"] = prompt_text
+        return "<p>Текст</p>"
+
+    monkeypatch.setattr(main, "ask_4o", fake_ask)
+
+    result = await main.compose_story_editorial_via_4o(
+        "История", instructions="Оставить теги <b>"
+    )
+
+    assert result == "<p>Текст</p>"
+    prompt = captured["prompt"]
+    assert "Дополнительные инструкции редактору" in prompt
+    assert "Оставить теги <b>" in prompt


### PR DESCRIPTION
## Summary
- prompt VK story reviewers for optional editor guidance, store their response, and reuse it when generating placement options
- update story pitch/editorial prompts to include operator instructions and ensure 4o requests honour the extra constraints
- extend automated coverage for the new guidance flow and prompt formatting

## Testing
- pytest tests/test_story_pitch.py tests/test_source_images.py


------
https://chatgpt.com/codex/tasks/task_e_68e3eba5bcdc8332accd08a15935e502