### PR TITLE
Ensure Supabase group meta upserts set defaults and timestamp

### DIFF
--- a/supabase_export.py
+++ b/supabase_export.py
@@ -102,8 +102,9 @@ class SBExporter:
             return
         payload = {
             "group_id": group_id,
-            "group_screen_name": screen_name,
-            "group_title": name,
+            "group_screen_name": screen_name or f"club{group_id}",
+            "group_title": name or "",
+            "updated_at": datetime.now(timezone.utc).isoformat(),
         }
         try:
             client.table("vk_groups").upsert(  # type: ignore[operator]


### PR DESCRIPTION
## Summary
- default group alias and title fields when upserting Supabase metadata
- stamp group metadata updates with the current UTC time

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e44d6afc548332ba894996ea179911