### PR TITLE
Add help entry for VK miss review command

### DIFF
--- a/main.py
+++ b/main.py
@@ -2015,6 +2015,11 @@ HELP_COMMANDS = [
         "roles": {"superadmin"},
     },
     {
+        "usage": VK_MISS_REVIEW_COMMAND,
+        "desc": "Supabase miss-review flow to process missed VK posts",
+        "roles": {"superadmin"},
+    },
+    {
         "usage": "/vk_crawl_now",
         "desc": "Run VK crawling now (admin only); reports \"добавлено N, всего M\" to the admin chat",
         "roles": {"superadmin"},

--- a/tests/test_help_vk_commands.py
+++ b/tests/test_help_vk_commands.py
@@ -48,6 +48,7 @@ async def test_help_superadmin_lists_vk_commands(tmp_path):
     lines = bot.messages[0].text.splitlines()
     assert any(line.startswith("/vk ") for line in lines)
     assert any(line.startswith("/vk_queue") for line in lines)
+    assert any(line.startswith(f"{main.VK_MISS_REVIEW_COMMAND} —") for line in lines)
     assert any(line.startswith("/vk_crawl_now") for line in lines)
     assert any("↪️ Репостнуть в Vk" in line for line in lines)
     assert any("✂️ Сокращённый рерайт" in line for line in lines)


### PR DESCRIPTION
## Summary
- add a help command entry describing the Supabase VK miss-review flow for superadmins
- extend the help command test snapshot to assert the new line

## Testing
- pytest tests/test_help_vk_commands.py

------
https://chatgpt.com/codex/tasks/task_e_68e5897ed5348332893a6c5638b2ba20