### PR TITLE
Add publication timestamp handling to VK miss review

### DIFF
--- a/tests/test_vk_miss_review.py
+++ b/tests/test_vk_miss_review.py
@@ -81,12 +81,42 @@ async def test_vk_miss_append_feedback_writes_file(tmp_path, monkeypatch):
         matched_kw=None,
         timestamp=datetime(2024, 5, 1, tzinfo=timezone.utc),
     )
-    await main._vk_miss_append_feedback(record, "  sample text  ")
+    published_at = datetime(2024, 5, 2, 15, 30, tzinfo=timezone.utc)
+    await main._vk_miss_append_feedback(record, "  sample text  ", published_at)
 
     content = path.read_text(encoding="utf-8")
     assert "sample text" in content
     assert "https://vk.com/wall-1_2" in content
     assert "miss" in content
+    assert "Дата публикации" in content
+
+
+@pytest.mark.asyncio
+async def test_fetch_vk_post_preview_returns_date(monkeypatch):
+    ts = 1_700_000_000
+
+    async def fake_wall_get_items(group_id, post_id, db, bot):
+        return [
+            {
+                "text": "Sample post",
+                "date": ts,
+                "attachments": [],
+            }
+        ]
+
+    def fake_extract_photo_urls(items):
+        return ["https://example.com/photo.jpg"]
+
+    monkeypatch.setattr(main, "_vk_wall_get_items", fake_wall_get_items)
+    monkeypatch.setattr(main, "_vk_extract_photo_urls", fake_extract_photo_urls)
+
+    text, photos, published_at = await main.fetch_vk_post_preview(1, 2, None, None)
+
+    assert text == "Sample post"
+    assert photos == ["https://example.com/photo.jpg"]
+    assert isinstance(published_at, datetime)
+    assert published_at.tzinfo is not None
+    assert published_at == datetime.fromtimestamp(ts, tz=timezone.utc)
 
 
 @pytest.mark.asyncio
@@ -107,6 +137,8 @@ async def test_vk_miss_callbacks_progress(monkeypatch):
         timestamp=datetime.now(timezone.utc),
     )
     session = main.VkMissReviewSession(queue=[record1, record2], index=0, last_text="text1")
+    session.last_published_at = datetime.now(timezone.utc)
+    first_published = session.last_published_at
     main.vk_miss_review_sessions[user_id] = session
 
     calls: list[tuple] = []
@@ -114,8 +146,8 @@ async def test_vk_miss_callbacks_progress(monkeypatch):
     async def fake_show_next(uid, chat_id, db, bot):
         calls.append(("show", uid, chat_id))
 
-    async def fake_append(record, text):
-        calls.append(("append", record.id, text))
+    async def fake_append(record, text, published_at=None):
+        calls.append(("append", record.id, text, published_at))
 
     monkeypatch.setattr(main, "_vk_miss_show_next", fake_show_next)
     monkeypatch.setattr(main, "_vk_miss_append_feedback", fake_append)
@@ -138,15 +170,18 @@ async def test_vk_miss_callbacks_progress(monkeypatch):
 
     assert session.index == 1
     assert session.last_text is None
-    assert ("append", record1.id, "text1") in calls
+    assert session.last_published_at is None
+    appended = [c for c in calls if c[0] == "append"]
+    assert appended and appended[0][1:] == (record1.id, "text1", first_published)
 
     calls.clear()
     session.last_text = "text2"
+    session.last_published_at = datetime.now(timezone.utc)
     callback_ok = DummyCallback("vkmiss:ok:1")
     await main.handle_vk_miss_review_callback(callback_ok, None, None)
 
     assert session.index == 2
-    assert ("append", record1.id, "text1") not in calls
+    assert all(call[0] != "append" for call in calls)
     assert ("show", user_id, 777) in calls
 
     main.vk_miss_review_sessions.pop(user_id, None)


### PR DESCRIPTION
## Summary
- update the VK post preview helper to return a publication timestamp along with text and photos
- show the publication time in VK miss review cards and feedback logs while tracking it in the session
- expand the VK miss review tests to cover the new timestamp plumbing and formatting

## Testing
- pytest tests/test_vk_miss_review.py

------
https://chatgpt.com/codex/tasks/task_e_68e61f276170833297eadd7ac9541724