### PR TITLE
Document Supabase export tables and retention

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 
+- VK crawler telemetry now exports group metadata, crawl snapshots, and sampled misses to Supabase (`vk_groups`, `vk_crawl_snapshots`, `vk_misses_sample`) with `SUPABASE_EXPORT_ENABLED`, `SUPABASE_RETENTION_DAYS` (default 60 days), and `VK_MISSES_SAMPLE_RATE` governing exports, sampling, and automatic cleanup.
 - VK stories now ask whether to collect extra editor instructions and forward the answer plus any guidance to the 4o prompts.
 - Добавлен справочник сезонных праздников (`docs/HOLIDAYS.md`), промпт 4o теперь перечисляет их с алиасами и описаниями, а импорт событий автоматически создаёт и переиспользует соответствующие фестивали.
 - Log OpenAI token usage through Supabase inserts (guarded by `BOT_CODE`) and ship the `/usage_test` admin self-test so operators can verify the inserts and share usage snapshots during release comms.

--- a/README.md
+++ b/README.md
@@ -350,7 +350,9 @@ line, and each line disappears when the source data is missing so operators imme
 The project uses `telegraph>=2.2.0`. `create_page` returns the page `url` and `path`;
 only `edit_page(path=...)` accepts a `path` argument when updating existing pages.
 Editing an event lets you create or delete an ICS file for calendars. The file is uploaded to Supabase when `SUPABASE_URL` and `SUPABASE_KEY` are set. Files are named `Event-<id>-dd-mm-yyyy.ics` and include a link back to the event. Set `SUPABASE_BUCKET` if you use a bucket name other than `events-ics`.
-Supabase export is enabled by default; set `SUPABASE_EXPORT_ENABLED=0` to disable pushing VK crawl telemetry (group metadata, post snapshots, sampled misses) into Supabase. Snapshots older than `SUPABASE_RETENTION_DAYS` (default: 60) are purged automatically. Tune `VK_MISSES_SAMPLE_RATE` (default: 0.1) to control what fraction of rejected posts are exported for analysis.
+Supabase export is enabled by default; set `SUPABASE_EXPORT_ENABLED=0` to disable pushing VK crawl telemetry into Supabase. The exporter writes group metadata to `vk_groups`, stores per-run counters in `vk_crawl_snapshots`, and upserts sampled misses in `vk_misses_sample`. The 60-day retention window (`SUPABASE_RETENTION_DAYS`, default: 60) deletes snapshots and miss samples older than the cutoff on each run.
+
+Miss logging always inserts rows when keyword detection and date parsing disagree (`kw_ok XOR has_date`); other misses follow probabilistic sampling controlled by `VK_MISSES_SAMPLE_RATE` (default: 0.1). Post bodies are never uploaded—only IDs, URLs, timestamps, counters, and match metadata—so sensitive text stays in VK. Operators can confirm that inserts flow through by querying the Supabase dashboards documented in [`docs/COMMANDS.md`](docs/COMMANDS.md) via `/usage_test` and `/stats`.
 When a calendar file exists the Telegraph page shows a link right under the title image: "📅 Добавить в календарь".
 Events may note support for the Пушкинская карта, shown as a separate line in postings.
 Run `/exhibitions` to see all ongoing exhibitions (events with a start and end date).


### PR DESCRIPTION
## Summary
- expand the README Supabase export section with table names, retention defaults, XOR sampling rules, and metadata scope
- note Supabase telemetry exports and cleanup behaviour in the Unreleased changelog

## Testing
- not run; documentation-only change

------
https://chatgpt.com/codex/tasks/task_e_68e4431085788332888ca956621fbc0b