### PR TITLE
Fix VK timestamp hint rollover for recomputation

### DIFF
--- a/vk_intake.py
+++ b/vk_intake.py
@@ -815,7 +815,7 @@ def extract_event_ts_hint(
             dt = datetime(year, month, day, tzinfo=tzinfo)
         except ValueError:
             return None
-        if dt < now and not allow_past:
+        if dt < now:
             skip_year_rollover = explicit_year
             if not explicit_year and now - dt <= RECENT_PAST_THRESHOLD:
                 skip_year_rollover = True


### PR DESCRIPTION
## Summary
- ensure `extract_event_ts_hint` performs year-rollover adjustments even when recomputing past hints
- add a regression test covering December posts referencing "1 января" to ensure recomputation keeps the timestamp in the next year

## Testing
- pytest tests/test_vk_review_show_next.py

------
https://chatgpt.com/codex/tasks/task_e_68e666eb7de88332b8948d4bf1a6de18