### PR TITLE
Adjust Supabase export defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -350,7 +350,7 @@ line, and each line disappears when the source data is missing so operators imme
 The project uses `telegraph>=2.2.0`. `create_page` returns the page `url` and `path`;
 only `edit_page(path=...)` accepts a `path` argument when updating existing pages.
 Editing an event lets you create or delete an ICS file for calendars. The file is uploaded to Supabase when `SUPABASE_URL` and `SUPABASE_KEY` are set. Files are named `Event-<id>-dd-mm-yyyy.ics` and include a link back to the event. Set `SUPABASE_BUCKET` if you use a bucket name other than `events-ics`.
-Set `SUPABASE_EXPORT_ENABLED=1` to push VK crawl telemetry (group metadata, post snapshots, sampled misses) into Supabase. Snapshots older than `SUPABASE_RETENTION_DAYS` (default: 30) are purged automatically. Tune `VK_MISSES_SAMPLE_RATE` (default: 0.1) to control what fraction of rejected posts are exported for analysis.
+Supabase export is enabled by default; set `SUPABASE_EXPORT_ENABLED=0` to disable pushing VK crawl telemetry (group metadata, post snapshots, sampled misses) into Supabase. Snapshots older than `SUPABASE_RETENTION_DAYS` (default: 60) are purged automatically. Tune `VK_MISSES_SAMPLE_RATE` (default: 0.1) to control what fraction of rejected posts are exported for analysis.
 When a calendar file exists the Telegraph page shows a link right under the title image: "📅 Добавить в календарь".
 Events may note support for the Пушкинская карта, shown as a separate line in postings.
 Run `/exhibitions` to see all ongoing exhibitions (events with a start and end date).

--- a/supabase_export.py
+++ b/supabase_export.py
@@ -10,13 +10,13 @@ from typing import Any, Callable, Mapping, Sequence
 
 logger = logging.getLogger(__name__)
 
-_DEFAULT_RETENTION_DAYS = 30
+_DEFAULT_RETENTION_DAYS = 60
 _DEFAULT_MISS_SAMPLE_RATE = 0.1
 
 
-def _parse_bool(value: str | None) -> bool:
+def _parse_bool(value: str | None, *, default: bool = False) -> bool:
     if value is None:
-        return False
+        return default
     value = value.strip().lower()
     return value in {"1", "true", "yes", "on"}
 
@@ -60,7 +60,9 @@ class SBExporter:
     def __init__(self, client_factory: Callable[[], Any]) -> None:
         self._client_factory = client_factory
         self._client: Any | None = None
-        self._enabled = _parse_bool(os.getenv("SUPABASE_EXPORT_ENABLED"))
+        self._enabled = _parse_bool(
+            os.getenv("SUPABASE_EXPORT_ENABLED"), default=True
+        )
         self._retention_days = _parse_int(
             os.getenv("SUPABASE_RETENTION_DAYS"), _DEFAULT_RETENTION_DAYS
         )

--- a/tests/test_supabase_export.py
+++ b/tests/test_supabase_export.py
@@ -1,0 +1,26 @@
+from supabase_export import SBExporter
+
+
+def _clear_env(monkeypatch):
+    monkeypatch.delenv("SUPABASE_EXPORT_ENABLED", raising=False)
+    monkeypatch.delenv("SUPABASE_RETENTION_DAYS", raising=False)
+    monkeypatch.delenv("VK_MISSES_SAMPLE_RATE", raising=False)
+
+
+def test_supabase_export_defaults_enabled(monkeypatch):
+    _clear_env(monkeypatch)
+
+    exporter = SBExporter(lambda: object())
+
+    assert exporter.enabled is True
+    assert exporter._retention_days == 60
+    assert exporter._miss_sample_rate == 0.1
+
+
+def test_supabase_export_disable_via_env(monkeypatch):
+    _clear_env(monkeypatch)
+    monkeypatch.setenv("SUPABASE_EXPORT_ENABLED", "0")
+
+    exporter = SBExporter(lambda: object())
+
+    assert exporter.enabled is False


### PR DESCRIPTION
## Summary
- enable Supabase export by default and increase retention to 60 days
- document the new defaults and cover them with unit tests

## Testing
- pytest tests/test_supabase_export.py

------
https://chatgpt.com/codex/tasks/task_e_68e43e6d2fec8332b32ef03931bcbc15