### PR TITLE
Include history keyword when combined with other matches

### DIFF
--- a/vk_intake.py
+++ b/vk_intake.py
@@ -1745,7 +1745,15 @@ async def crawl_once(
                         )
                         if event_ts_hint is None or event_ts_hint < int(time.time()) + 2 * 3600:
                             continue
-                        matched_kw_value = ",".join(kws)
+                        seen_kws: set[str] = set()
+                        matched_kw_list: list[str] = []
+                        for kw in kws:
+                            if kw not in seen_kws:
+                                matched_kw_list.append(kw)
+                                seen_kws.add(kw)
+                        if history_hit and HISTORY_MATCHED_KEYWORD not in seen_kws:
+                            matched_kw_list.append(HISTORY_MATCHED_KEYWORD)
+                        matched_kw_value = ",".join(matched_kw_list)
                         has_date_value = int(has_date)
                     elif history_hit:
                         matched_kw_value = HISTORY_MATCHED_KEYWORD


### PR DESCRIPTION
## Summary
- append the history marker to matched keywords when both event triggers and a historical hit are present, avoiding duplicates
- add a regression test ensuring combined matches store both the detected keyword and the history flag

## Testing
- pytest tests/test_vk_intake_history.py

------
https://chatgpt.com/codex/tasks/task_e_68e3f38a97cc8332b1a79826c136bce4