### PR TITLE
Add unique constraint to vk_misses_sample

### DIFF
--- a/alembic/versions/20250909_vk_misses_unique_constraint.py
+++ b/alembic/versions/20250909_vk_misses_unique_constraint.py
@@ -1,0 +1,28 @@
+"""add unique constraint to vk_misses_sample"""
+
+from __future__ import annotations
+
+from typing import Sequence, Union
+
+from alembic import op
+
+
+revision: str = "20250909_vk_misses_unique_constraint"
+down_revision: Union[str, None] = "20250908_festival_created_at"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.execute(
+        "ALTER TABLE vk_misses_sample "
+        "ADD CONSTRAINT IF NOT EXISTS uniq_vk_miss "
+        "UNIQUE (group_id, post_id)"
+    )
+
+
+def downgrade() -> None:
+    op.execute(
+        "ALTER TABLE vk_misses_sample "
+        "DROP CONSTRAINT IF EXISTS uniq_vk_miss"
+    )


### PR DESCRIPTION
## Summary
- add a new Alembic migration that ensures `vk_misses_sample` has a unique constraint on `(group_id, post_id)`
- include a downgrade path that removes the constraint if present

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e43849e5008332bd6f914af5e9a5db