### PR TITLE
Limit snapshot exports to supported counters

### DIFF
--- a/supabase_export.py
+++ b/supabase_export.py
@@ -142,13 +142,18 @@ class SBExporter:
             payload["match_rate"] = match_rate
         if errors is not None:
             payload["errors"] = errors
-        for key, value in counters.items():
+        snapshot_fields = (
+            "posts_scanned",
+            "matched",
+            "duplicates",
+            "errors",
+            "pages_loaded",
+        )
+        for key in snapshot_fields:
+            value = counters.get(key)
             if value is None:
                 continue
-            if isinstance(value, (int, float, bool, str)):
-                payload[key] = value
-            else:
-                payload[key] = str(value)
+            payload[key] = value
         try:
             client.table("vk_crawl_snapshots").insert(payload).execute()  # type: ignore[operator]
             logger.debug("Supabase snapshot stored: group_id=%s", group_id)

--- a/vk_intake.py
+++ b/vk_intake.py
@@ -2084,17 +2084,9 @@ async def crawl_once(
             snapshot_counters = {
                 "posts_scanned": group_posts,
                 "matched": group_matches,
-                "added": group_added,
                 "duplicates": group_duplicates,
+                "errors": group_errors,
                 "pages_loaded": pages_loaded,
-                "backfill": backfill,
-                "mode": mode,
-                "safety_cap_triggered": safety_cap_triggered,
-                "hard_cap_triggered": hard_cap_triggered,
-                "reached_cursor_overlap": reached_cursor_overlap,
-                "deep_backfill_scheduled": deep_backfill_scheduled,
-                "blank_single_photo_matches": group_blank_single_photo_matches,
-                "history_matches": group_history_matches,
             }
             exporter.write_snapshot(
                 group_id=gid,


### PR DESCRIPTION
## Summary
- reduce snapshot counters in vk intake to the schema-supported metrics
- whitelist snapshot fields in the Supabase exporter to avoid inserting undefined columns

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e4c1c53dfc8332ad6841af68540a30