### PR TITLE
Stop exporting deprecated fields in Supabase miss samples

### DIFF
--- a/supabase_export.py
+++ b/supabase_export.py
@@ -173,10 +173,6 @@ class SBExporter:
         url: str | None,
         reason: str,
         matched_kw: Sequence[str] | None = None,
-        post_ts: int | None = None,
-        event_ts_hint: int | None = None,
-        flags: Mapping[str, Any] | None = None,
-        extra: Mapping[str, Any] | None = None,
         kw_ok: bool | None = None,
         has_date: bool | None = None,
         ts: int | None = None,
@@ -208,8 +204,6 @@ class SBExporter:
             "url": url,
             "reason": reason,
             "matched_kw": list(matched_kw or [])[:20],
-            "post_ts": _ts_to_iso(post_ts),
-            "event_ts_hint": _ts_to_iso(event_ts_hint),
         }
         timestamp_value = _ts_to_iso(ts)
         if timestamp_value is None:
@@ -223,21 +217,6 @@ class SBExporter:
             payload["kw_ok"] = bool(kw_ok)
         if has_date is not None:
             payload["has_date"] = bool(has_date)
-        if flags:
-            serialized_flags: dict[str, Any] = {}
-            for key, value in flags.items():
-                if value is None:
-                    continue
-                if isinstance(value, (int, float, bool, str)):
-                    serialized_flags[key] = value
-                else:
-                    serialized_flags[key] = str(value)
-            if serialized_flags:
-                payload["flags"] = serialized_flags
-        if extra:
-            for key, value in extra.items():
-                if value is not None:
-                    payload[key] = value
         try:
             client.table("vk_misses_sample").upsert(  # type: ignore[operator]
                 payload,

--- a/tests/test_supabase_export.py
+++ b/tests/test_supabase_export.py
@@ -92,7 +92,7 @@ def test_write_snapshot_includes_expected_counters(monkeypatch):
     assert "ignored" not in payload
 
 
-def test_log_miss_preserves_flags_and_keywords(monkeypatch):
+def test_log_miss_includes_expected_fields(monkeypatch):
     _clear_env(monkeypatch)
     monkeypatch.setenv("VK_MISSES_SAMPLE_RATE", "1")
 
@@ -105,7 +105,6 @@ def test_log_miss_preserves_flags_and_keywords(monkeypatch):
         url="https://vk.com/wall99_123",
         reason="no_date",
         matched_kw=["music", "festival"],
-        post_ts=1700000000,
         ts=1700000100,
         kw_ok=True,
         has_date=False,
@@ -121,3 +120,7 @@ def test_log_miss_preserves_flags_and_keywords(monkeypatch):
     assert payload["matched_kw"] == ["music", "festival"]
     assert payload["kw_ok"] is True
     assert payload["has_date"] is False
+    assert payload["ts"] == "2023-11-14T22:15:00+00:00"
+    assert "post_ts" not in payload
+    assert "event_ts_hint" not in payload
+    assert "flags" not in payload

--- a/vk_intake.py
+++ b/vk_intake.py
@@ -1886,14 +1886,6 @@ async def crawl_once(
                                     ts=int(time.time()),
                                     reason="past_event",
                                     matched_kw=log_keywords,
-                                    post_ts=ts,
-                                    event_ts_hint=event_ts_hint,
-                                    flags={
-                                        "history_hit": bool(history_hit),
-                                        "has_date": bool(has_date),
-                                        "blank_single_photo": blank_single_photo,
-                                        "backfill": backfill,
-                                    },
                                     kw_ok=bool(kw_ok),
                                     has_date=bool(has_date),
                                 )
@@ -1911,14 +1903,6 @@ async def crawl_once(
                                     ts=int(time.time()),
                                     reason="too_far",
                                     matched_kw=log_keywords,
-                                    post_ts=ts,
-                                    event_ts_hint=event_ts_hint,
-                                    flags={
-                                        "history_hit": bool(history_hit),
-                                        "has_date": bool(has_date),
-                                        "blank_single_photo": blank_single_photo,
-                                        "backfill": backfill,
-                                    },
                                     kw_ok=bool(kw_ok),
                                     has_date=bool(has_date),
                                 )
@@ -1945,13 +1929,6 @@ async def crawl_once(
                             ts=int(time.time()),
                             reason=reason,
                             matched_kw=unique_kws,
-                            post_ts=ts,
-                            flags={
-                                "history_hit": bool(history_hit),
-                                "has_date": bool(has_date),
-                                "blank_single_photo": blank_single_photo,
-                                "backfill": backfill,
-                            },
                             kw_ok=bool(kw_ok),
                             has_date=bool(has_date),
                         )
@@ -2011,15 +1988,6 @@ async def crawl_once(
                             ts=int(time.time()),
                             reason=reason,
                             matched_kw=matched_kw_list,
-                            post_ts=ts,
-                            event_ts_hint=event_ts_hint,
-                            flags={
-                                "existing_status": existing_status,
-                                "history_hit": bool(history_hit),
-                                "has_date": bool(has_date),
-                                "blank_single_photo": blank_single_photo,
-                                "backfill": backfill,
-                            },
                             kw_ok=bool(kw_ok),
                             has_date=bool(has_date),
                         )


### PR DESCRIPTION
## Summary
- drop post and flag metadata from the Supabase miss export payload so it matches vk_misses_sample
- update vk intake callers to pass only the supported miss fields
- refresh Supabase exporter tests to cover the slimmer payload

## Testing
- pytest tests/test_supabase_export.py
- pytest tests/test_vk_intake_metrics.py

------
https://chatgpt.com/codex/tasks/task_e_68e4c3a7fac88332a91b0944b7519b1d