### PR TITLE
Export group metadata with snapshot metrics

### DIFF
--- a/supabase_export.py
+++ b/supabase_export.py
@@ -119,11 +119,26 @@ class SBExporter:
         *,
         group_id: int,
         counters: Mapping[str, Any],
+        group_title: str | None = None,
+        group_screen_name: str | None = None,
+        ts: int | None = None,
+        match_rate: float | None = None,
+        errors: int | None = None,
     ) -> None:
         client = self._get_client()
         if client is None:
             return
         payload: dict[str, Any] = {"group_id": group_id}
+        if group_title is not None:
+            payload["group_title"] = group_title
+        if group_screen_name is not None:
+            payload["group_screen_name"] = group_screen_name
+        if ts is not None:
+            payload["ts"] = _ts_to_iso(ts) or ts
+        if match_rate is not None:
+            payload["match_rate"] = match_rate
+        if errors is not None:
+            payload["errors"] = errors
         for key, value in counters.items():
             if value is None:
                 continue


### PR DESCRIPTION
## Summary
- extend the Supabase snapshot exporter so it stores group identity, run timestamp, match rate, and error counts alongside the existing counters
- track per-group errors during crawling, compute match rate, and always push a snapshot even when no posts were scanned so dashboards remain current

## Testing
- pytest tests/test_supabase_export.py -q

------
https://chatgpt.com/codex/tasks/task_e_68e445a950b483328c8921cce6473e01