### PR TITLE
Align Supabase snapshot counters with matched column

### DIFF
--- a/tests/test_supabase_export.py
+++ b/tests/test_supabase_export.py
@@ -24,3 +24,63 @@ def test_supabase_export_disable_via_env(monkeypatch):
     exporter = SBExporter(lambda: object())
 
     assert exporter.enabled is False
+
+
+class _DummyTable:
+    def __init__(self, client):
+        self._client = client
+
+    def insert(self, payload):
+        self._client.last_payload = payload
+        return self
+
+    def execute(self):
+        return self
+
+
+class _DummyClient:
+    def __init__(self):
+        self.table_name = None
+        self.last_payload = None
+
+    def table(self, name):
+        self.table_name = name
+        return _DummyTable(self)
+
+
+def test_write_snapshot_includes_expected_counters(monkeypatch):
+    _clear_env(monkeypatch)
+
+    client = _DummyClient()
+    exporter = SBExporter(lambda: client)
+
+    exporter.write_snapshot(
+        group_id=123,
+        group_title="Example",
+        group_screen_name="example",
+        ts=1700000000,
+        match_rate=0.25,
+        errors=3,
+        counters={
+            "posts_scanned": 42,
+            "matched": 7,
+            "duplicates": 2,
+            "pages_loaded": 5,
+            "ignored": None,
+        },
+    )
+
+    assert client.table_name == "vk_crawl_snapshots"
+    payload = client.last_payload
+    assert payload is not None
+    assert payload["group_id"] == 123
+    assert payload["group_title"] == "Example"
+    assert payload["group_screen_name"] == "example"
+    assert payload["ts"] == "2023-11-14T22:13:20+00:00"
+    assert payload["match_rate"] == 0.25
+    assert payload["errors"] == 3
+    assert payload["posts_scanned"] == 42
+    assert payload["matched"] == 7
+    assert payload["duplicates"] == 2
+    assert payload["pages_loaded"] == 5
+    assert "ignored" not in payload

--- a/vk_intake.py
+++ b/vk_intake.py
@@ -2053,7 +2053,7 @@ async def crawl_once(
             match_rate = group_matches / max(1, group_posts)
             snapshot_counters = {
                 "posts_scanned": group_posts,
-                "matches": group_matches,
+                "matched": group_matches,
                 "added": group_added,
                 "duplicates": group_duplicates,
                 "pages_loaded": pages_loaded,


### PR DESCRIPTION
## Summary
- rename the per-group Supabase snapshot counter from `matches` to `matched`
- add a regression test ensuring the Supabase snapshot payload includes the expected columns

## Testing
- pytest tests/test_supabase_export.py

------
https://chatgpt.com/codex/tasks/task_e_68e44f1763488332bdb82e7d96702377