### PR TITLE
Handle bare hour mentions after dates

### DIFF
--- a/tests/test_vk_intake_keywords_dates.py
+++ b/tests/test_vk_intake_keywords_dates.py
@@ -169,6 +169,17 @@ def test_numeric_identifier_like_sequence_ignored():
     assert (dt.year, dt.month, dt.day) == (2024, 2, 24)
 
 
+def test_extract_event_ts_hint_bare_hours_after_date():
+    publish_dt = real_datetime(2024, 10, 1, tzinfo=main.LOCAL_TZ)
+    ts = extract_event_ts_hint("9 октября 14 часов", publish_ts=publish_dt)
+    assert ts is not None
+    dt = real_datetime.fromtimestamp(ts, tz=main.LOCAL_TZ)
+    assert (dt.year, dt.month, dt.day, dt.hour, dt.minute) == (2024, 10, 9, 14, 0)
+
+    duration_text = "2 часа живого звука"
+    assert extract_event_ts_hint(duration_text, publish_ts=publish_dt) is None
+
+
 def test_extract_event_ts_hint_recent_past():
     publish_dt = real_datetime(2024, 10, 1, tzinfo=main.LOCAL_TZ)
     past_text = "7 сентября прошла лекция"


### PR DESCRIPTION
## Summary
- extend `extract_event_ts_hint` to record date spans and capture bare "HH часов" mentions that follow a detected date
- keep bare-hour parsing constrained to the date sentence to avoid mistaking durations for start times
- add regression coverage for "9 октября 14 часов" and ensure duration phrases remain ignored

## Testing
- pytest tests/test_vk_intake_keywords_dates.py

------
https://chatgpt.com/codex/tasks/task_e_68e65f3aab4c8332a3877d7cd020c5df