### PR TITLE
Track reviewed VK misses

### DIFF
--- a/supabase_export.py
+++ b/supabase_export.py
@@ -204,6 +204,7 @@ class SBExporter:
             "url": url,
             "reason": reason,
             "matched_kw": list(matched_kw or [])[:20],
+            "checked": False,
         }
         timestamp_value = _ts_to_iso(ts)
         if timestamp_value is None:


### PR DESCRIPTION
## Summary
- default new miss exports to Supabase as unchecked
- fetch only unchecked VK miss samples for review and mark them checked once processed
- extend tests to cover the new filtering and checked updates

## Testing
- pytest tests/test_vk_miss_review.py

------
https://chatgpt.com/codex/tasks/task_e_68e63f3aa91c8332ad767162fb2b6bc5