### PR TITLE
Update changelog with v0.3.17 release section

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+- _No changes yet._
+
+## v0.3.17 – 2025-10-07
+
 - VK crawler telemetry now exports group metadata, crawl snapshots, and sampled misses to Supabase (`vk_groups`, `vk_crawl_snapshots`, `vk_misses_sample`) with `SUPABASE_EXPORT_ENABLED`, `SUPABASE_RETENTION_DAYS` (default 60 days), and `VK_MISSES_SAMPLE_RATE` governing exports, sampling, and automatic cleanup.
 - VK stories now ask whether to collect extra editor instructions and forward the answer plus any guidance to the 4o prompts.
 - Добавлен справочник сезонных праздников (`docs/HOLIDAYS.md`), промпт 4o теперь перечисляет их с алиасами и описаниями, а импорт событий автоматически создаёт и переиспользует соответствующие фестивали.


### PR DESCRIPTION
## Summary
- add a v0.3.17 section dated 2025-10-07 to CHANGELOG.md
- move the Supabase export notes from Unreleased into the new release section
- leave an Unreleased placeholder for future entries

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e4c73eefb88332b18cafd8c2a731f2