### PR TITLE
Refine VK crawl cursor handling and list timestamps

### DIFF
--- a/tests/test_vk_default_time.py
+++ b/tests/test_vk_default_time.py
@@ -95,7 +95,8 @@ async def test_vk_list_shows_numbers_and_default_time(tmp_path):
     assert lines[0].startswith("1.")
     assert "типовое время: 19:00" in lines[0]
     assert "билеты: https://tickets.example/club1" in lines[0]
-    assert "последняя проверка: 2024-06-01 12:34" in lines[0]
+    assert "последнее сканирование: 2024-06-01 12:34" in lines[0]
+    assert "последний найденный пост: 2024-05-31 12:34" in lines[0]
     assert lines[1] == " Pending | Skipped | Imported | Rejected "
     assert (
         lines[2]
@@ -103,7 +104,8 @@ async def test_vk_list_shows_numbers_and_default_time(tmp_path):
     )
     assert lines[3].startswith("2.")
     assert "типовое время: -" in lines[3]
-    assert ", последняя проверка: 2024-05-31 11:54" in lines[3]
+    assert ", последнее сканирование: -" in lines[3]
+    assert "последний найденный пост: 2024-05-31 11:54" in lines[3]
     assert lines[4] == " Pending | Skipped | Imported | Rejected "
     assert (
         lines[5]


### PR DESCRIPTION
## Summary
- ensure each VK crawl run records a checked_at timestamp even when no new posts are found while keeping existing cursor data intact
- only refresh cursor updated_at on successful matches and insert cursor rows for previously unseen groups
- display separate "last scan" and "last found post" timestamps in the VK list output

## Testing
- pytest tests/test_vk_default_time.py

------
https://chatgpt.com/codex/tasks/task_e_68e6464871188332aacbbce16d8cb299